### PR TITLE
修复Linux构建：将弃用API警告降级为非致命错误

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -2,6 +2,7 @@
 cmake_minimum_required(VERSION 3.13)
 project(runner LANGUAGES CXX)
 
+add_compile_options(-Wno-error=deprecated-declarations)
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
 set(BINARY_NAME "ParticleMusic")


### PR DESCRIPTION
- 在 CMakeLists.txt 中添加 add_compile_options(-Wno-error=deprecated-declarations)
- 解决因 tray_manager 插件中已弃用的 app_indicator_new 导致的构建失败
- 允许编译继续进行，仅输出警告