### PR TITLE
feat: add USB audio output controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# AGENTS.md
+
+## 语言
+
+始终使用中文回复用户。所有输出、解释、代码注释都应该使用中文。
+
+## Codex 窗口约束
+
+所有 Codex 窗口进入本项目后，必须先阅读并遵守本文件。若本文件与通用习惯冲突，以本文件为准；若用户在当前对话中给出更明确的新要求，以用户当前要求为准。
+
+## Android 编译约束
+
+- 默认只编译 Android arm64-v8a，也就是 armv8；不要编译 armeabi-v7a、x86 或 x86_64。
+- 默认只编译性能包，也就是 Flutter profile 包；不要编译 debug 包或 release 包，除非用户明确要求。
+- 推荐编译命令：
+
+```powershell
+& 'F:\software\flutter_3.44.0\bin\flutter.bat' build apk --profile --target-platform android-arm64
+```
+
+## 设备安装约束
+
+- Android 性能包编译成功后，若有设备已连接，必须把编译好的包安装到设备上。
+- 安装前先确认设备连接状态：
+
+```powershell
+adb devices
+```
+
+- 推荐安装命令：
+
+```powershell
+adb install -r build\app\outputs\flutter-apk\app-profile.apk
+```
+
+- 如果没有可用设备、设备未授权或安装失败，必须明确告诉用户失败原因和下一步需要用户处理的事项。
+
+## 提交约束
+
+- 每完成一个明确任务后，必须进行本地 git 提交。
+- 提交时只纳入本任务相关文件；工作区中已有的其它修改不要回滚、不要混入提交。
+- 提交前必须查看 `git status --short`，确认 staged 文件范围正确。

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -43,6 +43,19 @@ android {
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
+
+        externalNativeBuild {
+            cmake {
+                cppFlags += listOf("-std=c++17", "-Wall", "-Wextra")
+            }
+        }
+    }
+
+    externalNativeBuild {
+        cmake {
+            path = file("src/main/cpp/CMakeLists.txt")
+            version = "3.22.1"
+        }
     }
 
     buildTypes {

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -39,7 +39,7 @@ android {
 
     defaultConfig {
         applicationId = "com.afalphy.sylvakru"
-        minSdk = flutter.minSdkVersion
+        minSdk = 26
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
@@ -51,6 +51,11 @@ android {
         }
         debug {
             applicationIdSuffix = ".debug" 
+        }
+        maybeCreate("profile").apply {
+            initWith(getByName("debug"))
+            applicationIdSuffix = ".profile"
+            signingConfig = signingConfigs.getByName("debug")
         }
     }
 
@@ -65,4 +70,8 @@ android {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    implementation("com.github.HChenX:SuperLyricApi:3.4")
 }

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -44,6 +44,10 @@ android {
         versionCode = flutter.versionCode
         versionName = flutter.versionName
 
+        ndk {
+            abiFilters.add("arm64-v8a")
+        }
+
         externalNativeBuild {
             cmake {
                 cppFlags += listOf("-std=c++17", "-Wall", "-Wextra")
@@ -55,6 +59,16 @@ android {
         cmake {
             path = file("src/main/cpp/CMakeLists.txt")
             version = "3.22.1"
+        }
+    }
+
+    packaging {
+        jniLibs {
+            excludes += setOf(
+                "lib/armeabi-v7a/**",
+                "lib/x86/**",
+                "lib/x86_64/**",
+            )
         }
     }
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -41,6 +41,13 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
                 <category android:name="android.intent.category.LEANBACK_LAUNCHER"/>
             </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"/>
+            </intent-filter>
+            <meta-data
+                android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"
+                android:resource="@xml/usb_audio_device_filter"/>
         </activity>
 
         <meta-data android:name="flutterEmbedding" android:value="2" />

--- a/android/app/src/main/cpp/CMakeLists.txt
+++ b/android/app/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.22.1)
+
+project(sylvakru_usb_exclusive)
+
+add_library(
+    sylvakru_usb_exclusive
+    SHARED
+    usb_exclusive_engine.cpp
+)
+
+find_library(log-lib log)
+
+target_link_libraries(
+    sylvakru_usb_exclusive
+    ${log-lib}
+)

--- a/android/app/src/main/cpp/usb_exclusive_engine.cpp
+++ b/android/app/src/main/cpp/usb_exclusive_engine.cpp
@@ -18,7 +18,8 @@ namespace {
 
 constexpr const char* kTag = "SylvakruUsbExclusive";
 constexpr int kMaxIsoPacketsPerUrb = 16;
-constexpr int kMaxPendingUrbs = 8;
+constexpr int kDefaultMaxPendingUrbs = 8;
+constexpr int kAbsoluteMaxPendingUrbs = 512;
 
 struct PendingUrb {
     usbdevfs_urb* urb;
@@ -43,6 +44,8 @@ long long g_total_bytes = 0;
 long long g_total_urbs = 0;
 long long g_total_iso_packets = 0;
 long long g_last_stats_ms = 0;
+long long g_iso_error_count = 0;
+int g_max_pending_urbs = kDefaultMaxPendingUrbs;
 std::vector<PendingUrb> g_pending_urbs;
 
 long long monotonicMillis() {
@@ -79,6 +82,7 @@ void logCompletedUrb(PendingUrb pending) {
         return;
     }
     if (pending.urb->status != 0) {
+        ++g_iso_error_count;
         __android_log_print(
             ANDROID_LOG_WARN,
             kTag,
@@ -89,6 +93,7 @@ void logCompletedUrb(PendingUrb pending) {
     }
     for (int i = 0; i < pending.packets; ++i) {
         if (pending.urb->iso_frame_desc[i].status != 0) {
+            ++g_iso_error_count;
             __android_log_print(
                 ANDROID_LOG_WARN,
                 kTag,
@@ -205,7 +210,7 @@ std::string reapCompletedLocked() {
             break;
         }
     }
-    while (error.empty() && static_cast<int>(g_pending_urbs.size()) >= kMaxPendingUrbs) {
+    while (error.empty() && static_cast<int>(g_pending_urbs.size()) >= g_max_pending_urbs) {
         error = reapOneLocked(true);
     }
     return error;
@@ -290,6 +295,8 @@ void closeLocked() {
     g_total_urbs = 0;
     g_total_iso_packets = 0;
     g_last_stats_ms = 0;
+    g_iso_error_count = 0;
+    g_max_pending_urbs = kDefaultMaxPendingUrbs;
 }
 
 std::string submitIsoPacketsLocked(
@@ -622,6 +629,35 @@ Java_com_afalphy_sylvakru_UsbExclusiveNative_feedbackFramesPerPacketQ16(JNIEnv*,
     return g_feedback_frames_per_packet_q16;
 }
 
+extern "C" JNIEXPORT jlongArray JNICALL
+Java_com_afalphy_sylvakru_UsbExclusiveNative_transportTelemetry(JNIEnv* env, jobject) {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    if (g_fd >= 0) {
+        reapCompletedLocked();
+    }
+
+    long long pending_iso_packets = 0;
+    long long pending_output_urbs = 0;
+    for (const auto& pending : g_pending_urbs) {
+        if (!pending.feedback) {
+            pending_iso_packets += pending.packets;
+            ++pending_output_urbs;
+        }
+    }
+
+    const jlong values[] = {
+        static_cast<jlong>(pending_iso_packets),
+        static_cast<jlong>(g_total_iso_packets),
+        static_cast<jlong>(pending_output_urbs),
+        static_cast<jlong>(g_iso_error_count),
+    };
+    jlongArray result = env->NewLongArray(4);
+    if (result != nullptr) {
+        env->SetLongArrayRegion(result, 0, 4, values);
+    }
+    return result;
+}
+
 extern "C" JNIEXPORT void JNICALL
 Java_com_afalphy_sylvakru_UsbExclusiveNative_setIsoPacketSize(
     JNIEnv*,
@@ -634,6 +670,22 @@ Java_com_afalphy_sylvakru_UsbExclusiveNative_setIsoPacketSize(
         kTag,
         "iso packet size set to %d bytes",
         g_iso_packet_size);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_afalphy_sylvakru_UsbExclusiveNative_setMaxPendingOutputUrbs(
+    JNIEnv*,
+    jobject,
+    jint max_pending_urbs) {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    g_max_pending_urbs = std::max(
+        kDefaultMaxPendingUrbs,
+        std::min(static_cast<int>(max_pending_urbs), kAbsoluteMaxPendingUrbs));
+    __android_log_print(
+        ANDROID_LOG_INFO,
+        kTag,
+        "max pending output URBs set to %d",
+        g_max_pending_urbs);
 }
 
 extern "C" JNIEXPORT void JNICALL

--- a/android/app/src/main/cpp/usb_exclusive_engine.cpp
+++ b/android/app/src/main/cpp/usb_exclusive_engine.cpp
@@ -6,22 +6,50 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/ioctl.h>
+#include <time.h>
 #include <unistd.h>
 
 #include <algorithm>
 #include <mutex>
 #include <string>
+#include <vector>
 
 namespace {
 
 constexpr const char* kTag = "SylvakruUsbExclusive";
-constexpr int kMaxIsoPacketsPerUrb = 32;
+constexpr int kMaxIsoPacketsPerUrb = 16;
+constexpr int kMaxPendingUrbs = 8;
+
+struct PendingUrb {
+    usbdevfs_urb* urb;
+    uint8_t* buffer;
+    int length;
+    int packets;
+    bool feedback;
+};
 
 std::mutex g_mutex;
 int g_fd = -1;
 int g_interface_number = -1;
 int g_endpoint_address = -1;
 int g_max_packet_size = 0;
+int g_iso_packet_size = 0;
+int g_feedback_endpoint_address = 0;
+int g_feedback_packet_size = 0;
+int g_feedback_frames_per_packet_q16 = 0;
+int g_feedback_log_count = 0;
+int g_write_log_count = 0;
+long long g_total_bytes = 0;
+long long g_total_urbs = 0;
+long long g_total_iso_packets = 0;
+long long g_last_stats_ms = 0;
+std::vector<PendingUrb> g_pending_urbs;
+
+long long monotonicMillis() {
+    timespec now = {};
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    return static_cast<long long>(now.tv_sec) * 1000LL + now.tv_nsec / 1000000LL;
+}
 
 std::string errorMessage(const char* action) {
     return std::string(action) + " failed: " + strerror(errno);
@@ -39,32 +67,258 @@ jstring nullableError(JNIEnv* env, const std::string& error) {
     return toJString(env, error);
 }
 
+void freePendingUrb(PendingUrb pending) {
+    free(pending.buffer);
+    free(pending.urb);
+}
+
+std::string submitFeedbackLocked();
+
+void logCompletedUrb(PendingUrb pending) {
+    if (pending.feedback) {
+        return;
+    }
+    if (pending.urb->status != 0) {
+        __android_log_print(
+            ANDROID_LOG_WARN,
+            kTag,
+            "URB completed with status=%d length=%d packets=%d",
+            pending.urb->status,
+            pending.length,
+            pending.packets);
+    }
+    for (int i = 0; i < pending.packets; ++i) {
+        if (pending.urb->iso_frame_desc[i].status != 0) {
+            __android_log_print(
+                ANDROID_LOG_WARN,
+                kTag,
+                "iso frame status=%d actual=%u requested=%u index=%d/%d",
+                pending.urb->iso_frame_desc[i].status,
+                pending.urb->iso_frame_desc[i].actual_length,
+                pending.urb->iso_frame_desc[i].length,
+                i,
+                pending.packets);
+        }
+    }
+}
+
+void handleFeedbackUrb(PendingUrb pending) {
+    if (pending.urb->status != 0 || pending.packets <= 0) {
+        if (pending.urb->status != 0) {
+            __android_log_print(
+                ANDROID_LOG_WARN,
+                kTag,
+                "feedback URB status=%d length=%d packets=%d",
+                pending.urb->status,
+                pending.length,
+                pending.packets);
+        }
+        return;
+    }
+
+    const auto& frame = pending.urb->iso_frame_desc[0];
+    if (frame.status != 0 || frame.actual_length < 3) {
+        if (frame.status != 0 && g_feedback_log_count < 8) {
+            __android_log_print(
+                ANDROID_LOG_WARN,
+                kTag,
+                "feedback frame status=%d actual=%u requested=%u",
+                frame.status,
+                frame.actual_length,
+                frame.length);
+        }
+        return;
+    }
+
+    const int actual = std::min<int>(frame.actual_length, pending.length);
+    int raw = 0;
+    for (int i = 0; i < std::min(actual, 4); ++i) {
+        raw |= static_cast<int>(pending.buffer[i]) << (i * 8);
+    }
+
+    int q16 = 0;
+    if (actual >= 4) {
+        q16 = raw;
+    } else {
+        q16 = raw << 2;
+    }
+
+    if (q16 > 0) {
+        g_feedback_frames_per_packet_q16 = q16;
+    }
+    if (g_feedback_log_count < 12) {
+        ++g_feedback_log_count;
+        __android_log_print(
+            ANDROID_LOG_INFO,
+            kTag,
+            "USB feedback actual=%d raw=0x%x framesPerPacketQ16=%d approxFrames=%.6f",
+            actual,
+            raw,
+            q16,
+            static_cast<double>(q16) / 65536.0);
+    }
+}
+
+std::string reapOneLocked(bool blocking) {
+    if (g_pending_urbs.empty()) {
+        return {};
+    }
+
+    void* completed = nullptr;
+    const int request = blocking ? USBDEVFS_REAPURB : USBDEVFS_REAPURBNDELAY;
+    if (ioctl(g_fd, request, &completed) < 0) {
+        if (!blocking && errno == EAGAIN) {
+            return {};
+        }
+        return errorMessage(blocking ? "USBDEVFS_REAPURB" : "USBDEVFS_REAPURBNDELAY");
+    }
+    auto found = std::find_if(
+        g_pending_urbs.begin(),
+        g_pending_urbs.end(),
+        [completed](const PendingUrb& pending) { return pending.urb == completed; });
+    if (found == g_pending_urbs.end()) {
+        return "USBDEVFS_REAPURB returned an unknown URB.";
+    }
+
+    const PendingUrb completed_pending = *found;
+    if (completed_pending.feedback) {
+        handleFeedbackUrb(completed_pending);
+    } else {
+        logCompletedUrb(completed_pending);
+    }
+    freePendingUrb(completed_pending);
+    g_pending_urbs.erase(found);
+    if (completed_pending.feedback && g_fd >= 0 && g_feedback_endpoint_address != 0) {
+        const auto feedback_error = submitFeedbackLocked();
+        if (!feedback_error.empty()) {
+            return feedback_error;
+        }
+    }
+    return {};
+}
+
+std::string reapCompletedLocked() {
+    std::string error;
+    while (error.empty() && !g_pending_urbs.empty()) {
+        error = reapOneLocked(false);
+        if (error.empty()) {
+            break;
+        }
+    }
+    while (error.empty() && static_cast<int>(g_pending_urbs.size()) >= kMaxPendingUrbs) {
+        error = reapOneLocked(true);
+    }
+    return error;
+}
+
+void discardPendingLocked() {
+    for (const auto& pending : g_pending_urbs) {
+        ioctl(g_fd, USBDEVFS_DISCARDURB, pending.urb);
+    }
+}
+
+void freeAllPendingLocked() {
+    for (auto& pending : g_pending_urbs) {
+        freePendingUrb(pending);
+    }
+    g_pending_urbs.clear();
+}
+
+std::string claimInterfaceLocked() {
+    usbdevfs_disconnect_claim disconnect_claim = {};
+    disconnect_claim.interface = static_cast<unsigned int>(g_interface_number);
+
+    if (ioctl(g_fd, USBDEVFS_DISCONNECT_CLAIM, &disconnect_claim) == 0) {
+        __android_log_print(
+            ANDROID_LOG_INFO,
+            kTag,
+            "USBDEVFS_DISCONNECT_CLAIM ok interface=%d",
+            g_interface_number);
+        return {};
+    }
+
+    const int disconnect_claim_errno = errno;
+    __android_log_print(
+        ANDROID_LOG_WARN,
+        kTag,
+        "USBDEVFS_DISCONNECT_CLAIM failed interface=%d: %s",
+        g_interface_number,
+        strerror(disconnect_claim_errno));
+
+    if (ioctl(g_fd, USBDEVFS_CLAIMINTERFACE, &g_interface_number) == 0) {
+        __android_log_print(
+            ANDROID_LOG_INFO,
+            kTag,
+            "USBDEVFS_CLAIMINTERFACE ok interface=%d",
+            g_interface_number);
+        return {};
+    }
+
+    return errorMessage("USBDEVFS_CLAIMINTERFACE");
+}
+
 void closeLocked() {
     if (g_fd < 0) {
         return;
     }
 
+    __android_log_print(
+        ANDROID_LOG_INFO,
+        kTag,
+        "closing exclusive USB fd=%d interface=%d endpoint=0x%x pendingUrbs=%zu",
+        g_fd,
+        g_interface_number,
+        g_endpoint_address,
+        g_pending_urbs.size());
+    discardPendingLocked();
     if (g_interface_number >= 0) {
         ioctl(g_fd, USBDEVFS_RELEASEINTERFACE, &g_interface_number);
     }
     close(g_fd);
+    freeAllPendingLocked();
     g_fd = -1;
     g_interface_number = -1;
     g_endpoint_address = -1;
     g_max_packet_size = 0;
+    g_iso_packet_size = 0;
+    g_feedback_endpoint_address = 0;
+    g_feedback_packet_size = 0;
+    g_feedback_frames_per_packet_q16 = 0;
+    g_feedback_log_count = 0;
+    g_write_log_count = 0;
+    g_total_bytes = 0;
+    g_total_urbs = 0;
+    g_total_iso_packets = 0;
+    g_last_stats_ms = 0;
 }
 
-std::string submitIsoChunkLocked(const uint8_t* data, int length) {
+std::string submitIsoPacketsLocked(
+    const uint8_t* data,
+    int length,
+    const int* packet_lengths,
+    int packet_count) {
     if (g_fd < 0) {
         return "USB exclusive device is not open.";
     }
     if (g_endpoint_address < 0 || g_max_packet_size <= 0) {
         return "USB exclusive endpoint is not configured.";
     }
+    if (data == nullptr || length <= 0 || packet_lengths == nullptr || packet_count <= 0) {
+        return {};
+    }
 
-    const int packets = std::max(
-        1,
-        std::min(kMaxIsoPacketsPerUrb, (length + g_max_packet_size - 1) / g_max_packet_size));
+    const int packets = std::min(packet_count, kMaxIsoPacketsPerUrb);
+    int described_length = 0;
+    for (int i = 0; i < packets; ++i) {
+        if (packet_lengths[i] <= 0 || packet_lengths[i] > g_max_packet_size) {
+            return "USB exclusive iso packet length is invalid.";
+        }
+        described_length += packet_lengths[i];
+    }
+    if (described_length != length) {
+        return "USB exclusive iso packet lengths do not match PCM length.";
+    }
+
     const size_t urb_size =
         sizeof(usbdevfs_urb) + sizeof(usbdevfs_iso_packet_desc) * packets;
     auto* urb = static_cast<usbdevfs_urb*>(calloc(1, urb_size));
@@ -84,11 +338,8 @@ std::string submitIsoChunkLocked(const uint8_t* data, int length) {
     urb->buffer_length = length;
     urb->number_of_packets = packets;
 
-    int remaining = length;
     for (int i = 0; i < packets; ++i) {
-        const int packet_length = std::min(g_max_packet_size, remaining);
-        urb->iso_frame_desc[i].length = packet_length;
-        remaining -= packet_length;
+        urb->iso_frame_desc[i].length = packet_lengths[i];
     }
 
     if (ioctl(g_fd, USBDEVFS_SUBMITURB, urb) < 0) {
@@ -98,22 +349,79 @@ std::string submitIsoChunkLocked(const uint8_t* data, int length) {
         return error;
     }
 
-    void* completed = nullptr;
-    if (ioctl(g_fd, USBDEVFS_REAPURB, &completed) < 0) {
-        const auto error = errorMessage("USBDEVFS_REAPURB");
+    g_pending_urbs.push_back(PendingUrb{urb, buffer, length, packets, false});
+    g_total_bytes += length;
+    g_total_urbs += 1;
+    g_total_iso_packets += packets;
+    const long long now_ms = monotonicMillis();
+    if (g_last_stats_ms == 0) {
+        g_last_stats_ms = now_ms;
+    } else if (now_ms - g_last_stats_ms >= 1000) {
+        __android_log_print(
+            ANDROID_LOG_INFO,
+            kTag,
+            "USB write stats bytes=%lld urbs=%lld isoPackets=%lld pendingUrbs=%zu isoPacketSize=%d endpoint=0x%x",
+            g_total_bytes,
+            g_total_urbs,
+            g_total_iso_packets,
+            g_pending_urbs.size(),
+            g_iso_packet_size,
+            g_endpoint_address);
+        g_last_stats_ms = now_ms;
+    }
+    return reapCompletedLocked();
+}
+
+std::string submitIsoChunkLocked(const uint8_t* data, int length) {
+    const int iso_packet_size =
+        g_iso_packet_size > 0 ? std::min(g_iso_packet_size, g_max_packet_size) : g_max_packet_size;
+    const int packets = std::max(
+        1,
+        std::min(kMaxIsoPacketsPerUrb, (length + iso_packet_size - 1) / iso_packet_size));
+    int remaining = length;
+    int packet_lengths[kMaxIsoPacketsPerUrb] = {};
+    for (int i = 0; i < packets; ++i) {
+        packet_lengths[i] = std::min(iso_packet_size, remaining);
+        remaining -= packet_lengths[i];
+    }
+    return submitIsoPacketsLocked(data, length, packet_lengths, packets);
+}
+
+std::string submitFeedbackLocked() {
+    if (g_fd < 0 || g_feedback_endpoint_address == 0 || g_feedback_packet_size <= 0) {
+        return {};
+    }
+
+    const int packets = 1;
+    const int length = std::min(4, std::max(3, g_feedback_packet_size));
+    const size_t urb_size =
+        sizeof(usbdevfs_urb) + sizeof(usbdevfs_iso_packet_desc) * packets;
+    auto* urb = static_cast<usbdevfs_urb*>(calloc(1, urb_size));
+    auto* buffer = static_cast<uint8_t*>(calloc(1, length));
+    if (urb == nullptr || buffer == nullptr) {
+        free(urb);
+        free(buffer);
+        return "Failed to allocate USB feedback transfer.";
+    }
+
+    urb->type = USBDEVFS_URB_TYPE_ISO;
+    urb->endpoint = static_cast<unsigned char>(g_feedback_endpoint_address);
+    urb->status = 0;
+    urb->flags = USBDEVFS_URB_ISO_ASAP;
+    urb->buffer = buffer;
+    urb->buffer_length = length;
+    urb->number_of_packets = packets;
+    urb->iso_frame_desc[0].length = length;
+
+    if (ioctl(g_fd, USBDEVFS_SUBMITURB, urb) < 0) {
+        const auto error = errorMessage("USBDEVFS_SUBMITURB feedback");
         free(buffer);
         free(urb);
         return error;
     }
 
-    std::string error;
-    if (urb->status != 0) {
-        error = "USB isochronous transfer completed with status " + std::to_string(urb->status) + ".";
-    }
-
-    free(buffer);
-    free(urb);
-    return error;
+    g_pending_urbs.push_back(PendingUrb{urb, buffer, length, packets, true});
+    return {};
 }
 
 }  // namespace
@@ -126,9 +434,22 @@ Java_com_afalphy_sylvakru_UsbExclusiveNative_open(
     jint interface_number,
     jint alternate_setting,
     jint endpoint_address,
-    jint max_packet_size) {
+    jint max_packet_size,
+    jint feedback_endpoint_address,
+    jint feedback_max_packet_size,
+    jboolean interface_already_claimed) {
     std::lock_guard<std::mutex> lock(g_mutex);
     closeLocked();
+
+    __android_log_print(
+        ANDROID_LOG_INFO,
+        kTag,
+        "open requested fd=%d interface=%d alt=%d endpoint=0x%x maxPacket=%d",
+        fd,
+        interface_number,
+        alternate_setting,
+        endpoint_address,
+        max_packet_size);
 
     const int duplicated = dup(fd);
     if (duplicated < 0) {
@@ -139,11 +460,21 @@ Java_com_afalphy_sylvakru_UsbExclusiveNative_open(
     g_interface_number = interface_number;
     g_endpoint_address = endpoint_address;
     g_max_packet_size = max_packet_size;
+    g_feedback_endpoint_address = feedback_endpoint_address;
+    g_feedback_packet_size = feedback_max_packet_size;
 
-    if (ioctl(g_fd, USBDEVFS_CLAIMINTERFACE, &g_interface_number) < 0) {
-        const auto error = errorMessage("USBDEVFS_CLAIMINTERFACE");
-        closeLocked();
-        return nullableError(env, error);
+    if (interface_already_claimed == JNI_TRUE) {
+        __android_log_print(
+            ANDROID_LOG_INFO,
+            kTag,
+            "USB interface already claimed by UsbDeviceConnection interface=%d",
+            g_interface_number);
+    } else {
+        const auto claim_error = claimInterfaceLocked();
+        if (!claim_error.empty()) {
+            closeLocked();
+            return nullableError(env, claim_error);
+        }
     }
 
     usbdevfs_setinterface set_interface = {};
@@ -153,6 +484,30 @@ Java_com_afalphy_sylvakru_UsbExclusiveNative_open(
         const auto error = errorMessage("USBDEVFS_SETINTERFACE");
         closeLocked();
         return nullableError(env, error);
+    }
+    __android_log_print(
+        ANDROID_LOG_INFO,
+        kTag,
+        "USBDEVFS_SETINTERFACE ok interface=%d alt=%d",
+        interface_number,
+        alternate_setting);
+
+    if (g_feedback_endpoint_address != 0 && g_feedback_packet_size > 0) {
+        const auto feedback_error = submitFeedbackLocked();
+        if (!feedback_error.empty()) {
+            __android_log_print(
+                ANDROID_LOG_WARN,
+                kTag,
+                "%s",
+                feedback_error.c_str());
+        } else {
+            __android_log_print(
+                ANDROID_LOG_INFO,
+                kTag,
+                "USB feedback endpoint armed endpoint=0x%x maxPacket=%d",
+                g_feedback_endpoint_address,
+                g_feedback_packet_size);
+        }
     }
 
     return nullptr;
@@ -179,7 +534,9 @@ Java_com_afalphy_sylvakru_UsbExclusiveNative_writePcm(
     int offset = 0;
     {
         std::lock_guard<std::mutex> lock(g_mutex);
-        const int max_chunk = std::max(1, g_max_packet_size * kMaxIsoPacketsPerUrb);
+        const int iso_packet_size =
+            g_iso_packet_size > 0 ? std::min(g_iso_packet_size, g_max_packet_size) : g_max_packet_size;
+        const int max_chunk = std::max(1, iso_packet_size * kMaxIsoPacketsPerUrb);
         while (offset < safe_length && error.empty()) {
             const int chunk = std::min(max_chunk, safe_length - offset);
             error = submitIsoChunkLocked(input + offset, chunk);
@@ -188,7 +545,95 @@ Java_com_afalphy_sylvakru_UsbExclusiveNative_writePcm(
     }
 
     env->ReleaseByteArrayElements(bytes, reinterpret_cast<jbyte*>(input), JNI_ABORT);
+    if (error.empty() && g_write_log_count < 5) {
+        ++g_write_log_count;
+        __android_log_print(
+            ANDROID_LOG_DEBUG,
+            kTag,
+            "writePcm submitted %d bytes to endpoint=0x%x isoPacket=%d",
+            safe_length,
+            g_endpoint_address,
+            g_iso_packet_size);
+    }
     return nullableError(env, error);
+}
+
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_afalphy_sylvakru_UsbExclusiveNative_writeIsoPackets(
+    JNIEnv* env,
+    jobject,
+    jbyteArray bytes,
+    jintArray packet_lengths,
+    jint packet_count) {
+    if (bytes == nullptr || packet_lengths == nullptr || packet_count <= 0) {
+        return nullptr;
+    }
+
+    const jsize array_length = env->GetArrayLength(bytes);
+    const jsize lengths_length = env->GetArrayLength(packet_lengths);
+    const int safe_packet_count = std::min<int>(
+        std::min<int>(packet_count, lengths_length),
+        kMaxIsoPacketsPerUrb);
+    if (safe_packet_count <= 0) {
+        return nullptr;
+    }
+
+    int safe_length = 0;
+    jint stack_lengths[kMaxIsoPacketsPerUrb] = {};
+    env->GetIntArrayRegion(packet_lengths, 0, safe_packet_count, stack_lengths);
+    for (int i = 0; i < safe_packet_count; ++i) {
+        if (stack_lengths[i] <= 0) {
+            return nullableError(env, "USB exclusive iso packet length is invalid.");
+        }
+        safe_length += stack_lengths[i];
+    }
+    if (safe_length > array_length) {
+        return nullableError(env, "USB exclusive iso packet data is shorter than packet lengths.");
+    }
+
+    auto* input = reinterpret_cast<uint8_t*>(env->GetByteArrayElements(bytes, nullptr));
+    if (input == nullptr) {
+        return nullableError(env, "Failed to access PCM buffer.");
+    }
+
+    std::string error;
+    {
+        std::lock_guard<std::mutex> lock(g_mutex);
+        error = submitIsoPacketsLocked(input, safe_length, stack_lengths, safe_packet_count);
+    }
+
+    env->ReleaseByteArrayElements(bytes, reinterpret_cast<jbyte*>(input), JNI_ABORT);
+    if (error.empty() && g_write_log_count < 5) {
+        ++g_write_log_count;
+        __android_log_print(
+            ANDROID_LOG_DEBUG,
+            kTag,
+            "writeIsoPackets submitted %d bytes packets=%d endpoint=0x%x",
+            safe_length,
+            safe_packet_count,
+            g_endpoint_address);
+    }
+    return nullableError(env, error);
+}
+
+extern "C" JNIEXPORT jint JNICALL
+Java_com_afalphy_sylvakru_UsbExclusiveNative_feedbackFramesPerPacketQ16(JNIEnv*, jobject) {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    return g_feedback_frames_per_packet_q16;
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_afalphy_sylvakru_UsbExclusiveNative_setIsoPacketSize(
+    JNIEnv*,
+    jobject,
+    jint packet_size) {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    g_iso_packet_size = std::max(0, std::min(static_cast<int>(packet_size), g_max_packet_size));
+    __android_log_print(
+        ANDROID_LOG_INFO,
+        kTag,
+        "iso packet size set to %d bytes",
+        g_iso_packet_size);
 }
 
 extern "C" JNIEXPORT void JNICALL

--- a/android/app/src/main/cpp/usb_exclusive_engine.cpp
+++ b/android/app/src/main/cpp/usb_exclusive_engine.cpp
@@ -1,0 +1,198 @@
+#include <jni.h>
+#include <android/log.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/usbdevice_fs.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <mutex>
+#include <string>
+
+namespace {
+
+constexpr const char* kTag = "SylvakruUsbExclusive";
+constexpr int kMaxIsoPacketsPerUrb = 32;
+
+std::mutex g_mutex;
+int g_fd = -1;
+int g_interface_number = -1;
+int g_endpoint_address = -1;
+int g_max_packet_size = 0;
+
+std::string errorMessage(const char* action) {
+    return std::string(action) + " failed: " + strerror(errno);
+}
+
+jstring toJString(JNIEnv* env, const std::string& value) {
+    return env->NewStringUTF(value.c_str());
+}
+
+jstring nullableError(JNIEnv* env, const std::string& error) {
+    if (error.empty()) {
+        return nullptr;
+    }
+    __android_log_print(ANDROID_LOG_WARN, kTag, "%s", error.c_str());
+    return toJString(env, error);
+}
+
+void closeLocked() {
+    if (g_fd < 0) {
+        return;
+    }
+
+    if (g_interface_number >= 0) {
+        ioctl(g_fd, USBDEVFS_RELEASEINTERFACE, &g_interface_number);
+    }
+    close(g_fd);
+    g_fd = -1;
+    g_interface_number = -1;
+    g_endpoint_address = -1;
+    g_max_packet_size = 0;
+}
+
+std::string submitIsoChunkLocked(const uint8_t* data, int length) {
+    if (g_fd < 0) {
+        return "USB exclusive device is not open.";
+    }
+    if (g_endpoint_address < 0 || g_max_packet_size <= 0) {
+        return "USB exclusive endpoint is not configured.";
+    }
+
+    const int packets = std::max(
+        1,
+        std::min(kMaxIsoPacketsPerUrb, (length + g_max_packet_size - 1) / g_max_packet_size));
+    const size_t urb_size =
+        sizeof(usbdevfs_urb) + sizeof(usbdevfs_iso_packet_desc) * packets;
+    auto* urb = static_cast<usbdevfs_urb*>(calloc(1, urb_size));
+    auto* buffer = static_cast<uint8_t*>(malloc(length));
+    if (urb == nullptr || buffer == nullptr) {
+        free(urb);
+        free(buffer);
+        return "Failed to allocate USB isochronous transfer.";
+    }
+
+    memcpy(buffer, data, length);
+    urb->type = USBDEVFS_URB_TYPE_ISO;
+    urb->endpoint = static_cast<unsigned char>(g_endpoint_address);
+    urb->status = 0;
+    urb->flags = USBDEVFS_URB_ISO_ASAP;
+    urb->buffer = buffer;
+    urb->buffer_length = length;
+    urb->number_of_packets = packets;
+
+    int remaining = length;
+    for (int i = 0; i < packets; ++i) {
+        const int packet_length = std::min(g_max_packet_size, remaining);
+        urb->iso_frame_desc[i].length = packet_length;
+        remaining -= packet_length;
+    }
+
+    if (ioctl(g_fd, USBDEVFS_SUBMITURB, urb) < 0) {
+        const auto error = errorMessage("USBDEVFS_SUBMITURB");
+        free(buffer);
+        free(urb);
+        return error;
+    }
+
+    void* completed = nullptr;
+    if (ioctl(g_fd, USBDEVFS_REAPURB, &completed) < 0) {
+        const auto error = errorMessage("USBDEVFS_REAPURB");
+        free(buffer);
+        free(urb);
+        return error;
+    }
+
+    std::string error;
+    if (urb->status != 0) {
+        error = "USB isochronous transfer completed with status " + std::to_string(urb->status) + ".";
+    }
+
+    free(buffer);
+    free(urb);
+    return error;
+}
+
+}  // namespace
+
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_afalphy_sylvakru_UsbExclusiveNative_open(
+    JNIEnv* env,
+    jobject,
+    jint fd,
+    jint interface_number,
+    jint alternate_setting,
+    jint endpoint_address,
+    jint max_packet_size) {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    closeLocked();
+
+    const int duplicated = dup(fd);
+    if (duplicated < 0) {
+        return nullableError(env, errorMessage("dup"));
+    }
+
+    g_fd = duplicated;
+    g_interface_number = interface_number;
+    g_endpoint_address = endpoint_address;
+    g_max_packet_size = max_packet_size;
+
+    if (ioctl(g_fd, USBDEVFS_CLAIMINTERFACE, &g_interface_number) < 0) {
+        const auto error = errorMessage("USBDEVFS_CLAIMINTERFACE");
+        closeLocked();
+        return nullableError(env, error);
+    }
+
+    usbdevfs_setinterface set_interface = {};
+    set_interface.interface = interface_number;
+    set_interface.altsetting = alternate_setting;
+    if (ioctl(g_fd, USBDEVFS_SETINTERFACE, &set_interface) < 0) {
+        const auto error = errorMessage("USBDEVFS_SETINTERFACE");
+        closeLocked();
+        return nullableError(env, error);
+    }
+
+    return nullptr;
+}
+
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_afalphy_sylvakru_UsbExclusiveNative_writePcm(
+    JNIEnv* env,
+    jobject,
+    jbyteArray bytes,
+    jint length) {
+    if (bytes == nullptr || length <= 0) {
+        return nullptr;
+    }
+
+    const jsize array_length = env->GetArrayLength(bytes);
+    const int safe_length = std::min<int>(length, array_length);
+    auto* input = reinterpret_cast<uint8_t*>(env->GetByteArrayElements(bytes, nullptr));
+    if (input == nullptr) {
+        return nullableError(env, "Failed to access PCM buffer.");
+    }
+
+    std::string error;
+    int offset = 0;
+    {
+        std::lock_guard<std::mutex> lock(g_mutex);
+        const int max_chunk = std::max(1, g_max_packet_size * kMaxIsoPacketsPerUrb);
+        while (offset < safe_length && error.empty()) {
+            const int chunk = std::min(max_chunk, safe_length - offset);
+            error = submitIsoChunkLocked(input + offset, chunk);
+            offset += chunk;
+        }
+    }
+
+    env->ReleaseByteArrayElements(bytes, reinterpret_cast<jbyte*>(input), JNI_ABORT);
+    return nullableError(env, error);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_afalphy_sylvakru_UsbExclusiveNative_close(JNIEnv*, jobject) {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    closeLocked();
+}

--- a/android/app/src/main/kotlin/com/afalphy/particle_music/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/afalphy/particle_music/MainActivity.kt
@@ -1,5 +1,399 @@
 package com.afalphy.sylvakru
 
+import android.annotation.TargetApi
+import android.content.Context
+import android.media.AudioAttributes
+import android.media.AudioDeviceInfo
+import android.media.AudioFormat
+import android.media.AudioManager
+import android.media.AudioMixerAttributes
+import android.os.Build
+import android.util.Log
+import com.hchen.superlyricapi.SuperLyricData
+import com.hchen.superlyricapi.SuperLyricHelper
+import com.hchen.superlyricapi.SuperLyricLine
 import com.ryanheise.audioservice.AudioServiceActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
 
-class MainActivity : AudioServiceActivity()
+class MainActivity : AudioServiceActivity() {
+    private val channelName = "com.afalphy.sylvakru/usb_audio"
+    private val superLyricChannelName = "com.afalphy.sylvakru/super_lyric"
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, channelName)
+            .setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "getStatus" -> result.success(getStatus())
+                    "applyPreferredOutput" -> result.success(applyPreferredOutput(call))
+                    "clearPreferredOutput" -> result.success(clearPreferredOutput(call))
+                    else -> result.notImplemented()
+                }
+            }
+
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, superLyricChannelName)
+            .setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "sendLyric" -> result.success(sendSuperLyric(call))
+                    "sendStop" -> result.success(sendSuperLyricStop())
+                    else -> result.notImplemented()
+                }
+            }
+
+        ensureSuperLyricPublisherRegistered()
+    }
+
+    override fun onDestroy() {
+        sendSuperLyricStop()
+        super.onDestroy()
+    }
+
+    private fun sendSuperLyric(call: MethodCall): Boolean {
+        val lyric = call.argument<String>("lyric")?.trim().orEmpty()
+        if (lyric.isEmpty()) {
+            return sendSuperLyricStop()
+        }
+
+        return runSuperLyricAction("sendLyric") {
+            SuperLyricHelper.sendLyric(
+                SuperLyricData().setLyric(SuperLyricLine(lyric)),
+            )
+        }
+    }
+
+    private fun sendSuperLyricStop(): Boolean {
+        return runSuperLyricAction("sendStop") {
+            SuperLyricHelper.sendStop(SuperLyricData())
+        }
+    }
+
+    private fun runSuperLyricAction(actionName: String, action: () -> Unit): Boolean {
+        if (!ensureSuperLyricPublisherRegistered()) {
+            return false
+        }
+
+        return try {
+            action()
+            true
+        } catch (error: Throwable) {
+            Log.w("MainActivity", "SuperLyric $actionName failed.", error)
+            false
+        }
+    }
+
+    private fun ensureSuperLyricPublisherRegistered(): Boolean {
+        return try {
+            if (!SuperLyricHelper.isAvailable()) {
+                return false
+            }
+
+            if (!SuperLyricHelper.isPublisherRegistered()) {
+                SuperLyricHelper.registerPublisher()
+            }
+            true
+        } catch (error: Throwable) {
+            Log.w("MainActivity", "SuperLyric service is unavailable.", error)
+            false
+        }
+    }
+
+    private fun getStatus(
+        preferredApplied: Boolean = false,
+        message: String? = null,
+    ): Map<String, Any?> {
+        val audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
+        val devices = getUsbAudioDevices(audioManager)
+        val activeDevice = getActiveUsbAudioDevice(audioManager, devices)
+        val preferredMixerAttributes = if (
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE &&
+            activeDevice != null
+        ) {
+            getPreferredMixerAttributes(audioManager, activeDevice)
+        } else {
+            null
+        }
+
+        return mapOf(
+            "supported" to devices.isNotEmpty(),
+            "androidSdk" to Build.VERSION.SDK_INT,
+            "activeDeviceId" to activeDevice?.id,
+            "preferredApplied" to preferredApplied,
+            "preferredSampleRate" to preferredMixerAttributes?.format?.sampleRate,
+            "preferredEncoding" to preferredMixerAttributes?.format?.encoding?.let {
+                encodingName(it)
+            },
+            "preferredBitPerfect" to (
+                preferredMixerAttributes?.mixerBehavior ==
+                    AudioMixerAttributes.MIXER_BEHAVIOR_BIT_PERFECT
+                ),
+            "message" to (message ?: defaultStatusMessage(devices)),
+            "devices" to devices.map { it.toMap(audioManager) },
+        )
+    }
+
+    private fun applyPreferredOutput(call: MethodCall): Map<String, Any?> {
+        val audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
+        val devices = getUsbAudioDevices(audioManager)
+        val device = findRequestedDevice(audioManager, devices, call.argument<Int>("deviceId"))
+            ?: return getStatus(message = "No USB audio output device detected.")
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            return getStatus(
+                message = "USB mixer attributes require Android 14 or newer.",
+            )
+        }
+
+        return applyPreferredOutputApi34(audioManager, device, call)
+    }
+
+    private fun clearPreferredOutput(call: MethodCall): Map<String, Any?> {
+        val audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
+        val devices = getUsbAudioDevices(audioManager)
+        val device = findRequestedDevice(audioManager, devices, call.argument<Int>("deviceId"))
+            ?: return getStatus(message = "No USB audio output device detected.")
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            return getStatus(
+                message = "USB mixer attributes require Android 14 or newer.",
+            )
+        }
+
+        val cleared = clearPreferredOutputApi34(audioManager, device)
+        return getStatus(
+            preferredApplied = false,
+            message = if (cleared) {
+                "Cleared preferred USB mixer attributes."
+            } else {
+                "No preferred USB mixer attributes were cleared."
+            },
+        )
+    }
+
+    @TargetApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    private fun applyPreferredOutputApi34(
+        audioManager: AudioManager,
+        device: AudioDeviceInfo,
+        call: MethodCall,
+    ): Map<String, Any?> {
+        val sampleRate = call.argument<Int>("sampleRate")
+            ?: chooseSampleRate(audioManager, device)
+            ?: 48000
+        val encoding = encodingFromName(
+            call.argument<String>("encoding") ?: "pcm_24bit_packed",
+        )
+        val bitPerfect = call.argument<Boolean>("bitPerfect") ?: true
+
+        val format = AudioFormat.Builder()
+            .setSampleRate(sampleRate)
+            .setEncoding(encoding)
+            .setChannelMask(AudioFormat.CHANNEL_OUT_STEREO)
+            .build()
+        val mixerAttributes = AudioMixerAttributes.Builder(format)
+            .setMixerBehavior(
+                if (bitPerfect) {
+                    AudioMixerAttributes.MIXER_BEHAVIOR_BIT_PERFECT
+                } else {
+                    AudioMixerAttributes.MIXER_BEHAVIOR_DEFAULT
+                },
+            )
+            .build()
+
+        return try {
+            val applied = audioManager.setPreferredMixerAttributes(
+                mediaAudioAttributes(),
+                device,
+                mixerAttributes,
+            )
+            getStatus(
+                preferredApplied = applied,
+                message = if (applied) {
+                    "Applied preferred USB mixer attributes."
+                } else {
+                    "Device rejected preferred USB mixer attributes."
+                },
+            )
+        } catch (error: RuntimeException) {
+            getStatus(message = "Failed to apply USB mixer attributes: ${error.message}")
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    private fun clearPreferredOutputApi34(
+        audioManager: AudioManager,
+        device: AudioDeviceInfo,
+    ): Boolean {
+        return try {
+            audioManager.clearPreferredMixerAttributes(mediaAudioAttributes(), device)
+        } catch (_: RuntimeException) {
+            false
+        }
+    }
+
+    private fun getUsbAudioDevices(audioManager: AudioManager): List<AudioDeviceInfo> {
+        return audioManager
+            .getDevices(AudioManager.GET_DEVICES_OUTPUTS)
+            .filter { it.isUsbAudioOutput() }
+    }
+
+    private fun getActiveUsbAudioDevice(
+        audioManager: AudioManager,
+        devices: List<AudioDeviceInfo>,
+    ): AudioDeviceInfo? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            return null
+        }
+
+        val activeDevices = audioManager.getAudioDevicesForAttributes(mediaAudioAttributes())
+        return activeDevices.firstOrNull { active ->
+            devices.any { it.id == active.id }
+        }
+    }
+
+    private fun findRequestedDevice(
+        audioManager: AudioManager,
+        devices: List<AudioDeviceInfo>,
+        requestedDeviceId: Int?,
+    ): AudioDeviceInfo? {
+        if (requestedDeviceId != null) {
+            return devices.firstOrNull { it.id == requestedDeviceId }
+        }
+        return getActiveUsbAudioDevice(audioManager, devices) ?: devices.firstOrNull()
+    }
+
+    @TargetApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    private fun chooseSampleRate(
+        audioManager: AudioManager,
+        device: AudioDeviceInfo,
+    ): Int? {
+        val mixerSampleRates = getSupportedMixerSampleRates(audioManager, device)
+        if (mixerSampleRates.isNotEmpty()) {
+            return mixerSampleRates.maxOrNull()
+        }
+        return device.sampleRates.maxOrNull()
+    }
+
+    private fun mediaAudioAttributes(): AudioAttributes {
+        return AudioAttributes.Builder()
+            .setUsage(AudioAttributes.USAGE_MEDIA)
+            .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+            .build()
+    }
+
+    private fun defaultStatusMessage(devices: List<AudioDeviceInfo>): String {
+        return if (devices.isEmpty()) {
+            "No USB audio output device detected."
+        } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            "USB audio device detected. Preferred mixer attributes require Android 14 or newer."
+        } else {
+            "USB audio device detected."
+        }
+    }
+
+    private fun AudioDeviceInfo.isUsbAudioOutput(): Boolean {
+        return type == AudioDeviceInfo.TYPE_USB_DEVICE ||
+            type == AudioDeviceInfo.TYPE_USB_HEADSET ||
+            type == AudioDeviceInfo.TYPE_USB_ACCESSORY
+    }
+
+    private fun AudioDeviceInfo.toMap(audioManager: AudioManager): Map<String, Any?> {
+        return mapOf(
+            "id" to id,
+            "name" to productName.toString(),
+            "type" to audioDeviceTypeName(type),
+            "address" to address,
+            "sampleRates" to sampleRates.toList(),
+            "encodings" to encodings.map { encodingName(it) },
+            "channelCounts" to channelCounts.toList(),
+            "supportedMixerSampleRates" to if (
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+            ) {
+                getSupportedMixerSampleRates(audioManager, this)
+            } else {
+                emptyList()
+            },
+            "supportsBitPerfectMixer" to if (
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+            ) {
+                supportsBitPerfectMixer(audioManager, this)
+            } else {
+                false
+            },
+        )
+    }
+
+    @TargetApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    private fun getSupportedMixerSampleRates(
+        audioManager: AudioManager,
+        device: AudioDeviceInfo,
+    ): List<Int> {
+        return try {
+            audioManager
+                .getSupportedMixerAttributes(device)
+                .map { it.format.sampleRate }
+                .filter { it > 0 }
+                .distinct()
+                .sorted()
+        } catch (_: RuntimeException) {
+            emptyList()
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    private fun supportsBitPerfectMixer(
+        audioManager: AudioManager,
+        device: AudioDeviceInfo,
+    ): Boolean {
+        return try {
+            audioManager
+                .getSupportedMixerAttributes(device)
+                .any { it.mixerBehavior == AudioMixerAttributes.MIXER_BEHAVIOR_BIT_PERFECT }
+        } catch (_: RuntimeException) {
+            false
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    private fun getPreferredMixerAttributes(
+        audioManager: AudioManager,
+        device: AudioDeviceInfo,
+    ): AudioMixerAttributes? {
+        return try {
+            audioManager.getPreferredMixerAttributes(mediaAudioAttributes(), device)
+        } catch (_: RuntimeException) {
+            null
+        }
+    }
+
+    private fun audioDeviceTypeName(type: Int): String {
+        return when (type) {
+            AudioDeviceInfo.TYPE_USB_DEVICE -> "usb_device"
+            AudioDeviceInfo.TYPE_USB_HEADSET -> "usb_headset"
+            AudioDeviceInfo.TYPE_USB_ACCESSORY -> "usb_accessory"
+            else -> "unknown"
+        }
+    }
+
+    private fun encodingName(encoding: Int): String {
+        return when (encoding) {
+            AudioFormat.ENCODING_PCM_8BIT -> "pcm_8bit"
+            AudioFormat.ENCODING_PCM_16BIT -> "pcm_16bit"
+            AudioFormat.ENCODING_PCM_24BIT_PACKED -> "pcm_24bit_packed"
+            AudioFormat.ENCODING_PCM_32BIT -> "pcm_32bit"
+            AudioFormat.ENCODING_PCM_FLOAT -> "pcm_float"
+            else -> "encoding_$encoding"
+        }
+    }
+
+    private fun encodingFromName(name: String): Int {
+        return when (name) {
+            "pcm_8bit" -> AudioFormat.ENCODING_PCM_8BIT
+            "pcm_16bit" -> AudioFormat.ENCODING_PCM_16BIT
+            "pcm_32bit" -> AudioFormat.ENCODING_PCM_32BIT
+            "pcm_float" -> AudioFormat.ENCODING_PCM_FLOAT
+            else -> AudioFormat.ENCODING_PCM_24BIT_PACKED
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/afalphy/particle_music/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/afalphy/particle_music/MainActivity.kt
@@ -47,11 +47,19 @@ class MainActivity : AudioServiceActivity() {
         super.configureFlutterEngine(flutterEngine)
 
         usbAudioChannel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, channelName)
-        usbExclusiveAudioEngine = UsbExclusiveAudioEngine(this) { state ->
-            runOnUiThread {
-                usbAudioChannel.invokeMethod("onUsbExclusiveStateChanged", state)
-            }
-        }
+        usbExclusiveAudioEngine = UsbExclusiveAudioEngine(
+            this,
+            emitState = { state ->
+                runOnUiThread {
+                    usbAudioChannel.invokeMethod("onUsbExclusiveStateChanged", state)
+                }
+            },
+            emitTelemetry = { telemetry ->
+                runOnUiThread {
+                    usbAudioChannel.invokeMethod("onUsbTransportTelemetryChanged", telemetry)
+                }
+            },
+        )
         usbAudioChannel.setMethodCallHandler { call, result ->
             when (call.method) {
                 "getStatus" -> result.success(getStatus())
@@ -62,6 +70,10 @@ class MainActivity : AudioServiceActivity() {
                 "startExclusivePlayback" -> result.success(startExclusivePlayback(call))
                 "pauseExclusivePlayback" -> result.success(usbExclusiveAudioEngine.pause())
                 "resumeExclusivePlayback" -> result.success(usbExclusiveAudioEngine.resume())
+                "setExclusiveTargetBufferMs" -> {
+                    val targetBufferMs = call.argument<Number>("targetBufferMs")?.toInt() ?: 200
+                    result.success(usbExclusiveAudioEngine.setTargetBufferMs(targetBufferMs))
+                }
                 "seekExclusivePlayback" -> {
                     val positionMs = call.argument<Number>("positionMs")?.toLong() ?: 0L
                     result.success(usbExclusiveAudioEngine.seek(positionMs))

--- a/android/app/src/main/kotlin/com/afalphy/particle_music/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/afalphy/particle_music/MainActivity.kt
@@ -36,6 +36,7 @@ class MainActivity : AudioServiceActivity() {
     private val superLyricChannelName = "com.afalphy.sylvakru/super_lyric"
     private val usbPermissionAction = "com.afalphy.sylvakru.USB_PERMISSION"
     private lateinit var usbAudioChannel: MethodChannel
+    private lateinit var usbExclusiveAudioEngine: UsbExclusiveAudioEngine
     private var usbAudioDeviceCallback: AudioDeviceCallback? = null
     private var pendingExclusiveProbeResult: MethodChannel.Result? = null
     private var pendingExclusiveProbeDevice: UsbDevice? = null
@@ -45,12 +46,27 @@ class MainActivity : AudioServiceActivity() {
         super.configureFlutterEngine(flutterEngine)
 
         usbAudioChannel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, channelName)
+        usbExclusiveAudioEngine = UsbExclusiveAudioEngine(this) { state ->
+            runOnUiThread {
+                usbAudioChannel.invokeMethod("onUsbExclusiveStateChanged", state)
+            }
+        }
         usbAudioChannel.setMethodCallHandler { call, result ->
             when (call.method) {
                 "getStatus" -> result.success(getStatus())
                 "applyPreferredOutput" -> result.success(applyPreferredOutput(call))
                 "clearPreferredOutput" -> result.success(clearPreferredOutput(call))
                 "probeExclusiveAccess" -> probeExclusiveAccess(result)
+                "getExclusiveCapabilities" -> result.success(getExclusiveCapabilities())
+                "startExclusivePlayback" -> result.success(startExclusivePlayback(call))
+                "pauseExclusivePlayback" -> result.success(usbExclusiveAudioEngine.pause())
+                "resumeExclusivePlayback" -> result.success(usbExclusiveAudioEngine.resume())
+                "seekExclusivePlayback" -> {
+                    val positionMs = call.argument<Number>("positionMs")?.toLong() ?: 0L
+                    result.success(usbExclusiveAudioEngine.seek(positionMs))
+                }
+                "stopExclusivePlayback" -> result.success(usbExclusiveAudioEngine.stop())
+                "releaseExclusiveDevice" -> result.success(usbExclusiveAudioEngine.release())
                 else -> result.notImplemented()
             }
         }
@@ -72,6 +88,9 @@ class MainActivity : AudioServiceActivity() {
     override fun onDestroy() {
         unregisterUsbPermissionReceiver()
         unregisterUsbAudioDeviceCallback()
+        if (::usbExclusiveAudioEngine.isInitialized) {
+            usbExclusiveAudioEngine.release()
+        }
         sendSuperLyricStop()
         super.onDestroy()
     }
@@ -297,6 +316,28 @@ class MainActivity : AudioServiceActivity() {
 
     private fun findUsbAudioDevice(usbManager: UsbManager): UsbDevice? {
         return usbManager.deviceList.values.firstOrNull { it.audioInterfaceCount() > 0 }
+    }
+
+    private fun getExclusiveCapabilities(): Map<String, Any?> {
+        val usbManager = getSystemService(Context.USB_SERVICE) as UsbManager
+        return usbExclusiveAudioEngine.capabilities(
+            usbManager,
+            findUsbAudioDevice(usbManager),
+        )
+    }
+
+    private fun startExclusivePlayback(call: MethodCall): Map<String, Any?> {
+        val usbManager = getSystemService(Context.USB_SERVICE) as UsbManager
+        return usbExclusiveAudioEngine.start(
+            usbManager,
+            findUsbAudioDevice(usbManager),
+            call.argumentsMap(),
+        )
+    }
+
+    private fun MethodCall.argumentsMap(): Map<String, Any?> {
+        val raw = arguments as? Map<*, *> ?: return emptyMap()
+        return raw.entries.associate { (key, value) -> key.toString() to value }
     }
 
     private fun UsbDevice.audioInterfaces(): List<UsbInterface> {

--- a/android/app/src/main/kotlin/com/afalphy/particle_music/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/afalphy/particle_music/MainActivity.kt
@@ -2,16 +2,21 @@ package com.afalphy.sylvakru
 
 import android.annotation.TargetApi
 import android.content.Context
+import android.media.AudioDeviceCallback
 import android.media.AudioAttributes
 import android.media.AudioDeviceInfo
 import android.media.AudioFormat
 import android.media.AudioManager
 import android.media.AudioMixerAttributes
+import android.media.AudioTrack
 import android.os.Build
+import android.os.Handler
+import android.os.Looper
 import android.util.Log
 import com.hchen.superlyricapi.SuperLyricData
 import com.hchen.superlyricapi.SuperLyricHelper
 import com.hchen.superlyricapi.SuperLyricLine
+import com.hchen.superlyricapi.SuperLyricWord
 import com.ryanheise.audioservice.AudioServiceActivity
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodCall
@@ -20,19 +25,22 @@ import io.flutter.plugin.common.MethodChannel
 class MainActivity : AudioServiceActivity() {
     private val channelName = "com.afalphy.sylvakru/usb_audio"
     private val superLyricChannelName = "com.afalphy.sylvakru/super_lyric"
+    private lateinit var usbAudioChannel: MethodChannel
+    private var usbAudioDeviceCallback: AudioDeviceCallback? = null
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
 
-        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, channelName)
-            .setMethodCallHandler { call, result ->
-                when (call.method) {
-                    "getStatus" -> result.success(getStatus())
-                    "applyPreferredOutput" -> result.success(applyPreferredOutput(call))
-                    "clearPreferredOutput" -> result.success(clearPreferredOutput(call))
-                    else -> result.notImplemented()
-                }
+        usbAudioChannel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, channelName)
+        usbAudioChannel.setMethodCallHandler { call, result ->
+            when (call.method) {
+                "getStatus" -> result.success(getStatus())
+                "applyPreferredOutput" -> result.success(applyPreferredOutput(call))
+                "clearPreferredOutput" -> result.success(clearPreferredOutput(call))
+                else -> result.notImplemented()
             }
+        }
+        registerUsbAudioDeviceCallback()
 
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, superLyricChannelName)
             .setMethodCallHandler { call, result ->
@@ -47,8 +55,53 @@ class MainActivity : AudioServiceActivity() {
     }
 
     override fun onDestroy() {
+        unregisterUsbAudioDeviceCallback()
         sendSuperLyricStop()
         super.onDestroy()
+    }
+
+    private fun registerUsbAudioDeviceCallback() {
+        if (usbAudioDeviceCallback != null) {
+            return
+        }
+
+        val audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
+        val callback = object : AudioDeviceCallback() {
+            override fun onAudioDevicesAdded(addedDevices: Array<out AudioDeviceInfo>) {
+                addedDevices
+                    .filter { it.isUsbAudioOutput() }
+                    .forEach { device -> sendUsbAudioDeviceEvent("added", device.id) }
+            }
+
+            override fun onAudioDevicesRemoved(removedDevices: Array<out AudioDeviceInfo>) {
+                removedDevices
+                    .filter { it.isUsbAudioOutput() }
+                    .forEach { device -> sendUsbAudioDeviceEvent("removed", device.id) }
+            }
+        }
+
+        audioManager.registerAudioDeviceCallback(callback, Handler(Looper.getMainLooper()))
+        usbAudioDeviceCallback = callback
+    }
+
+    private fun unregisterUsbAudioDeviceCallback() {
+        val callback = usbAudioDeviceCallback ?: return
+        val audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
+        audioManager.unregisterAudioDeviceCallback(callback)
+        usbAudioDeviceCallback = null
+    }
+
+    private fun sendUsbAudioDeviceEvent(type: String, deviceId: Int) {
+        runOnUiThread {
+            usbAudioChannel.invokeMethod(
+                "onUsbAudioDeviceEvent",
+                mapOf(
+                    "type" to type,
+                    "deviceId" to deviceId,
+                    "status" to getStatus(),
+                ),
+            )
+        }
     }
 
     private fun sendSuperLyric(call: MethodCall): Boolean {
@@ -57,11 +110,37 @@ class MainActivity : AudioServiceActivity() {
             return sendSuperLyricStop()
         }
 
+        val startTime = call.argument<Number>("startTime")?.toLong() ?: 0L
+        val endTime = call.argument<Number>("endTime")?.toLong() ?: startTime
+        val words = parseSuperLyricWords(call.argument<List<Any?>>("tokens"))
+
         return runSuperLyricAction("sendLyric") {
             SuperLyricHelper.sendLyric(
-                SuperLyricData().setLyric(SuperLyricLine(lyric)),
+                SuperLyricData().setLyric(
+                    if (words.isNotEmpty()) {
+                        SuperLyricLine(lyric, words.toTypedArray(), startTime, endTime)
+                    } else if (endTime > startTime) {
+                        SuperLyricLine(lyric, startTime, endTime)
+                    } else {
+                        SuperLyricLine(lyric)
+                    },
+                ),
             )
         }
+    }
+
+    private fun parseSuperLyricWords(tokens: List<Any?>?): List<SuperLyricWord> {
+        return tokens
+            ?.mapNotNull { token ->
+                val map = token as? Map<*, *> ?: return@mapNotNull null
+                val text = map["text"] as? String ?: return@mapNotNull null
+                if (text.isEmpty()) return@mapNotNull null
+
+                val startTime = (map["startTime"] as? Number)?.toLong() ?: return@mapNotNull null
+                val endTime = (map["endTime"] as? Number)?.toLong() ?: return@mapNotNull null
+                SuperLyricWord(text, startTime, endTime)
+            }
+            .orEmpty()
     }
 
     private fun sendSuperLyricStop(): Boolean {
@@ -107,6 +186,7 @@ class MainActivity : AudioServiceActivity() {
         val audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
         val devices = getUsbAudioDevices(audioManager)
         val activeDevice = getActiveUsbAudioDevice(audioManager, devices)
+        val outputDevice = activeDevice ?: getActiveOutputDevice(audioManager)
         val preferredMixerAttributes = if (
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE &&
             activeDevice != null
@@ -129,6 +209,9 @@ class MainActivity : AudioServiceActivity() {
                 preferredMixerAttributes?.mixerBehavior ==
                     AudioMixerAttributes.MIXER_BEHAVIOR_BIT_PERFECT
                 ),
+            "outputDeviceName" to outputDevice?.productName?.toString(),
+            "outputSampleRate" to outputSampleRate(outputDevice),
+            "outputEncoding" to outputEncoding(outputDevice),
             "message" to (message ?: defaultStatusMessage(devices)),
             "devices" to devices.map { it.toMap(audioManager) },
         )
@@ -252,6 +335,35 @@ class MainActivity : AudioServiceActivity() {
         }
     }
 
+    private fun getActiveOutputDevice(audioManager: AudioManager): AudioDeviceInfo? {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            audioManager
+                .getAudioDevicesForAttributes(mediaAudioAttributes())
+                .firstOrNull()
+                ?.let { return it }
+        }
+
+        return audioManager
+            .getDevices(AudioManager.GET_DEVICES_OUTPUTS)
+            .firstOrNull { it.type == AudioDeviceInfo.TYPE_BUILTIN_SPEAKER }
+            ?: audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS).firstOrNull()
+    }
+
+    private fun outputSampleRate(device: AudioDeviceInfo?): Int? {
+        device?.sampleRates?.filter { it > 0 }?.maxOrNull()?.let { return it }
+        return AudioTrack
+            .getNativeOutputSampleRate(AudioManager.STREAM_MUSIC)
+            .takeIf { it > 0 }
+    }
+
+    private fun outputEncoding(device: AudioDeviceInfo?): String? {
+        return device
+            ?.encodings
+            ?.firstOrNull { it == AudioFormat.ENCODING_PCM_16BIT }
+            ?.let { encodingName(it) }
+            ?: device?.encodings?.firstOrNull()?.let { encodingName(it) }
+    }
+
     private fun findRequestedDevice(
         audioManager: AudioManager,
         devices: List<AudioDeviceInfo>,
@@ -372,6 +484,11 @@ class MainActivity : AudioServiceActivity() {
             AudioDeviceInfo.TYPE_USB_DEVICE -> "usb_device"
             AudioDeviceInfo.TYPE_USB_HEADSET -> "usb_headset"
             AudioDeviceInfo.TYPE_USB_ACCESSORY -> "usb_accessory"
+            AudioDeviceInfo.TYPE_BUILTIN_SPEAKER -> "builtin_speaker"
+            AudioDeviceInfo.TYPE_BLUETOOTH_A2DP -> "bluetooth_a2dp"
+            AudioDeviceInfo.TYPE_BLUETOOTH_SCO -> "bluetooth_sco"
+            AudioDeviceInfo.TYPE_WIRED_HEADPHONES -> "wired_headphones"
+            AudioDeviceInfo.TYPE_WIRED_HEADSET -> "wired_headset"
             else -> "unknown"
         }
     }

--- a/android/app/src/main/kotlin/com/afalphy/particle_music/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/afalphy/particle_music/MainActivity.kt
@@ -32,6 +32,7 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 
 class MainActivity : AudioServiceActivity() {
+    private val tag = "UsbExclusiveAudioEngine"
     private val channelName = "com.afalphy.sylvakru/usb_audio"
     private val superLyricChannelName = "com.afalphy.sylvakru/super_lyric"
     private val usbPermissionAction = "com.afalphy.sylvakru.USB_PERMISSION"
@@ -201,6 +202,7 @@ class MainActivity : AudioServiceActivity() {
         val usbManager = getSystemService(Context.USB_SERVICE) as UsbManager
         val device = findUsbAudioDevice(usbManager)
         if (device == null) {
+            Log.i(tag, "probeExclusiveAccess: no USB Audio Class device found.")
             result.success(
                 exclusiveProbeResult(
                     supported = false,
@@ -216,6 +218,7 @@ class MainActivity : AudioServiceActivity() {
         }
 
         if (!usbManager.hasPermission(device)) {
+            Log.i(tag, "probeExclusiveAccess: requesting USB permission for ${device.debugLabel()}.")
             if (pendingExclusiveProbeResult != null) {
                 result.success(
                     exclusiveProbeResult(
@@ -248,12 +251,17 @@ class MainActivity : AudioServiceActivity() {
             return
         }
 
+        Log.i(tag, "probeExclusiveAccess: permission already granted for ${device.debugLabel()}.")
         result.success(runExclusiveProbe(device))
     }
 
     private fun runExclusiveProbe(device: UsbDevice): Map<String, Any?> {
         val usbManager = getSystemService(Context.USB_SERVICE) as UsbManager
         val audioInterfaces = device.audioInterfaces()
+        Log.i(
+            tag,
+            "runExclusiveProbe: opening ${device.debugLabel()}, audioInterfaces=${audioInterfaces.size}.",
+        )
         val connection = usbManager.openDevice(device)
             ?: return exclusiveProbeResult(
                 supported = true,
@@ -264,6 +272,7 @@ class MainActivity : AudioServiceActivity() {
                 rawDescriptorLength = 0,
                 message = "Failed to open USB device.",
             )
+                .also { Log.w(tag, "runExclusiveProbe: openDevice failed for ${device.debugLabel()}.") }
 
         return connection.useConnection {
             val claimed = mutableListOf<UsbInterface>()
@@ -273,6 +282,17 @@ class MainActivity : AudioServiceActivity() {
                 for (usbInterface in audioInterfaces) {
                     if (connection.claimInterface(usbInterface, true)) {
                         claimed.add(usbInterface)
+                        Log.i(
+                            tag,
+                            "runExclusiveProbe: claimInterface ok id=${usbInterface.id}, " +
+                                "class=${usbInterface.interfaceClass}, alt=${usbInterface.alternateSetting}.",
+                        )
+                    } else {
+                        Log.w(
+                            tag,
+                            "runExclusiveProbe: claimInterface failed id=${usbInterface.id}, " +
+                                "class=${usbInterface.interfaceClass}, alt=${usbInterface.alternateSetting}.",
+                        )
                     }
                 }
                 exclusiveProbeResult(
@@ -315,22 +335,39 @@ class MainActivity : AudioServiceActivity() {
     }
 
     private fun findUsbAudioDevice(usbManager: UsbManager): UsbDevice? {
-        return usbManager.deviceList.values.firstOrNull { it.audioInterfaceCount() > 0 }
+        val devices = usbManager.deviceList.values.toList()
+        Log.i(
+            tag,
+            "enumerating USB devices count=${devices.size}: " +
+                devices.joinToString { it.debugLabel() },
+        )
+        val device = devices.firstOrNull { it.audioInterfaceCount() > 0 }
+        Log.i(tag, "selected USB Audio device=${device?.debugLabel() ?: "none"}.")
+        return device
     }
 
     private fun getExclusiveCapabilities(): Map<String, Any?> {
         val usbManager = getSystemService(Context.USB_SERVICE) as UsbManager
-        return usbExclusiveAudioEngine.capabilities(
+        val device = findUsbAudioDevice(usbManager)
+        val capabilities = usbExclusiveAudioEngine.capabilities(
             usbManager,
-            findUsbAudioDevice(usbManager),
+            device,
         )
+        Log.i(tag, "getExclusiveCapabilities: $capabilities")
+        return capabilities
     }
 
     private fun startExclusivePlayback(call: MethodCall): Map<String, Any?> {
         val usbManager = getSystemService(Context.USB_SERVICE) as UsbManager
+        val device = findUsbAudioDevice(usbManager)
+        Log.i(
+            tag,
+            "startExclusivePlayback: device=${device?.debugLabel() ?: "none"}, " +
+                "arguments=${call.argumentsMap()}",
+        )
         return usbExclusiveAudioEngine.start(
             usbManager,
-            findUsbAudioDevice(usbManager),
+            device,
             call.argumentsMap(),
         )
     }
@@ -353,6 +390,11 @@ class MainActivity : AudioServiceActivity() {
 
     private fun UsbDevice.audioInterfaceCount(): Int {
         return audioInterfaces().size
+    }
+
+    private fun UsbDevice.debugLabel(): String {
+        return "name=${productName ?: deviceName}, vendor=$vendorId, product=$productId, " +
+            "id=$deviceId, interfaces=$interfaceCount, audioInterfaces=${audioInterfaceCount()}"
     }
 
     private fun exclusiveProbeResult(
@@ -533,7 +575,13 @@ class MainActivity : AudioServiceActivity() {
         device: AudioDeviceInfo,
         call: MethodCall,
     ): Map<String, Any?> {
-        val sampleRate = call.argument<Int>("sampleRate")
+        val requestedSampleRate = call.argument<Int>("sampleRate")
+        if (requestedSampleRate != null && !isValidMixerSampleRate(requestedSampleRate)) {
+            return getStatus(
+                message = "Skipped preferred USB mixer attributes: Android rejected sample rate $requestedSampleRate.",
+            )
+        }
+        val sampleRate = requestedSampleRate
             ?: chooseSampleRate(audioManager, device)
             ?: 48000
         val encoding = encodingFromName(
@@ -541,22 +589,22 @@ class MainActivity : AudioServiceActivity() {
         )
         val bitPerfect = call.argument<Boolean>("bitPerfect") ?: true
 
-        val format = AudioFormat.Builder()
-            .setSampleRate(sampleRate)
-            .setEncoding(encoding)
-            .setChannelMask(AudioFormat.CHANNEL_OUT_STEREO)
-            .build()
-        val mixerAttributes = AudioMixerAttributes.Builder(format)
-            .setMixerBehavior(
-                if (bitPerfect) {
-                    AudioMixerAttributes.MIXER_BEHAVIOR_BIT_PERFECT
-                } else {
-                    AudioMixerAttributes.MIXER_BEHAVIOR_DEFAULT
-                },
-            )
-            .build()
-
         return try {
+            Log.i(tag, "applyPreferredOutputApi34: requesting sampleRate=$sampleRate, encoding=$encoding.")
+            val format = AudioFormat.Builder()
+                .setSampleRate(sampleRate)
+                .setEncoding(encoding)
+                .setChannelMask(AudioFormat.CHANNEL_OUT_STEREO)
+                .build()
+            val mixerAttributes = AudioMixerAttributes.Builder(format)
+                .setMixerBehavior(
+                    if (bitPerfect) {
+                        AudioMixerAttributes.MIXER_BEHAVIOR_BIT_PERFECT
+                    } else {
+                        AudioMixerAttributes.MIXER_BEHAVIOR_DEFAULT
+                    },
+                )
+                .build()
             val applied = audioManager.setPreferredMixerAttributes(
                 mediaAudioAttributes(),
                 device,
@@ -622,7 +670,7 @@ class MainActivity : AudioServiceActivity() {
     }
 
     private fun outputSampleRate(device: AudioDeviceInfo?): Int? {
-        device?.sampleRates?.filter { it > 0 }?.maxOrNull()?.let { return it }
+        chooseStableSampleRate(device?.sampleRates?.toList().orEmpty())?.let { return it }
         return AudioTrack
             .getNativeOutputSampleRate(AudioManager.STREAM_MUSIC)
             .takeIf { it > 0 }
@@ -634,6 +682,10 @@ class MainActivity : AudioServiceActivity() {
             ?.firstOrNull { it == AudioFormat.ENCODING_PCM_16BIT }
             ?.let { encodingName(it) }
             ?: device?.encodings?.firstOrNull()?.let { encodingName(it) }
+    }
+
+    private fun isValidMixerSampleRate(sampleRate: Int): Boolean {
+        return sampleRate in 4000..192000
     }
 
     private fun findRequestedDevice(
@@ -653,10 +705,25 @@ class MainActivity : AudioServiceActivity() {
         device: AudioDeviceInfo,
     ): Int? {
         val mixerSampleRates = getSupportedMixerSampleRates(audioManager, device)
-        if (mixerSampleRates.isNotEmpty()) {
-            return mixerSampleRates.maxOrNull()
+        val rates = if (mixerSampleRates.isNotEmpty()) {
+            mixerSampleRates
+        } else {
+            device.sampleRates.toList()
         }
-        return device.sampleRates.maxOrNull()
+        return chooseStableSampleRate(rates)
+    }
+
+    private fun chooseStableSampleRate(rates: List<Int>): Int? {
+        if (rates.isEmpty()) {
+            return null
+        }
+        val validRates = rates.filter { isValidMixerSampleRate(it) }.toSet()
+        for (rate in listOf(48000, 44100, 96000, 88200, 192000, 176400)) {
+            if (validRates.contains(rate)) {
+                return rate
+            }
+        }
+        return validRates.maxOrNull()
     }
 
     private fun mediaAudioAttributes(): AudioAttributes {

--- a/android/app/src/main/kotlin/com/afalphy/particle_music/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/afalphy/particle_music/MainActivity.kt
@@ -1,7 +1,11 @@
 package com.afalphy.sylvakru
 
 import android.annotation.TargetApi
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import android.media.AudioDeviceCallback
 import android.media.AudioAttributes
 import android.media.AudioDeviceInfo
@@ -13,6 +17,11 @@ import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
+import android.hardware.usb.UsbConstants
+import android.hardware.usb.UsbDevice
+import android.hardware.usb.UsbDeviceConnection
+import android.hardware.usb.UsbInterface
+import android.hardware.usb.UsbManager
 import com.hchen.superlyricapi.SuperLyricData
 import com.hchen.superlyricapi.SuperLyricHelper
 import com.hchen.superlyricapi.SuperLyricLine
@@ -25,8 +34,12 @@ import io.flutter.plugin.common.MethodChannel
 class MainActivity : AudioServiceActivity() {
     private val channelName = "com.afalphy.sylvakru/usb_audio"
     private val superLyricChannelName = "com.afalphy.sylvakru/super_lyric"
+    private val usbPermissionAction = "com.afalphy.sylvakru.USB_PERMISSION"
     private lateinit var usbAudioChannel: MethodChannel
     private var usbAudioDeviceCallback: AudioDeviceCallback? = null
+    private var pendingExclusiveProbeResult: MethodChannel.Result? = null
+    private var pendingExclusiveProbeDevice: UsbDevice? = null
+    private var usbPermissionReceiver: BroadcastReceiver? = null
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
@@ -37,10 +50,12 @@ class MainActivity : AudioServiceActivity() {
                 "getStatus" -> result.success(getStatus())
                 "applyPreferredOutput" -> result.success(applyPreferredOutput(call))
                 "clearPreferredOutput" -> result.success(clearPreferredOutput(call))
+                "probeExclusiveAccess" -> probeExclusiveAccess(result)
                 else -> result.notImplemented()
             }
         }
         registerUsbAudioDeviceCallback()
+        registerUsbPermissionReceiver()
 
         MethodChannel(flutterEngine.dartExecutor.binaryMessenger, superLyricChannelName)
             .setMethodCallHandler { call, result ->
@@ -55,9 +70,68 @@ class MainActivity : AudioServiceActivity() {
     }
 
     override fun onDestroy() {
+        unregisterUsbPermissionReceiver()
         unregisterUsbAudioDeviceCallback()
         sendSuperLyricStop()
         super.onDestroy()
+    }
+
+    private fun registerUsbPermissionReceiver() {
+        if (usbPermissionReceiver != null) {
+            return
+        }
+
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context, intent: Intent) {
+                if (intent.action != usbPermissionAction) {
+                    return
+                }
+
+                val result = pendingExclusiveProbeResult ?: return
+                val device = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    intent.getParcelableExtra(UsbManager.EXTRA_DEVICE, UsbDevice::class.java)
+                } else {
+                    @Suppress("DEPRECATION")
+                    intent.getParcelableExtra(UsbManager.EXTRA_DEVICE)
+                } ?: pendingExclusiveProbeDevice
+                val granted = intent.getBooleanExtra(UsbManager.EXTRA_PERMISSION_GRANTED, false)
+
+                pendingExclusiveProbeResult = null
+                pendingExclusiveProbeDevice = null
+
+                if (device == null || !granted) {
+                    result.success(
+                        exclusiveProbeResult(
+                            supported = device != null,
+                            permissionGranted = false,
+                            device = device,
+                            audioInterfaceCount = device?.audioInterfaceCount() ?: 0,
+                            claimedInterfaceCount = 0,
+                            rawDescriptorLength = 0,
+                            message = "USB permission was denied.",
+                        ),
+                    )
+                    return
+                }
+
+                result.success(runExclusiveProbe(device))
+            }
+        }
+
+        val filter = IntentFilter(usbPermissionAction)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            registerReceiver(receiver, filter, Context.RECEIVER_NOT_EXPORTED)
+        } else {
+            @Suppress("DEPRECATION")
+            registerReceiver(receiver, filter)
+        }
+        usbPermissionReceiver = receiver
+    }
+
+    private fun unregisterUsbPermissionReceiver() {
+        val receiver = usbPermissionReceiver ?: return
+        unregisterReceiver(receiver)
+        usbPermissionReceiver = null
     }
 
     private fun registerUsbAudioDeviceCallback() {
@@ -102,6 +176,163 @@ class MainActivity : AudioServiceActivity() {
                 ),
             )
         }
+    }
+
+    private fun probeExclusiveAccess(result: MethodChannel.Result) {
+        val usbManager = getSystemService(Context.USB_SERVICE) as UsbManager
+        val device = findUsbAudioDevice(usbManager)
+        if (device == null) {
+            result.success(
+                exclusiveProbeResult(
+                    supported = false,
+                    permissionGranted = false,
+                    device = null,
+                    audioInterfaceCount = 0,
+                    claimedInterfaceCount = 0,
+                    rawDescriptorLength = 0,
+                    message = "No USB Audio Class device was found.",
+                ),
+            )
+            return
+        }
+
+        if (!usbManager.hasPermission(device)) {
+            if (pendingExclusiveProbeResult != null) {
+                result.success(
+                    exclusiveProbeResult(
+                        supported = true,
+                        permissionGranted = false,
+                        device = device,
+                        audioInterfaceCount = device.audioInterfaceCount(),
+                        claimedInterfaceCount = 0,
+                        rawDescriptorLength = 0,
+                        message = "USB permission request is already pending.",
+                    ),
+                )
+                return
+            }
+
+            pendingExclusiveProbeResult = result
+            pendingExclusiveProbeDevice = device
+            val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                PendingIntent.FLAG_MUTABLE
+            } else {
+                0
+            }
+            val permissionIntent = PendingIntent.getBroadcast(
+                this,
+                0,
+                Intent(usbPermissionAction).setPackage(packageName),
+                flags,
+            )
+            usbManager.requestPermission(device, permissionIntent)
+            return
+        }
+
+        result.success(runExclusiveProbe(device))
+    }
+
+    private fun runExclusiveProbe(device: UsbDevice): Map<String, Any?> {
+        val usbManager = getSystemService(Context.USB_SERVICE) as UsbManager
+        val audioInterfaces = device.audioInterfaces()
+        val connection = usbManager.openDevice(device)
+            ?: return exclusiveProbeResult(
+                supported = true,
+                permissionGranted = true,
+                device = device,
+                audioInterfaceCount = audioInterfaces.size,
+                claimedInterfaceCount = 0,
+                rawDescriptorLength = 0,
+                message = "Failed to open USB device.",
+            )
+
+        return connection.useConnection {
+            val claimed = mutableListOf<UsbInterface>()
+            var rawDescriptorLength = 0
+            try {
+                rawDescriptorLength = connection.rawDescriptors?.size ?: 0
+                for (usbInterface in audioInterfaces) {
+                    if (connection.claimInterface(usbInterface, true)) {
+                        claimed.add(usbInterface)
+                    }
+                }
+                exclusiveProbeResult(
+                    supported = true,
+                    permissionGranted = true,
+                    device = device,
+                    audioInterfaceCount = audioInterfaces.size,
+                    claimedInterfaceCount = claimed.size,
+                    rawDescriptorLength = rawDescriptorLength,
+                    message = if (claimed.isNotEmpty()) {
+                        "USB Audio interface can be claimed."
+                    } else {
+                        "USB Audio interface was found but could not be claimed."
+                    },
+                )
+            } catch (error: RuntimeException) {
+                exclusiveProbeResult(
+                    supported = true,
+                    permissionGranted = true,
+                    device = device,
+                    audioInterfaceCount = audioInterfaces.size,
+                    claimedInterfaceCount = claimed.size,
+                    rawDescriptorLength = rawDescriptorLength,
+                    message = "USB exclusive probe failed: ${error.message}",
+                )
+            } finally {
+                claimed.forEach { connection.releaseInterface(it) }
+            }
+        }
+    }
+
+    private inline fun UsbDeviceConnection.useConnection(
+        block: () -> Map<String, Any?>,
+    ): Map<String, Any?> {
+        return try {
+            block()
+        } finally {
+            close()
+        }
+    }
+
+    private fun findUsbAudioDevice(usbManager: UsbManager): UsbDevice? {
+        return usbManager.deviceList.values.firstOrNull { it.audioInterfaceCount() > 0 }
+    }
+
+    private fun UsbDevice.audioInterfaces(): List<UsbInterface> {
+        val interfaces = mutableListOf<UsbInterface>()
+        for (index in 0 until interfaceCount) {
+            val usbInterface = getInterface(index)
+            if (usbInterface.interfaceClass == UsbConstants.USB_CLASS_AUDIO) {
+                interfaces.add(usbInterface)
+            }
+        }
+        return interfaces
+    }
+
+    private fun UsbDevice.audioInterfaceCount(): Int {
+        return audioInterfaces().size
+    }
+
+    private fun exclusiveProbeResult(
+        supported: Boolean,
+        permissionGranted: Boolean,
+        device: UsbDevice?,
+        audioInterfaceCount: Int,
+        claimedInterfaceCount: Int,
+        rawDescriptorLength: Int,
+        message: String,
+    ): Map<String, Any?> {
+        return mapOf(
+            "supported" to supported,
+            "permissionGranted" to permissionGranted,
+            "deviceName" to device?.productName,
+            "deviceId" to device?.deviceId,
+            "audioInterfaceCount" to audioInterfaceCount,
+            "claimedInterfaceCount" to claimedInterfaceCount,
+            "rawDescriptorLength" to rawDescriptorLength,
+            "message" to message,
+        )
     }
 
     private fun sendSuperLyric(call: MethodCall): Boolean {

--- a/android/app/src/main/kotlin/com/afalphy/particle_music/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/afalphy/particle_music/MainActivity.kt
@@ -42,6 +42,7 @@ class MainActivity : AudioServiceActivity() {
     private var pendingExclusiveProbeResult: MethodChannel.Result? = null
     private var pendingExclusiveProbeDevice: UsbDevice? = null
     private var usbPermissionReceiver: BroadcastReceiver? = null
+    private var lastExclusiveProbeResult: Map<String, Any?>? = null
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
@@ -80,6 +81,7 @@ class MainActivity : AudioServiceActivity() {
                 }
                 "stopExclusivePlayback" -> result.success(usbExclusiveAudioEngine.stop())
                 "releaseExclusiveDevice" -> result.success(usbExclusiveAudioEngine.release())
+                "getUsbDiagnosticsReport" -> collectUsbDiagnosticsReport(result)
                 else -> result.notImplemented()
             }
         }
@@ -214,7 +216,7 @@ class MainActivity : AudioServiceActivity() {
         val usbManager = getSystemService(Context.USB_SERVICE) as UsbManager
         val device = findUsbAudioDevice(usbManager)
         if (device == null) {
-            Log.i(tag, "probeExclusiveAccess: no USB Audio Class device found.")
+            UsbDiagnostics.i(tag, "probeExclusiveAccess: no USB Audio Class device found.")
             result.success(
                 exclusiveProbeResult(
                     supported = false,
@@ -230,7 +232,7 @@ class MainActivity : AudioServiceActivity() {
         }
 
         if (!usbManager.hasPermission(device)) {
-            Log.i(tag, "probeExclusiveAccess: requesting USB permission for ${device.debugLabel()}.")
+            UsbDiagnostics.i(tag, "probeExclusiveAccess: requesting USB permission for ${device.debugLabel()}.")
             if (pendingExclusiveProbeResult != null) {
                 result.success(
                     exclusiveProbeResult(
@@ -263,15 +265,14 @@ class MainActivity : AudioServiceActivity() {
             return
         }
 
-        Log.i(tag, "probeExclusiveAccess: permission already granted for ${device.debugLabel()}.")
+        UsbDiagnostics.i(tag, "probeExclusiveAccess: permission already granted for ${device.debugLabel()}.")
         result.success(runExclusiveProbe(device))
     }
 
     private fun runExclusiveProbe(device: UsbDevice): Map<String, Any?> {
         val usbManager = getSystemService(Context.USB_SERVICE) as UsbManager
         val audioInterfaces = device.audioInterfaces()
-        Log.i(
-            tag,
+        UsbDiagnostics.i(tag,
             "runExclusiveProbe: opening ${device.debugLabel()}, audioInterfaces=${audioInterfaces.size}.",
         )
         val connection = usbManager.openDevice(device)
@@ -284,7 +285,7 @@ class MainActivity : AudioServiceActivity() {
                 rawDescriptorLength = 0,
                 message = "Failed to open USB device.",
             )
-                .also { Log.w(tag, "runExclusiveProbe: openDevice failed for ${device.debugLabel()}.") }
+                .also { UsbDiagnostics.w(tag, "runExclusiveProbe: openDevice failed for ${device.debugLabel()}.") }
 
         return connection.useConnection {
             val claimed = mutableListOf<UsbInterface>()
@@ -294,14 +295,12 @@ class MainActivity : AudioServiceActivity() {
                 for (usbInterface in audioInterfaces) {
                     if (connection.claimInterface(usbInterface, true)) {
                         claimed.add(usbInterface)
-                        Log.i(
-                            tag,
+                        UsbDiagnostics.i(tag,
                             "runExclusiveProbe: claimInterface ok id=${usbInterface.id}, " +
                                 "class=${usbInterface.interfaceClass}, alt=${usbInterface.alternateSetting}.",
                         )
                     } else {
-                        Log.w(
-                            tag,
+                        UsbDiagnostics.w(tag,
                             "runExclusiveProbe: claimInterface failed id=${usbInterface.id}, " +
                                 "class=${usbInterface.interfaceClass}, alt=${usbInterface.alternateSetting}.",
                         )
@@ -348,13 +347,12 @@ class MainActivity : AudioServiceActivity() {
 
     private fun findUsbAudioDevice(usbManager: UsbManager): UsbDevice? {
         val devices = usbManager.deviceList.values.toList()
-        Log.i(
-            tag,
+        UsbDiagnostics.i(tag,
             "enumerating USB devices count=${devices.size}: " +
                 devices.joinToString { it.debugLabel() },
         )
         val device = devices.firstOrNull { it.audioInterfaceCount() > 0 }
-        Log.i(tag, "selected USB Audio device=${device?.debugLabel() ?: "none"}.")
+        UsbDiagnostics.i(tag, "selected USB Audio device=${device?.debugLabel() ?: "none"}.")
         return device
     }
 
@@ -365,15 +363,14 @@ class MainActivity : AudioServiceActivity() {
             usbManager,
             device,
         )
-        Log.i(tag, "getExclusiveCapabilities: $capabilities")
+        UsbDiagnostics.i(tag, "getExclusiveCapabilities: $capabilities")
         return capabilities
     }
 
     private fun startExclusivePlayback(call: MethodCall): Map<String, Any?> {
         val usbManager = getSystemService(Context.USB_SERVICE) as UsbManager
         val device = findUsbAudioDevice(usbManager)
-        Log.i(
-            tag,
+        UsbDiagnostics.i(tag,
             "startExclusivePlayback: device=${device?.debugLabel() ?: "none"}, " +
                 "arguments=${call.argumentsMap()}",
         )
@@ -387,6 +384,77 @@ class MainActivity : AudioServiceActivity() {
     private fun MethodCall.argumentsMap(): Map<String, Any?> {
         val raw = arguments as? Map<*, *> ?: return emptyMap()
         return raw.entries.associate { (key, value) -> key.toString() to value }
+    }
+
+    private fun collectUsbDiagnosticsReport(result: MethodChannel.Result) {
+        val mainHandler = Handler(Looper.getMainLooper())
+        Thread({
+            val report = try {
+                buildUsbDiagnosticsReport()
+            } catch (error: Throwable) {
+                UsbDiagnostics.w(tag, "collectUsbDiagnosticsReport failed.", error)
+                mapOf("error" to (error.message ?: error.toString()))
+            }
+            mainHandler.post { result.success(report) }
+        }, "SylvakruUsbDiag").start()
+    }
+
+    private fun buildUsbDiagnosticsReport(): Map<String, Any?> {
+        val usbManager = getSystemService(Context.USB_SERVICE) as UsbManager
+        val device = findUsbAudioDevice(usbManager)
+        return mapOf(
+            "generatedAtMs" to System.currentTimeMillis(),
+            "androidSdk" to Build.VERSION.SDK_INT,
+            "androidRelease" to Build.VERSION.RELEASE,
+            "manufacturer" to Build.MANUFACTURER,
+            "model" to Build.MODEL,
+            "permissionGranted" to (device?.let { usbManager.hasPermission(it) } ?: false),
+            "device" to device?.let { deviceIdentity(it) },
+            "diagnostics" to usbExclusiveAudioEngine.collectDiagnostics(usbManager, device),
+            "lastProbe" to lastExclusiveProbeResult,
+            "systemStatus" to getStatus(),
+            "nativeLogcat" to readNativeLogcat(),
+            "logs" to UsbDiagnostics.snapshot(),
+        )
+    }
+
+    private fun deviceIdentity(device: UsbDevice): Map<String, Any?> {
+        return mapOf(
+            "vendorId" to device.vendorId,
+            "productId" to device.productId,
+            "vendorIdHex" to String.format("0x%04x", device.vendorId),
+            "productIdHex" to String.format("0x%04x", device.productId),
+            "manufacturerName" to device.manufacturerName,
+            "productName" to device.productName,
+            "deviceClass" to device.deviceClass,
+            "deviceSubclass" to device.deviceSubclass,
+            "interfaceCount" to device.interfaceCount,
+            "audioInterfaceCount" to device.audioInterfaceCount(),
+            "serialTail" to maskedSerial(device),
+        )
+    }
+
+    private fun maskedSerial(device: UsbDevice): String? {
+        return try {
+            val serial = device.serialNumber ?: return null
+            if (serial.length <= 4) "****" else "****${serial.takeLast(4)}"
+        } catch (_: SecurityException) {
+            null
+        }
+    }
+
+    private fun readNativeLogcat(): List<String> {
+        return try {
+            val pid = android.os.Process.myPid()
+            val process = ProcessBuilder(
+                "logcat", "-d", "-v", "time", "--pid=$pid", "-s", "SylvakruUsbExclusive:*",
+            ).redirectErrorStream(true).start()
+            val lines = process.inputStream.bufferedReader().use { it.readLines() }
+            process.waitFor()
+            lines.takeLast(500)
+        } catch (error: Exception) {
+            listOf("native 日志不可用：${error.message}")
+        }
     }
 
     private fun UsbDevice.audioInterfaces(): List<UsbInterface> {
@@ -427,7 +495,7 @@ class MainActivity : AudioServiceActivity() {
             "claimedInterfaceCount" to claimedInterfaceCount,
             "rawDescriptorLength" to rawDescriptorLength,
             "message" to message,
-        )
+        ).also { lastExclusiveProbeResult = it }
     }
 
     private fun sendSuperLyric(call: MethodCall): Boolean {
@@ -602,7 +670,7 @@ class MainActivity : AudioServiceActivity() {
         val bitPerfect = call.argument<Boolean>("bitPerfect") ?: true
 
         return try {
-            Log.i(tag, "applyPreferredOutputApi34: requesting sampleRate=$sampleRate, encoding=$encoding.")
+            UsbDiagnostics.i(tag, "applyPreferredOutputApi34: requesting sampleRate=$sampleRate, encoding=$encoding.")
             val format = AudioFormat.Builder()
                 .setSampleRate(sampleRate)
                 .setEncoding(encoding)

--- a/android/app/src/main/kotlin/com/afalphy/particle_music/UsbDiagnostics.kt
+++ b/android/app/src/main/kotlin/com/afalphy/particle_music/UsbDiagnostics.kt
@@ -1,0 +1,63 @@
+package com.afalphy.sylvakru
+
+import android.util.Log
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * USB 独占链路的进程内诊断日志缓冲。
+ *
+ * 所有 USB 相关的 [Log] 调用都改为经由这里转发：既保持 logcat 行为不变，
+ * 又把最近 [MAX_ENTRIES] 条日志留在环形缓冲里，供“生成诊断报告”功能读取。
+ * 普通用户拿不到 logcat，这个缓冲是他们能带走的第一手排查数据。
+ */
+object UsbDiagnostics {
+    private const val MAX_ENTRIES = 500
+
+    private val lock = Any()
+    private val entries = ArrayDeque<String>()
+    private val timeFormat = SimpleDateFormat("HH:mm:ss.SSS", Locale.US)
+
+    fun i(tag: String, message: String) {
+        Log.i(tag, message)
+        record("I", tag, message)
+    }
+
+    fun w(tag: String, message: String) {
+        Log.w(tag, message)
+        record("W", tag, message)
+    }
+
+    fun w(tag: String, message: String, throwable: Throwable) {
+        Log.w(tag, message, throwable)
+        record("W", tag, "$message ${throwable.javaClass.simpleName}: ${throwable.message}")
+    }
+
+    fun d(tag: String, message: String) {
+        Log.d(tag, message)
+        record("D", tag, message)
+    }
+
+    fun e(tag: String, message: String) {
+        Log.e(tag, message)
+        record("E", tag, message)
+    }
+
+    /** 返回环形缓冲内最近的日志快照（时间升序），供诊断报告拼装。 */
+    fun snapshot(): List<String> {
+        synchronized(lock) {
+            return entries.toList()
+        }
+    }
+
+    private fun record(level: String, tag: String, message: String) {
+        val line = "${timeFormat.format(Date())} $level/$tag: $message"
+        synchronized(lock) {
+            entries.addLast(line)
+            while (entries.size > MAX_ENTRIES) {
+                entries.removeFirst()
+            }
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/afalphy/particle_music/UsbExclusiveAudioEngine.kt
+++ b/android/app/src/main/kotlin/com/afalphy/particle_music/UsbExclusiveAudioEngine.kt
@@ -46,6 +46,8 @@ object UsbExclusiveNative {
 
     external fun transportTelemetry(): LongArray
 
+    external fun setMaxPendingOutputUrbs(maxPendingUrbs: Int)
+
     external fun close()
 }
 
@@ -73,6 +75,7 @@ class UsbExclusiveAudioEngine(
     private var lastTelemetryEmitMs = 0L
     private var lastTelemetryBufferMs: Long? = null
     private var zeroBufferUnderruns = 0L
+    private var activePacketsPerSecond = 0
 
     fun capabilities(usbManager: UsbManager, device: UsbDevice?): Map<String, Any?> {
         if (!NATIVE_USB_EXCLUSIVE_STREAMING_ENABLED) {
@@ -156,6 +159,7 @@ class UsbExclusiveAudioEngine(
         lastTelemetryEmitMs = 0L
         lastTelemetryBufferMs = null
         zeroBufferUnderruns = 0L
+        activePacketsPerSecond = 0
         val requestedChannels = 2
         val openedConnection = usbManager.openDevice(device)
             ?: return updateState(inactiveState("Failed to open USB device for exclusive playback."))
@@ -260,6 +264,15 @@ class UsbExclusiveAudioEngine(
         )
     }
 
+    fun setTargetBufferMs(value: Int): Map<String, Any?> {
+        targetBufferMs = value.coerceIn(50, 5000)
+        applyNativeTargetBuffer(activePacketsPerSecond)
+        if (activePacketsPerSecond > 0) {
+            emitTransportTelemetry(activePacketsPerSecond, force = true)
+        }
+        return currentState + mapOf("targetBufferMs" to targetBufferMs)
+    }
+
     fun stop(): Map<String, Any?> {
         stopped.set(true)
         paused.set(false)
@@ -272,6 +285,7 @@ class UsbExclusiveAudioEngine(
         UsbExclusiveNative.close()
         connection?.close()
         connection = null
+        activePacketsPerSecond = 0
         return updateState(inactiveState("USB exclusive playback stopped."))
     }
 
@@ -332,6 +346,20 @@ class UsbExclusiveAudioEngine(
                 "underrunCount" to 0,
                 "updatedAtMs" to SystemClock.elapsedRealtime(),
             ),
+        )
+    }
+
+    private fun applyNativeTargetBuffer(packetsPerSecond: Int) {
+        if (packetsPerSecond <= 0) {
+            return
+        }
+        val packetCount = ((targetBufferMs.toLong() * packetsPerSecond) + 999L) / 1000L
+        val maxPendingUrbs = ((packetCount + 15L) / 16L).coerceIn(8L, 512L).toInt()
+        UsbExclusiveNative.setMaxPendingOutputUrbs(maxPendingUrbs)
+        Log.i(
+            tag,
+            "USB target buffer targetMs=$targetBufferMs packetsPerSecond=$packetsPerSecond " +
+                "maxPendingUrbs=$maxPendingUrbs",
         )
     }
 
@@ -730,6 +758,8 @@ class UsbExclusiveAudioEngine(
             channels,
             usbBytesPerSample,
         )
+        activePacketsPerSecond = target.packetsPerSecond
+        applyNativeTargetBuffer(target.packetsPerSecond)
         UsbExclusiveNative.setIsoPacketSize(packetBytes)
         val outputIntervalMicroframes = isoIntervalMicroframes(target.endpoint.interval)
         val feedbackOutputPacketDivisor = target.feedbackEndpoint?.let {

--- a/android/app/src/main/kotlin/com/afalphy/particle_music/UsbExclusiveAudioEngine.kt
+++ b/android/app/src/main/kotlin/com/afalphy/particle_music/UsbExclusiveAudioEngine.kt
@@ -1,0 +1,459 @@
+package com.afalphy.sylvakru
+
+import android.content.Context
+import android.hardware.usb.UsbConstants
+import android.hardware.usb.UsbDevice
+import android.hardware.usb.UsbDeviceConnection
+import android.hardware.usb.UsbEndpoint
+import android.hardware.usb.UsbInterface
+import android.hardware.usb.UsbManager
+import android.media.MediaCodec
+import android.media.MediaExtractor
+import android.media.MediaFormat
+import android.os.Build
+import android.os.SystemClock
+import android.util.Log
+import java.io.File
+import java.nio.ByteBuffer
+import java.util.Locale
+import java.util.concurrent.atomic.AtomicBoolean
+
+object UsbExclusiveNative {
+    init {
+        System.loadLibrary("sylvakru_usb_exclusive")
+    }
+
+    external fun open(
+        fd: Int,
+        interfaceNumber: Int,
+        alternateSetting: Int,
+        endpointAddress: Int,
+        maxPacketSize: Int,
+    ): String?
+
+    external fun writePcm(bytes: ByteArray, length: Int): String?
+
+    external fun close()
+}
+
+class UsbExclusiveAudioEngine(
+    private val context: Context,
+    private val emitState: (Map<String, Any?>) -> Unit,
+) {
+    private var worker: Thread? = null
+    private var connection: UsbDeviceConnection? = null
+    private val paused = AtomicBoolean(false)
+    private val stopped = AtomicBoolean(false)
+
+    @Volatile private var currentState = inactiveState()
+
+    fun capabilities(usbManager: UsbManager, device: UsbDevice?): Map<String, Any?> {
+        if (device == null) {
+            return capability(
+                available = false,
+                permissionGranted = false,
+                device = null,
+                target = null,
+                message = "No USB Audio Class output endpoint was found.",
+            )
+        }
+
+        val target = findOutputTarget(device)
+        return capability(
+            available = target != null,
+            permissionGranted = usbManager.hasPermission(device),
+            device = device,
+            target = target,
+            message = if (target != null) {
+                "USB exclusive endpoint is available."
+            } else {
+                "USB Audio device was found, but no isochronous OUT endpoint was exposed."
+            },
+        )
+    }
+
+    fun start(
+        usbManager: UsbManager,
+        device: UsbDevice?,
+        arguments: Map<String, Any?>,
+    ): Map<String, Any?> {
+        stop()
+
+        if (device == null) {
+            return updateState(inactiveState("No USB Audio Class device was found."))
+        }
+        if (!usbManager.hasPermission(device)) {
+            return updateState(inactiveState("USB permission is required before exclusive playback."))
+        }
+
+        val filePath = arguments["filePath"] as? String
+        if (filePath.isNullOrBlank()) {
+            return updateState(inactiveState("Exclusive playback requires a local audio file path."))
+        }
+
+        val file = File(filePath)
+        if (!file.exists()) {
+            return updateState(inactiveState("Exclusive playback file does not exist: $filePath"))
+        }
+        if (!isSupportedFile(filePath)) {
+            return updateState(inactiveState("Exclusive playback currently supports FLAC and WAV only."))
+        }
+
+        val target = findOutputTarget(device)
+            ?: return updateState(inactiveState("No isochronous USB Audio OUT endpoint was found."))
+        val openedConnection = usbManager.openDevice(device)
+            ?: return updateState(inactiveState("Failed to open USB device for exclusive playback."))
+
+        val openError = UsbExclusiveNative.open(
+            openedConnection.fileDescriptor,
+            target.usbInterface.id,
+            target.alternateSetting,
+            target.endpoint.address,
+            target.endpoint.maxPacketSize,
+        )
+        if (openError != null) {
+            openedConnection.close()
+            return updateState(inactiveState(openError))
+        }
+
+        connection = openedConnection
+        paused.set(arguments["startPaused"] == true)
+        stopped.set(false)
+
+        val initialState = mapOf(
+            "active" to true,
+            "playing" to !paused.get(),
+            "positionMs" to 0,
+            "durationMs" to null,
+            "sampleRate" to arguments["sampleRate"],
+            "bitDepth" to arguments["bitDepth"],
+            "format" to file.extension.lowercase(Locale.ROOT),
+            "message" to "USB exclusive playback prepared.",
+        )
+        updateState(initialState)
+
+        worker = Thread({
+            decodeAndWrite(file, target)
+        }, "SylvakruUsbExclusive")
+        worker?.start()
+        return currentState
+    }
+
+    fun pause(): Map<String, Any?> {
+        paused.set(true)
+        return updateState(currentState + mapOf("playing" to false, "message" to "Paused."))
+    }
+
+    fun resume(): Map<String, Any?> {
+        if (currentState["active"] != true) {
+            return updateState(inactiveState("No exclusive playback is active."))
+        }
+        paused.set(false)
+        return updateState(currentState + mapOf("playing" to true, "message" to "Playing."))
+    }
+
+    fun seek(positionMs: Long): Map<String, Any?> {
+        return updateState(
+            currentState + mapOf(
+                "message" to "USB exclusive seek is not supported in this MVP.",
+                "positionMs" to positionMs,
+            ),
+        )
+    }
+
+    fun stop(): Map<String, Any?> {
+        stopped.set(true)
+        paused.set(false)
+        val thread = worker
+        worker = null
+        if (thread != null && thread != Thread.currentThread()) {
+            thread.join(500)
+        }
+        UsbExclusiveNative.close()
+        connection?.close()
+        connection = null
+        return updateState(inactiveState("USB exclusive playback stopped."))
+    }
+
+    fun release(): Map<String, Any?> = stop()
+
+    private fun decodeAndWrite(file: File, target: OutputTarget) {
+        val extractor = MediaExtractor()
+        var codec: MediaCodec? = null
+        var sawInputEos = false
+        var outputDone = false
+        val info = MediaCodec.BufferInfo()
+        val startMs = SystemClock.elapsedRealtime()
+        var lastPositionEmitMs = 0L
+
+        try {
+            extractor.setDataSource(file.absolutePath)
+            val trackIndex = findAudioTrack(extractor)
+            if (trackIndex < 0) {
+                emitError("No audio track was found in ${file.name}.")
+                return
+            }
+
+            extractor.selectTrack(trackIndex)
+            val format = extractor.getTrackFormat(trackIndex)
+            val mime = format.getString(MediaFormat.KEY_MIME)
+            if (mime.isNullOrBlank()) {
+                emitError("Audio MIME type is missing.")
+                return
+            }
+
+            codec = MediaCodec.createDecoderByType(mime)
+            codec.configure(format, null, null, 0)
+            codec.start()
+
+            val durationMs = if (format.containsKey(MediaFormat.KEY_DURATION)) {
+                format.getLong(MediaFormat.KEY_DURATION) / 1000
+            } else {
+                null
+            }
+            val sampleRate = if (format.containsKey(MediaFormat.KEY_SAMPLE_RATE)) {
+                format.getInteger(MediaFormat.KEY_SAMPLE_RATE)
+            } else {
+                null
+            }
+            val channels = if (format.containsKey(MediaFormat.KEY_CHANNEL_COUNT)) {
+                format.getInteger(MediaFormat.KEY_CHANNEL_COUNT)
+            } else {
+                null
+            }
+
+            updateState(
+                currentState + mapOf(
+                    "active" to true,
+                    "playing" to !paused.get(),
+                    "durationMs" to durationMs,
+                    "sampleRate" to sampleRate,
+                    "bitDepth" to 16,
+                    "message" to "USB exclusive decoding ${file.name} to ${target.endpointLabel}, channels=$channels.",
+                ),
+            )
+
+            while (!stopped.get() && !outputDone) {
+                while (paused.get() && !stopped.get()) {
+                    Thread.sleep(25)
+                }
+                if (stopped.get()) break
+
+                if (!sawInputEos) {
+                    val inputIndex = codec.dequeueInputBuffer(10_000)
+                    if (inputIndex >= 0) {
+                        val inputBuffer = codec.getInputBuffer(inputIndex)
+                        val sampleSize = if (inputBuffer != null) {
+                            extractor.readSampleData(inputBuffer, 0)
+                        } else {
+                            -1
+                        }
+                        if (sampleSize < 0) {
+                            codec.queueInputBuffer(
+                                inputIndex,
+                                0,
+                                0,
+                                0,
+                                MediaCodec.BUFFER_FLAG_END_OF_STREAM,
+                            )
+                            sawInputEos = true
+                        } else {
+                            codec.queueInputBuffer(
+                                inputIndex,
+                                0,
+                                sampleSize,
+                                extractor.sampleTime,
+                                0,
+                            )
+                            extractor.advance()
+                        }
+                    }
+                }
+
+                val outputIndex = codec.dequeueOutputBuffer(info, 10_000)
+                if (outputIndex >= 0) {
+                    val outputBuffer = codec.getOutputBuffer(outputIndex)
+                    if (outputBuffer != null && info.size > 0) {
+                        writeOutputBuffer(outputBuffer, info)
+                    }
+                    if ((info.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
+                        outputDone = true
+                    }
+                    codec.releaseOutputBuffer(outputIndex, false)
+
+                    val positionMs = if (info.presentationTimeUs > 0) {
+                        info.presentationTimeUs / 1000
+                    } else {
+                        SystemClock.elapsedRealtime() - startMs
+                    }
+                    if (positionMs - lastPositionEmitMs >= 250) {
+                        lastPositionEmitMs = positionMs
+                        updateState(
+                            currentState + mapOf(
+                                "active" to true,
+                                "playing" to !paused.get(),
+                                "positionMs" to positionMs,
+                            ),
+                        )
+                    }
+                } else if (outputIndex == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED) {
+                    val outputFormat = codec.outputFormat
+                    val outputSampleRate = if (outputFormat.containsKey(MediaFormat.KEY_SAMPLE_RATE)) {
+                        outputFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE)
+                    } else {
+                        null
+                    }
+                    val pcmEncoding = if (
+                        Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
+                        outputFormat.containsKey(MediaFormat.KEY_PCM_ENCODING)
+                    ) {
+                        outputFormat.getInteger(MediaFormat.KEY_PCM_ENCODING)
+                    } else {
+                        null
+                    }
+                    updateState(
+                        currentState + mapOf(
+                            "sampleRate" to outputSampleRate,
+                            "bitDepth" to bitDepthFromPcmEncoding(pcmEncoding),
+                        ),
+                    )
+                }
+            }
+
+            if (!stopped.get()) {
+                updateState(inactiveState("USB exclusive playback completed."))
+            }
+        } catch (error: Throwable) {
+            Log.w("UsbExclusiveAudioEngine", "Exclusive playback failed.", error)
+            emitError(error.message ?: "USB exclusive playback failed.")
+        } finally {
+            try {
+                codec?.stop()
+            } catch (_: Throwable) {
+            }
+            codec?.release()
+            extractor.release()
+            UsbExclusiveNative.close()
+            connection?.close()
+            connection = null
+        }
+    }
+
+    private fun writeOutputBuffer(outputBuffer: ByteBuffer, info: MediaCodec.BufferInfo) {
+        val data = ByteArray(info.size)
+        outputBuffer.position(info.offset)
+        outputBuffer.limit(info.offset + info.size)
+        outputBuffer.get(data)
+        val error = UsbExclusiveNative.writePcm(data, data.size)
+        if (error != null) {
+            throw IllegalStateException(error)
+        }
+    }
+
+    private fun findAudioTrack(extractor: MediaExtractor): Int {
+        for (index in 0 until extractor.trackCount) {
+            val format = extractor.getTrackFormat(index)
+            val mime = format.getString(MediaFormat.KEY_MIME)
+            if (mime?.startsWith("audio/") == true) {
+                return index
+            }
+        }
+        return -1
+    }
+
+    private fun findOutputTarget(device: UsbDevice): OutputTarget? {
+        for (index in 0 until device.interfaceCount) {
+            val usbInterface = device.getInterface(index)
+            if (usbInterface.interfaceClass != UsbConstants.USB_CLASS_AUDIO) {
+                continue
+            }
+            for (endpointIndex in 0 until usbInterface.endpointCount) {
+                val endpoint = usbInterface.getEndpoint(endpointIndex)
+                if (
+                    endpoint.direction == UsbConstants.USB_DIR_OUT &&
+                    endpoint.type == UsbConstants.USB_ENDPOINT_XFER_ISOC
+                ) {
+                    return OutputTarget(usbInterface, endpoint)
+                }
+            }
+        }
+        return null
+    }
+
+    private fun isSupportedFile(filePath: String): Boolean {
+        val lower = filePath.lowercase(Locale.ROOT)
+        return lower.endsWith(".flac") || lower.endsWith(".wav") || lower.endsWith(".wave")
+    }
+
+    private fun capability(
+        available: Boolean,
+        permissionGranted: Boolean,
+        device: UsbDevice?,
+        target: OutputTarget?,
+        message: String,
+    ): Map<String, Any?> {
+        return mapOf(
+            "available" to available,
+            "permissionGranted" to permissionGranted,
+            "deviceName" to device?.productName,
+            "deviceId" to device?.deviceId,
+            "interfaceNumber" to target?.usbInterface?.id,
+            "alternateSetting" to target?.alternateSetting,
+            "endpointAddress" to target?.endpoint?.address,
+            "maxPacketSize" to target?.endpoint?.maxPacketSize,
+            "sampleRates" to listOf(44100, 48000, 88200, 96000, 176400, 192000),
+            "bitDepths" to listOf(16, 24, 32),
+            "channelCounts" to listOf(2),
+            "message" to message,
+        )
+    }
+
+    private fun emitError(message: String) {
+        updateState(inactiveState(message))
+    }
+
+    private fun updateState(state: Map<String, Any?>): Map<String, Any?> {
+        currentState = state
+        emitState(state)
+        return state
+    }
+
+    private fun inactiveState(message: String? = null): Map<String, Any?> {
+        return mapOf(
+            "active" to false,
+            "playing" to false,
+            "positionMs" to 0,
+            "durationMs" to null,
+            "sampleRate" to null,
+            "bitDepth" to null,
+            "format" to null,
+            "message" to message,
+        )
+    }
+
+    private fun bitDepthFromPcmEncoding(pcmEncoding: Int?): Int {
+        return when (pcmEncoding) {
+            3 -> 8
+            4 -> 32
+            0x80000000.toInt() -> 24
+            else -> 16
+        }
+    }
+
+    private data class OutputTarget(
+        val usbInterface: UsbInterface,
+        val endpoint: UsbEndpoint,
+    ) {
+        val alternateSetting: Int
+            get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                usbInterface.alternateSetting
+            } else {
+                0
+            }
+
+        val endpointLabel: String
+            get() = "interface=${usbInterface.id}, alt=$alternateSetting, endpoint=0x${
+                endpoint.address.toString(16)
+            }"
+    }
+}

--- a/android/app/src/main/kotlin/com/afalphy/particle_music/UsbExclusiveAudioEngine.kt
+++ b/android/app/src/main/kotlin/com/afalphy/particle_music/UsbExclusiveAudioEngine.kt
@@ -18,6 +18,7 @@ import java.io.File
 import java.nio.ByteBuffer
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
 
 object UsbExclusiveNative {
     init {
@@ -43,6 +44,8 @@ object UsbExclusiveNative {
 
     external fun feedbackFramesPerPacketQ16(): Int
 
+    external fun transportTelemetry(): LongArray
+
     external fun close()
 }
 
@@ -55,14 +58,21 @@ private const val USB_RECIP_ENDPOINT = 0x02
 class UsbExclusiveAudioEngine(
     private val context: Context,
     private val emitState: (Map<String, Any?>) -> Unit,
+    private val emitTelemetry: (Map<String, Any?>) -> Unit,
 ) {
     private val tag = "UsbExclusiveAudioEngine"
     private var worker: Thread? = null
     private var connection: UsbDeviceConnection? = null
     private val paused = AtomicBoolean(false)
     private val stopped = AtomicBoolean(false)
+    private val pendingSeekMs = AtomicLong(-1L)
 
     @Volatile private var currentState = inactiveState()
+    private var targetBufferMs = 200
+    private var minimumBufferLevelMs: Long? = null
+    private var lastTelemetryEmitMs = 0L
+    private var lastTelemetryBufferMs: Long? = null
+    private var zeroBufferUnderruns = 0L
 
     fun capabilities(usbManager: UsbManager, device: UsbDevice?): Map<String, Any?> {
         if (!NATIVE_USB_EXCLUSIVE_STREAMING_ENABLED) {
@@ -141,6 +151,11 @@ class UsbExclusiveAudioEngine(
 
         val requestedSampleRate = (arguments["sampleRate"] as? Number)?.toInt()
         val requestedBitDepth = (arguments["bitDepth"] as? Number)?.toInt()
+        targetBufferMs = ((arguments["targetBufferMs"] as? Number)?.toInt() ?: 200).coerceIn(50, 5000)
+        minimumBufferLevelMs = null
+        lastTelemetryEmitMs = 0L
+        lastTelemetryBufferMs = null
+        zeroBufferUnderruns = 0L
         val requestedChannels = 2
         val openedConnection = usbManager.openDevice(device)
             ?: return updateState(inactiveState("Failed to open USB device for exclusive playback."))
@@ -189,6 +204,7 @@ class UsbExclusiveAudioEngine(
         connection = openedConnection
         paused.set(arguments["startPaused"] == true)
         stopped.set(false)
+        pendingSeekMs.set(-1L)
 
         val initialState = mapOf(
             "active" to true,
@@ -201,6 +217,7 @@ class UsbExclusiveAudioEngine(
             "message" to "USB exclusive playback prepared.",
         )
         updateState(initialState)
+        emitTransportTelemetry(target.packetsPerSecond, force = true)
 
         worker = Thread({
             decodeAndWrite(file, target)
@@ -229,10 +246,16 @@ class UsbExclusiveAudioEngine(
     }
 
     fun seek(positionMs: Long): Map<String, Any?> {
+        if (currentState["active"] != true) {
+            Log.w(tag, "seek ignored because exclusive playback is not active: $currentState")
+            return updateState(inactiveState("No exclusive playback is active."))
+        }
+        val safePositionMs = positionMs.coerceAtLeast(0L)
+        pendingSeekMs.set(safePositionMs)
         return updateState(
             currentState + mapOf(
-                "message" to "USB exclusive seek is not supported in this MVP.",
-                "positionMs" to positionMs,
+                "message" to "Seeking.",
+                "positionMs" to safePositionMs,
             ),
         )
     }
@@ -240,6 +263,7 @@ class UsbExclusiveAudioEngine(
     fun stop(): Map<String, Any?> {
         stopped.set(true)
         paused.set(false)
+        pendingSeekMs.set(-1L)
         val thread = worker
         worker = null
         if (thread != null && thread != Thread.currentThread()) {
@@ -252,6 +276,64 @@ class UsbExclusiveAudioEngine(
     }
 
     fun release(): Map<String, Any?> = stop()
+
+    private fun emitTransportTelemetry(packetsPerSecond: Int, force: Boolean = false) {
+        val nowMs = SystemClock.elapsedRealtime()
+        if (!force && nowMs - lastTelemetryEmitMs < 100) {
+            return
+        }
+        lastTelemetryEmitMs = nowMs
+
+        val nativeTelemetry = UsbExclusiveNative.transportTelemetry()
+        val pendingIsoPackets = nativeTelemetry.getOrNull(0) ?: 0L
+        val totalIsoPackets = nativeTelemetry.getOrNull(1) ?: 0L
+        val pendingUrbs = nativeTelemetry.getOrNull(2) ?: 0L
+        val nativeIsoErrors = nativeTelemetry.getOrNull(3) ?: 0L
+        val bufferLevelMs = if (packetsPerSecond > 0) {
+            (pendingIsoPackets * 1000L) / packetsPerSecond
+        } else {
+            0L
+        }
+        val active = currentState["active"] == true
+
+        if (active && lastTelemetryBufferMs != null && lastTelemetryBufferMs!! > 0 && bufferLevelMs == 0L) {
+            zeroBufferUnderruns += 1
+        }
+        lastTelemetryBufferMs = bufferLevelMs
+
+        if (active && bufferLevelMs > 0) {
+            minimumBufferLevelMs = minimumBufferLevelMs?.let { minOf(it, bufferLevelMs) } ?: bufferLevelMs
+        }
+
+        emitTelemetry(
+            mapOf(
+                "active" to active,
+                "bufferLevelMs" to if (active) bufferLevelMs else 0L,
+                "minimumBufferLevelMs" to minimumBufferLevelMs,
+                "targetBufferMs" to targetBufferMs,
+                "isoPacketCount" to totalIsoPackets,
+                "pendingUrbs" to pendingUrbs,
+                "underrunCount" to (nativeIsoErrors + zeroBufferUnderruns),
+                "updatedAtMs" to nowMs,
+            ),
+        )
+    }
+
+    private fun emitInactiveTelemetry() {
+        lastTelemetryBufferMs = null
+        emitTelemetry(
+            mapOf(
+                "active" to false,
+                "bufferLevelMs" to 0,
+                "minimumBufferLevelMs" to null,
+                "targetBufferMs" to targetBufferMs,
+                "isoPacketCount" to 0,
+                "pendingUrbs" to 0,
+                "underrunCount" to 0,
+                "updatedAtMs" to SystemClock.elapsedRealtime(),
+            ),
+        )
+    }
 
     private fun decodeAndWrite(file: File, target: OutputTarget) {
         val extractor = MediaExtractor()
@@ -337,6 +419,25 @@ class UsbExclusiveAudioEngine(
                     Log.i(tag, "exclusive worker resumed.")
                 }
                 if (stopped.get()) break
+
+                consumePendingSeekMs()?.let { seekMs ->
+                    val seekUs = seekMs * 1000
+                    Log.i(tag, "exclusive decoder seek to ${seekMs}ms.")
+                    extractor.seekTo(seekUs, MediaExtractor.SEEK_TO_CLOSEST_SYNC)
+                    codec.flush()
+                    packetizer?.reset()
+                    sawInputEos = false
+                    outputDone = false
+                    lastPositionEmitMs = -1L
+                    updateState(
+                        currentState + mapOf(
+                            "active" to true,
+                            "playing" to !paused.get(),
+                            "positionMs" to seekMs,
+                            "message" to "Seeked.",
+                        ),
+                    )
+                }
 
                 if (!sawInputEos) {
                     val inputIndex = codec.dequeueInputBuffer(10_000)
@@ -540,6 +641,23 @@ class UsbExclusiveAudioEngine(
             }
             if (stopped.get()) break
 
+            consumePendingSeekMs()?.let { seekMs ->
+                val seekUs = seekMs * 1000
+                Log.i(tag, "exclusive raw PCM seek to ${seekMs}ms.")
+                extractor.seekTo(seekUs, MediaExtractor.SEEK_TO_CLOSEST_SYNC)
+                packetizer.reset()
+                lastPositionEmitMs = -1L
+                lastSampleTimeUs = null
+                updateState(
+                    currentState + mapOf(
+                        "active" to true,
+                        "playing" to !paused.get(),
+                        "positionMs" to seekMs,
+                        "message" to "Seeked.",
+                    ),
+                )
+            }
+
             buffer.clear()
             val sampleTimeUs = extractor.sampleTime
             val sampleSize = extractor.readSampleData(buffer, 0)
@@ -645,6 +763,7 @@ class UsbExclusiveAudioEngine(
             if (error != null) {
                 throw IllegalStateException(error)
             }
+            emitTransportTelemetry(target.packetsPerSecond)
         }
     }
 
@@ -1160,9 +1279,17 @@ class UsbExclusiveAudioEngine(
         updateState(inactiveState(message))
     }
 
+    private fun consumePendingSeekMs(): Long? {
+        val seekMs = pendingSeekMs.getAndSet(-1L)
+        return if (seekMs >= 0L) seekMs else null
+    }
+
     private fun updateState(state: Map<String, Any?>): Map<String, Any?> {
         currentState = state
         emitState(state)
+        if (state["active"] != true) {
+            emitInactiveTelemetry()
+        }
         return state
     }
 
@@ -1285,6 +1412,18 @@ class UsbExclusiveAudioEngine(
 
         fun flush() {
             drain(fullPacketsOnly = false)
+        }
+
+        fun reset() {
+            pending.reset()
+            transfer.reset()
+            transferPacketCount = 0
+            sampleRemainder = 0
+            feedbackRemainderQ16 = 0L
+            packetLogCount = 0
+            feedbackRejectLogCount = 0
+            pcmPreviewLogged = false
+            pcmPreviewAttempts = 0
         }
 
         private fun drain(fullPacketsOnly: Boolean) {

--- a/android/app/src/main/kotlin/com/afalphy/particle_music/UsbExclusiveAudioEngine.kt
+++ b/android/app/src/main/kotlin/com/afalphy/particle_music/UsbExclusiveAudioEngine.kt
@@ -13,6 +13,7 @@ import android.media.MediaFormat
 import android.os.Build
 import android.os.SystemClock
 import android.util.Log
+import java.io.ByteArrayOutputStream
 import java.io.File
 import java.nio.ByteBuffer
 import java.util.Locale
@@ -29,17 +30,33 @@ object UsbExclusiveNative {
         alternateSetting: Int,
         endpointAddress: Int,
         maxPacketSize: Int,
+        feedbackEndpointAddress: Int,
+        feedbackMaxPacketSize: Int,
+        interfaceAlreadyClaimed: Boolean,
     ): String?
 
     external fun writePcm(bytes: ByteArray, length: Int): String?
 
+    external fun writeIsoPackets(bytes: ByteArray, packetLengths: IntArray, packetCount: Int): String?
+
+    external fun setIsoPacketSize(packetSize: Int)
+
+    external fun feedbackFramesPerPacketQ16(): Int
+
     external fun close()
 }
+
+private const val NATIVE_USB_EXCLUSIVE_STREAMING_ENABLED = true
+private const val NATIVE_USB_EXCLUSIVE_DISABLED_MESSAGE =
+    "真独占 USB 流式输出暂未启用，已回退到系统 USB 输出。"
+private const val USB_RECIP_INTERFACE = 0x01
+private const val USB_RECIP_ENDPOINT = 0x02
 
 class UsbExclusiveAudioEngine(
     private val context: Context,
     private val emitState: (Map<String, Any?>) -> Unit,
 ) {
+    private val tag = "UsbExclusiveAudioEngine"
     private var worker: Thread? = null
     private var connection: UsbDeviceConnection? = null
     private val paused = AtomicBoolean(false)
@@ -48,6 +65,16 @@ class UsbExclusiveAudioEngine(
     @Volatile private var currentState = inactiveState()
 
     fun capabilities(usbManager: UsbManager, device: UsbDevice?): Map<String, Any?> {
+        if (!NATIVE_USB_EXCLUSIVE_STREAMING_ENABLED) {
+            return capability(
+                available = false,
+                permissionGranted = device?.let { usbManager.hasPermission(it) } ?: false,
+                device = device,
+                target = null,
+                message = NATIVE_USB_EXCLUSIVE_DISABLED_MESSAGE,
+            )
+        }
+
         if (device == null) {
             return capability(
                 available = false,
@@ -79,6 +106,10 @@ class UsbExclusiveAudioEngine(
     ): Map<String, Any?> {
         stop()
 
+        if (!NATIVE_USB_EXCLUSIVE_STREAMING_ENABLED) {
+            return updateState(inactiveState(NATIVE_USB_EXCLUSIVE_DISABLED_MESSAGE))
+        }
+
         if (device == null) {
             return updateState(inactiveState("No USB Audio Class device was found."))
         }
@@ -87,6 +118,10 @@ class UsbExclusiveAudioEngine(
         }
 
         val filePath = arguments["filePath"] as? String
+        val sourceFormat = (arguments["sourceFormat"] as? String)
+            ?.lowercase(Locale.ROOT)
+            ?.trim()
+            ?.takeIf { it.isNotEmpty() }
         if (filePath.isNullOrBlank()) {
             return updateState(inactiveState("Exclusive playback requires a local audio file path."))
         }
@@ -95,14 +130,41 @@ class UsbExclusiveAudioEngine(
         if (!file.exists()) {
             return updateState(inactiveState("Exclusive playback file does not exist: $filePath"))
         }
-        if (!isSupportedFile(filePath)) {
+        Log.i(
+            tag,
+            "start exclusive playback file=${file.name}, sourceFormat=$sourceFormat, size=${file.length()}",
+        )
+
+        if (!isSupportedFile(filePath, sourceFormat)) {
             return updateState(inactiveState("Exclusive playback currently supports FLAC and WAV only."))
         }
 
-        val target = findOutputTarget(device)
-            ?: return updateState(inactiveState("No isochronous USB Audio OUT endpoint was found."))
+        val requestedSampleRate = (arguments["sampleRate"] as? Number)?.toInt()
+        val requestedBitDepth = (arguments["bitDepth"] as? Number)?.toInt()
+        val requestedChannels = 2
         val openedConnection = usbManager.openDevice(device)
             ?: return updateState(inactiveState("Failed to open USB device for exclusive playback."))
+        val descriptors = openedConnection.rawDescriptors
+        val streamingFormats = parseStreamingFormatInfo(descriptors)
+        val target = findOutputTarget(
+            device,
+            streamingFormats = streamingFormats,
+            sampleRate = requestedSampleRate,
+            channels = requestedChannels,
+            bitDepth = requestedBitDepth,
+        )
+            ?: run {
+                openedConnection.close()
+                return updateState(inactiveState("No isochronous USB Audio OUT endpoint was found."))
+            }
+        Log.i(
+            tag,
+            "exclusive target interface=${target.usbInterface.id}, alt=${target.alternateSetting}, " +
+                "endpoint=0x${target.endpoint.address.toString(16)}, maxPacket=${target.endpoint.maxPacketSize}, " +
+                "feedback=${target.feedbackEndpointLabel}, " +
+                "requestedSampleRate=$requestedSampleRate, requestedBitDepth=${requestedBitDepth ?: "auto"}, " +
+                "usbFormat=${target.formatInfo}",
+        )
 
         val openError = UsbExclusiveNative.open(
             openedConnection.fileDescriptor,
@@ -110,10 +172,18 @@ class UsbExclusiveAudioEngine(
             target.alternateSetting,
             target.endpoint.address,
             target.endpoint.maxPacketSize,
+            target.feedbackEndpoint?.address ?: 0,
+            target.feedbackEndpoint?.maxPacketSize ?: 0,
+            false,
         )
         if (openError != null) {
             openedConnection.close()
             return updateState(inactiveState(openError))
+        }
+        Log.i(tag, "native USB exclusive endpoint opened.")
+
+        if (requestedSampleRate != null) {
+            configureUsbAudioClock(openedConnection, device, target, requestedSampleRate)
         }
 
         connection = openedConnection
@@ -127,7 +197,7 @@ class UsbExclusiveAudioEngine(
             "durationMs" to null,
             "sampleRate" to arguments["sampleRate"],
             "bitDepth" to arguments["bitDepth"],
-            "format" to file.extension.lowercase(Locale.ROOT),
+            "format" to (sourceFormat ?: file.extension.lowercase(Locale.ROOT)),
             "message" to "USB exclusive playback prepared.",
         )
         updateState(initialState)
@@ -140,14 +210,20 @@ class UsbExclusiveAudioEngine(
     }
 
     fun pause(): Map<String, Any?> {
+        Log.i(tag, "pause exclusive playback.")
         paused.set(true)
         return updateState(currentState + mapOf("playing" to false, "message" to "Paused."))
     }
 
     fun resume(): Map<String, Any?> {
         if (currentState["active"] != true) {
+            Log.w(tag, "resume ignored because exclusive playback is not active: $currentState")
             return updateState(inactiveState("No exclusive playback is active."))
         }
+        Log.i(
+            tag,
+            "resume exclusive playback position=${currentState["positionMs"]}, wasPaused=${paused.get()}",
+        )
         paused.set(false)
         return updateState(currentState + mapOf("playing" to true, "message" to "Playing."))
     }
@@ -185,6 +261,7 @@ class UsbExclusiveAudioEngine(
         val info = MediaCodec.BufferInfo()
         val startMs = SystemClock.elapsedRealtime()
         var lastPositionEmitMs = 0L
+        var packetizer: PcmIsoPacketizer? = null
 
         try {
             extractor.setDataSource(file.absolutePath)
@@ -202,10 +279,6 @@ class UsbExclusiveAudioEngine(
                 return
             }
 
-            codec = MediaCodec.createDecoderByType(mime)
-            codec.configure(format, null, null, 0)
-            codec.start()
-
             val durationMs = if (format.containsKey(MediaFormat.KEY_DURATION)) {
                 format.getLong(MediaFormat.KEY_DURATION) / 1000
             } else {
@@ -222,20 +295,46 @@ class UsbExclusiveAudioEngine(
                 null
             }
 
+            Log.i(
+                tag,
+                "decoder input format=$format, mime=$mime, sampleRate=$sampleRate, channels=$channels, " +
+                    "durationMs=$durationMs, endpointInterval=${target.endpoint.interval}",
+            )
+
+            if (mime == "audio/raw") {
+                writeRawPcm(extractor, file, format, sampleRate, channels, durationMs, target, startMs)
+                return
+            }
+
+            codec = MediaCodec.createDecoderByType(mime)
+            codec.configure(format, null, null, 0)
+            codec.start()
+
+            if (sampleRate != null && channels != null) {
+                packetizer = createPacketizer(sampleRate, channels, 16, target)
+            }
+
             updateState(
                 currentState + mapOf(
                     "active" to true,
                     "playing" to !paused.get(),
                     "durationMs" to durationMs,
                     "sampleRate" to sampleRate,
-                    "bitDepth" to 16,
+                    "bitDepth" to (target.usbBitResolution ?: 16),
                     "message" to "USB exclusive decoding ${file.name} to ${target.endpointLabel}, channels=$channels.",
                 ),
             )
 
             while (!stopped.get() && !outputDone) {
+                val wasPaused = paused.get()
+                if (wasPaused) {
+                    Log.i(tag, "exclusive worker waiting because playback is paused.")
+                }
                 while (paused.get() && !stopped.get()) {
                     Thread.sleep(25)
+                }
+                if (wasPaused && !stopped.get()) {
+                    Log.i(tag, "exclusive worker resumed.")
                 }
                 if (stopped.get()) break
 
@@ -274,7 +373,14 @@ class UsbExclusiveAudioEngine(
                 if (outputIndex >= 0) {
                     val outputBuffer = codec.getOutputBuffer(outputIndex)
                     if (outputBuffer != null && info.size > 0) {
-                        writeOutputBuffer(outputBuffer, info)
+                        val writer = packetizer
+                            ?: createPacketizer(
+                                sampleRate ?: 48000,
+                                channels ?: 2,
+                                16,
+                                target,
+                            ).also { packetizer = it }
+                        writeOutputBuffer(outputBuffer, info, writer)
                     }
                     if ((info.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
                         outputDone = true
@@ -311,15 +417,36 @@ class UsbExclusiveAudioEngine(
                     } else {
                         null
                     }
+                    val outputChannels = if (outputFormat.containsKey(MediaFormat.KEY_CHANNEL_COUNT)) {
+                        outputFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT)
+                    } else {
+                        channels
+                    }
+                    val outputBitDepth = bitDepthFromPcmEncoding(pcmEncoding)
+                    Log.i(
+                        tag,
+                        "decoder output format changed: $outputFormat, pcmEncoding=$pcmEncoding, " +
+                            "decoderBitDepth=$outputBitDepth, usbBitDepth=${target.usbBitResolution}",
+                    )
+                    if (outputSampleRate != null && outputChannels != null) {
+                        packetizer?.flush()
+                        packetizer = createPacketizer(
+                            outputSampleRate,
+                            outputChannels,
+                            outputBitDepth,
+                            target,
+                        )
+                    }
                     updateState(
                         currentState + mapOf(
                             "sampleRate" to outputSampleRate,
-                            "bitDepth" to bitDepthFromPcmEncoding(pcmEncoding),
+                            "bitDepth" to (target.usbBitResolution ?: outputBitDepth),
                         ),
                     )
                 }
             }
 
+            packetizer?.flush()
             if (!stopped.get()) {
                 updateState(inactiveState("USB exclusive playback completed."))
             }
@@ -339,15 +466,332 @@ class UsbExclusiveAudioEngine(
         }
     }
 
-    private fun writeOutputBuffer(outputBuffer: ByteBuffer, info: MediaCodec.BufferInfo) {
+    private fun writeRawPcm(
+        extractor: MediaExtractor,
+        file: File,
+        format: MediaFormat,
+        sampleRate: Int?,
+        channels: Int?,
+        durationMs: Long?,
+        target: OutputTarget,
+        startMs: Long,
+    ) {
+        if (sampleRate == null || channels == null) {
+            emitError("Raw PCM stream is missing sample rate or channel count.")
+            return
+        }
+
+        val pcmEncoding = if (
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
+            format.containsKey(MediaFormat.KEY_PCM_ENCODING)
+        ) {
+            format.getInteger(MediaFormat.KEY_PCM_ENCODING)
+        } else {
+            null
+        }
+        val containerBitDepth = if (format.containsKey("bits-per-sample")) {
+            format.getInteger("bits-per-sample")
+        } else {
+            null
+        }
+        val sourceBitDepth = pcmEncoding
+            ?.let { bitDepthFromPcmEncoding(it) }
+            ?: containerBitDepth
+            ?: 16
+        val maxInputSize = if (format.containsKey(MediaFormat.KEY_MAX_INPUT_SIZE)) {
+            format.getInteger(MediaFormat.KEY_MAX_INPUT_SIZE).coerceAtLeast(4096)
+        } else {
+            64 * 1024
+        }
+        val buffer = ByteBuffer.allocate(maxInputSize)
+        val packetizer = createPacketizer(sampleRate, channels, sourceBitDepth, target)
+        var lastPositionEmitMs = 0L
+        var lastSampleTimeUs: Long? = null
+        var rawChunkLogCount = 0
+
+        Log.i(
+            tag,
+            "raw PCM direct path sampleRate=$sampleRate, channels=$channels, " +
+                "sourceBitDepth=$sourceBitDepth, pcmEncoding=$pcmEncoding, " +
+                "containerBitDepth=$containerBitDepth, maxInputSize=$maxInputSize, " +
+                "targetBitDepth=${target.usbBitResolution}",
+        )
+        updateState(
+            currentState + mapOf(
+                "active" to true,
+                "playing" to !paused.get(),
+                "durationMs" to durationMs,
+                "sampleRate" to sampleRate,
+                "bitDepth" to (target.usbBitResolution ?: sourceBitDepth),
+                "message" to "USB exclusive streaming raw PCM ${file.name} to ${target.endpointLabel}.",
+            ),
+        )
+
+        while (!stopped.get()) {
+            val wasPaused = paused.get()
+            if (wasPaused) {
+                Log.i(tag, "exclusive worker waiting because playback is paused.")
+            }
+            while (paused.get() && !stopped.get()) {
+                Thread.sleep(25)
+            }
+            if (wasPaused && !stopped.get()) {
+                Log.i(tag, "exclusive worker resumed.")
+            }
+            if (stopped.get()) break
+
+            buffer.clear()
+            val sampleTimeUs = extractor.sampleTime
+            val sampleSize = extractor.readSampleData(buffer, 0)
+            if (sampleSize < 0) {
+                break
+            }
+            val data = ByteArray(sampleSize)
+            buffer.position(0)
+            buffer.limit(sampleSize)
+            buffer.get(data)
+            if (rawChunkLogCount < 12) {
+                val frameBytes = channels * bytesPerSampleForBitDepth(sourceBitDepth)
+                val frames = if (frameBytes > 0) sampleSize / frameBytes else 0
+                val deltaUs = lastSampleTimeUs?.let { sampleTimeUs - it }
+                Log.i(
+                    tag,
+                    "raw PCM chunk size=$sampleSize, sampleTimeUs=$sampleTimeUs, " +
+                        "deltaUs=${deltaUs ?: "n/a"}, frames=$frames, frameBytes=$frameBytes, " +
+                        "sourceBitDepth=$sourceBitDepth",
+                )
+                rawChunkLogCount++
+            }
+            lastSampleTimeUs = sampleTimeUs
+            packetizer.write(data)
+
+            val positionMs = if (sampleTimeUs > 0) {
+                sampleTimeUs / 1000
+            } else {
+                SystemClock.elapsedRealtime() - startMs
+            }
+            if (positionMs - lastPositionEmitMs >= 250) {
+                lastPositionEmitMs = positionMs
+                updateState(
+                    currentState + mapOf(
+                        "active" to true,
+                        "playing" to !paused.get(),
+                        "positionMs" to positionMs,
+                    ),
+                )
+            }
+            extractor.advance()
+        }
+
+        packetizer.flush()
+        if (!stopped.get()) {
+            updateState(inactiveState("USB exclusive playback completed."))
+        }
+    }
+
+    private fun createPacketizer(
+        sampleRate: Int,
+        channels: Int,
+        bitDepth: Int,
+        target: OutputTarget,
+    ): PcmIsoPacketizer {
+        val inputBytesPerSample = bytesPerSampleForBitDepth(bitDepth)
+        val usbBytesPerSample = target.usbBytesPerSample
+        val usbBitResolution = target.usbBitResolution ?: (usbBytesPerSample * 8)
+        Log.i(
+            tag,
+            "USB PCM packetizer sampleRate=$sampleRate, channels=$channels, " +
+                "decoderBitDepth=$bitDepth, inputBytesPerSample=$inputBytesPerSample, " +
+                "usbBytesPerSample=$usbBytesPerSample, usbBitResolution=$usbBitResolution, " +
+                "packetsPerSecond=${target.packetsPerSecond}, endpointInterval=${target.endpoint.interval}, " +
+                "format=${target.formatInfo}",
+        )
+        val packetBytes = requiredIsoPacketBytes(
+            sampleRate,
+            target.packetsPerSecond,
+            channels,
+            usbBytesPerSample,
+        )
+        UsbExclusiveNative.setIsoPacketSize(packetBytes)
+        val outputIntervalMicroframes = isoIntervalMicroframes(target.endpoint.interval)
+        val feedbackOutputPacketDivisor = target.feedbackEndpoint?.let {
+            val feedbackIntervalMicroframes = isoIntervalMicroframes(it.interval)
+            Log.i(
+                tag,
+                "USB feedback intervals outputMicroframes=$outputIntervalMicroframes, " +
+                    "feedbackMicroframes=$feedbackIntervalMicroframes",
+            )
+            1
+        } ?: 1
+        Log.i(
+            tag,
+            "USB feedback scaling outputIntervalMicroframes=$outputIntervalMicroframes, " +
+                "feedbackDivisor=$feedbackOutputPacketDivisor, feedback=${target.feedbackEndpointLabel}",
+        )
+        return PcmIsoPacketizer(
+            sampleRate,
+            target.packetsPerSecond,
+            channels,
+            inputBytesPerSample,
+            bitDepth,
+            usbBytesPerSample,
+            usbBitResolution,
+            feedbackOutputPacketDivisor,
+            feedbackFramesPerPacketQ16 = target.feedbackEndpoint?.let {
+                { UsbExclusiveNative.feedbackFramesPerPacketQ16() }
+            },
+        ) { data, packetLengths, packetCount ->
+            val error = UsbExclusiveNative.writeIsoPackets(data, packetLengths, packetCount)
+            if (error != null) {
+                throw IllegalStateException(error)
+            }
+        }
+    }
+
+    private fun configureUsbAudioClock(
+        connection: UsbDeviceConnection,
+        device: UsbDevice,
+        target: OutputTarget,
+        sampleRate: Int,
+    ) {
+        val controlInterface = findAudioControlInterface(device)
+        val controlInterfaceNumber = controlInterface?.id ?: target.usbInterface.id
+        val clockSourceId = findUac2ClockSourceId(
+            connection.rawDescriptors,
+            streamingInterfaceNumber = target.usbInterface.id,
+            streamingAlternateSetting = target.alternateSetting,
+        )
+
+        val claimedControl = controlInterface?.let {
+            runCatching { connection.claimInterface(it, true) }.getOrDefault(false)
+        } == true
+        try {
+            if (clockSourceId != null) {
+                readUac2ClockSampleRate(
+                    connection,
+                    clockSourceId,
+                    controlInterfaceNumber,
+                    "before",
+                )
+                val data = byteArrayOf(
+                    (sampleRate and 0xff).toByte(),
+                    ((sampleRate ushr 8) and 0xff).toByte(),
+                    ((sampleRate ushr 16) and 0xff).toByte(),
+                    ((sampleRate ushr 24) and 0xff).toByte(),
+                )
+                val result = connection.controlTransfer(
+                    UsbConstants.USB_DIR_OUT or UsbConstants.USB_TYPE_CLASS or USB_RECIP_INTERFACE,
+                    0x01,
+                    0x01 shl 8,
+                    (clockSourceId shl 8) or controlInterfaceNumber,
+                    data,
+                    data.size,
+                    1000,
+                )
+                Log.i(
+                    tag,
+                    "UAC2 clock SET_CUR sampleRate=$sampleRate, clockSourceId=$clockSourceId, " +
+                    "controlInterface=$controlInterfaceNumber, result=$result",
+                )
+                readUac2ClockSampleRate(
+                    connection,
+                    clockSourceId,
+                    controlInterfaceNumber,
+                    "after",
+                )
+                return
+            }
+
+            val data = byteArrayOf(
+                (sampleRate and 0xff).toByte(),
+                ((sampleRate ushr 8) and 0xff).toByte(),
+                ((sampleRate ushr 16) and 0xff).toByte(),
+            )
+            val result = connection.controlTransfer(
+                UsbConstants.USB_DIR_OUT or UsbConstants.USB_TYPE_CLASS or USB_RECIP_ENDPOINT,
+                0x01,
+                0x01 shl 8,
+                target.endpoint.address,
+                data,
+                data.size,
+                1000,
+            )
+            Log.i(
+                tag,
+                "UAC1 endpoint SET_CUR sampleRate=$sampleRate, endpoint=0x${
+                    target.endpoint.address.toString(16)
+                }, result=$result",
+            )
+        } catch (error: RuntimeException) {
+            Log.w(tag, "USB audio clock configuration failed.", error)
+        } finally {
+            if (claimedControl && controlInterface != null) {
+                runCatching { connection.releaseInterface(controlInterface) }
+            }
+        }
+    }
+
+    private fun readUac2ClockSampleRate(
+        connection: UsbDeviceConnection,
+        clockSourceId: Int,
+        controlInterfaceNumber: Int,
+        label: String,
+    ): Int? {
+        val data = ByteArray(4)
+        val result = connection.controlTransfer(
+            UsbConstants.USB_DIR_IN or UsbConstants.USB_TYPE_CLASS or USB_RECIP_INTERFACE,
+            0x81,
+            0x01 shl 8,
+            (clockSourceId shl 8) or controlInterfaceNumber,
+            data,
+            data.size,
+            1000,
+        )
+        val sampleRate = if (result == 4) {
+            (data[0].toInt() and 0xff) or
+                ((data[1].toInt() and 0xff) shl 8) or
+                ((data[2].toInt() and 0xff) shl 16) or
+                ((data[3].toInt() and 0xff) shl 24)
+        } else {
+            null
+        }
+        Log.i(
+            tag,
+            "UAC2 clock GET_CUR $label result=$result, clockSourceId=$clockSourceId, " +
+                "controlInterface=$controlInterfaceNumber, sampleRate=${sampleRate ?: "n/a"}, " +
+                "raw=${hexPreview(data)}",
+        )
+        return sampleRate
+    }
+
+    private fun hexPreview(data: ByteArray, limit: Int = 16): String =
+        data.take(minOf(data.size, limit)).joinToString(" ") { byte ->
+            (byte.toInt() and 0xff).toString(16).padStart(2, '0')
+        }
+
+    private fun findAudioControlInterface(device: UsbDevice): UsbInterface? {
+        for (index in 0 until device.interfaceCount) {
+            val usbInterface = device.getInterface(index)
+            if (
+                usbInterface.interfaceClass == UsbConstants.USB_CLASS_AUDIO &&
+                usbInterface.interfaceSubclass == 1
+            ) {
+                return usbInterface
+            }
+        }
+        return null
+    }
+
+    private fun writeOutputBuffer(
+        outputBuffer: ByteBuffer,
+        info: MediaCodec.BufferInfo,
+        packetizer: PcmIsoPacketizer,
+    ) {
         val data = ByteArray(info.size)
         outputBuffer.position(info.offset)
         outputBuffer.limit(info.offset + info.size)
         outputBuffer.get(data)
-        val error = UsbExclusiveNative.writePcm(data, data.size)
-        if (error != null) {
-            throw IllegalStateException(error)
-        }
+        packetizer.write(data)
     }
 
     private fun findAudioTrack(extractor: MediaExtractor): Int {
@@ -361,7 +805,14 @@ class UsbExclusiveAudioEngine(
         return -1
     }
 
-    private fun findOutputTarget(device: UsbDevice): OutputTarget? {
+    private fun findOutputTarget(
+        device: UsbDevice,
+        streamingFormats: Map<Pair<Int, Int>, StreamingFormatInfo> = emptyMap(),
+        sampleRate: Int? = null,
+        channels: Int = 2,
+        bitDepth: Int? = null,
+    ): OutputTarget? {
+        val candidates = mutableListOf<OutputTarget>()
         for (index in 0 until device.interfaceCount) {
             val usbInterface = device.getInterface(index)
             if (usbInterface.interfaceClass != UsbConstants.USB_CLASS_AUDIO) {
@@ -373,14 +824,311 @@ class UsbExclusiveAudioEngine(
                     endpoint.direction == UsbConstants.USB_DIR_OUT &&
                     endpoint.type == UsbConstants.USB_ENDPOINT_XFER_ISOC
                 ) {
-                    return OutputTarget(usbInterface, endpoint)
+                    val alt = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                        usbInterface.alternateSetting
+                    } else {
+                        0
+                    }
+                    candidates += OutputTarget(
+                        usbInterface = usbInterface,
+                        endpoint = endpoint,
+                        feedbackEndpoint = findFeedbackEndpoint(usbInterface),
+                        formatInfo = streamingFormats[usbInterface.id to alt],
+                    )
                 }
+            }
+        }
+
+        if (candidates.isEmpty()) {
+            return null
+        }
+
+        if (sampleRate == null) {
+            return candidates.minWith(compareBy<OutputTarget> {
+                it.endpoint.maxPacketSize
+            }.thenBy { it.alternateSetting })
+        }
+
+        val sortedCandidates = candidates.sortedWith(compareBy<OutputTarget> {
+            it.endpoint.maxPacketSize
+        }.thenBy { it.alternateSetting })
+        val fittingCandidates = sortedCandidates.filter {
+            it.endpoint.maxPacketSize >= requiredIsoPacketBytes(
+                sampleRate,
+                it.packetsPerSecond,
+                channels,
+                it.usbBytesPerSample,
+            )
+        }
+        val exactBitDepthCandidates = bitDepth?.let { requested ->
+            fittingCandidates.filter { it.usbBitResolution == requested }
+        } ?: emptyList()
+        val autoBitDepthCandidates = if (bitDepth == null) {
+            listOf(24, 32, 16)
+                .firstNotNullOfOrNull { preferred ->
+                    fittingCandidates.filter { it.usbBitResolution == preferred }.takeIf { it.isNotEmpty() }
+                }
+                ?: fittingCandidates
+        } else {
+            emptyList()
+        }
+        val selectedPool = when {
+            exactBitDepthCandidates.isNotEmpty() -> exactBitDepthCandidates
+            autoBitDepthCandidates.isNotEmpty() -> autoBitDepthCandidates
+            fittingCandidates.isNotEmpty() -> fittingCandidates
+            else -> sortedCandidates
+        }
+        val selected = selectedPool.minWith(
+            compareBy<OutputTarget> { it.usbBytesPerSample }
+                .thenBy { it.endpoint.maxPacketSize }
+                .thenBy { it.alternateSetting },
+        )
+        val selectedRequiredPacketBytes = requiredIsoPacketBytes(
+            sampleRate,
+            selected.packetsPerSecond,
+            channels,
+            selected.usbBytesPerSample,
+        )
+        if (selected.endpoint.maxPacketSize < selectedRequiredPacketBytes) {
+            Log.w(
+                tag,
+                "selected USB alt may be too small: requiredPacketBytes=$selectedRequiredPacketBytes, " +
+                    "selectedMaxPacket=${selected.endpoint.maxPacketSize}, sampleRate=$sampleRate, " +
+                    "channels=$channels, bitDepth=${bitDepth ?: "auto"}",
+            )
+        }
+        Log.i(
+            tag,
+            "selected USB alt=${selected.alternateSetting}, maxPacket=${selected.endpoint.maxPacketSize}, " +
+                "requiredPacketBytes=$selectedRequiredPacketBytes, " +
+                "requestedBitDepth=${bitDepth ?: "auto"}, selectedBitDepth=${selected.usbBitResolution}, " +
+                "packetsPerSecond=${selected.packetsPerSecond}, candidates=${sortedCandidates.joinToString { candidate ->
+                    val required = requiredIsoPacketBytes(
+                        sampleRate,
+                        candidate.packetsPerSecond,
+                        channels,
+                        candidate.usbBytesPerSample,
+                    )
+                    "alt=${candidate.alternateSetting}/max=${candidate.endpoint.maxPacketSize}/" +
+                        "outAttr=0x${candidate.endpoint.attributes.toString(16)}/" +
+                        "feedback=${candidate.feedbackEndpointLabel}/" +
+                        "usbBytes=${candidate.usbBytesPerSample}/bits=${candidate.usbBitResolution}/" +
+                        "required=$required/format=${candidate.formatInfo}"
+                }}",
+        )
+        return selected
+    }
+
+    private fun findFeedbackEndpoint(usbInterface: UsbInterface): UsbEndpoint? {
+        for (endpointIndex in 0 until usbInterface.endpointCount) {
+            val endpoint = usbInterface.getEndpoint(endpointIndex)
+            val isIsochronous = endpoint.type == UsbConstants.USB_ENDPOINT_XFER_ISOC
+            val isInput = endpoint.direction == UsbConstants.USB_DIR_IN
+            val usageType = endpoint.attributes and 0x30
+            if (isIsochronous && isInput && usageType == 0x10) {
+                return endpoint
             }
         }
         return null
     }
 
-    private fun isSupportedFile(filePath: String): Boolean {
+    private fun parseStreamingFormatInfo(descriptors: ByteArray?): Map<Pair<Int, Int>, StreamingFormatInfo> {
+        if (descriptors == null) {
+            Log.w(tag, "USB raw descriptors unavailable; cannot parse AS format descriptors.")
+            return emptyMap()
+        }
+
+        val formats = mutableMapOf<Pair<Int, Int>, StreamingFormatInfo>()
+        var offset = 0
+        var currentInterfaceNumber = -1
+        var currentAlternateSetting = -1
+        var currentInterfaceSubclass = -1
+        var currentInterfaceProtocol = -1
+
+        while (offset + 1 < descriptors.size) {
+            val length = descriptors[offset].toInt() and 0xff
+            val descriptorType = descriptors[offset + 1].toInt() and 0xff
+            if (length < 2 || offset + length > descriptors.size) {
+                break
+            }
+
+            if (descriptorType == 0x04 && length >= 9) {
+                currentInterfaceNumber = descriptors[offset + 2].toInt() and 0xff
+                currentAlternateSetting = descriptors[offset + 3].toInt() and 0xff
+                currentInterfaceSubclass = descriptors[offset + 6].toInt() and 0xff
+                currentInterfaceProtocol = descriptors[offset + 8].toInt() and 0xff
+            } else if (
+                descriptorType == 0x24 &&
+                currentInterfaceSubclass == 2 &&
+                length >= 3
+            ) {
+                val key = currentInterfaceNumber to currentAlternateSetting
+                val subtype = descriptors[offset + 2].toInt() and 0xff
+                val existing = formats[key] ?: StreamingFormatInfo(
+                    interfaceNumber = currentInterfaceNumber,
+                    alternateSetting = currentAlternateSetting,
+                    protocol = currentInterfaceProtocol,
+                )
+                when (subtype) {
+                    0x01 -> {
+                        val terminalLink = if (length >= 4) {
+                            descriptors[offset + 3].toInt() and 0xff
+                        } else {
+                            existing.terminalLink
+                        }
+                        val formatType = if (length >= 6) {
+                            descriptors[offset + 5].toInt() and 0xff
+                        } else {
+                            existing.formatType
+                        }
+                        val channels = if (length >= 11) {
+                            descriptors[offset + 10].toInt() and 0xff
+                        } else {
+                            existing.channels
+                        }
+                        formats[key] = existing.copy(
+                            terminalLink = terminalLink,
+                            formatType = formatType,
+                            channels = channels,
+                        )
+                    }
+                    0x02 -> {
+                        if (length >= 6) {
+                            formats[key] = existing.copy(
+                                formatType = descriptors[offset + 3].toInt() and 0xff,
+                                subslotSize = descriptors[offset + 4].toInt() and 0xff,
+                                bitResolution = descriptors[offset + 5].toInt() and 0xff,
+                            )
+                        } else if (length >= 7) {
+                            formats[key] = existing.copy(
+                                formatType = descriptors[offset + 3].toInt() and 0xff,
+                                channels = descriptors[offset + 4].toInt() and 0xff,
+                                subslotSize = descriptors[offset + 5].toInt() and 0xff,
+                                bitResolution = descriptors[offset + 6].toInt() and 0xff,
+                            )
+                        }
+                    }
+                }
+            }
+
+            offset += length
+        }
+
+        Log.i(
+            tag,
+            "USB AS formats parsed: ${formats.values.sortedWith(
+                compareBy<StreamingFormatInfo> { it.interfaceNumber }.thenBy { it.alternateSetting },
+            ).joinToString()}",
+        )
+        return formats
+    }
+
+    private fun findUac2ClockSourceId(
+        descriptors: ByteArray?,
+        streamingInterfaceNumber: Int,
+        streamingAlternateSetting: Int,
+    ): Int? {
+        if (descriptors == null) {
+            return null
+        }
+
+        var offset = 0
+        var currentInterfaceNumber = -1
+        var currentAlternateSetting = -1
+        var currentInterfaceSubclass = -1
+        var terminalLink: Int? = null
+        var firstClockSourceId: Int? = null
+        val inputTerminalClockIds = mutableMapOf<Int, Int>()
+        val outputTerminalClockIds = mutableMapOf<Int, Int>()
+
+        while (offset + 1 < descriptors.size) {
+            val length = descriptors[offset].toInt() and 0xff
+            val descriptorType = descriptors[offset + 1].toInt() and 0xff
+            if (length < 2 || offset + length > descriptors.size) {
+                break
+            }
+
+            if (descriptorType == 0x04 && length >= 9) {
+                currentInterfaceNumber = descriptors[offset + 2].toInt() and 0xff
+                currentAlternateSetting = descriptors[offset + 3].toInt() and 0xff
+                currentInterfaceSubclass = descriptors[offset + 6].toInt() and 0xff
+            } else if (descriptorType == 0x24 && length >= 3) {
+                val subtype = descriptors[offset + 2].toInt() and 0xff
+                when (subtype) {
+                    0x0a -> {
+                        if (length >= 4 && firstClockSourceId == null) {
+                            firstClockSourceId = descriptors[offset + 3].toInt() and 0xff
+                        }
+                    }
+                    0x02 -> {
+                        if (length >= 8) {
+                            val terminalId = descriptors[offset + 3].toInt() and 0xff
+                            inputTerminalClockIds[terminalId] =
+                                descriptors[offset + 7].toInt() and 0xff
+                        }
+                    }
+                    0x03 -> {
+                        if (length >= 9) {
+                            val terminalId = descriptors[offset + 3].toInt() and 0xff
+                            outputTerminalClockIds[terminalId] =
+                                descriptors[offset + 8].toInt() and 0xff
+                        }
+                    }
+                    0x01 -> {
+                        if (
+                            currentInterfaceNumber == streamingInterfaceNumber &&
+                            currentAlternateSetting == streamingAlternateSetting &&
+                            currentInterfaceSubclass == 2 &&
+                            length >= 4
+                        ) {
+                            terminalLink = descriptors[offset + 3].toInt() and 0xff
+                        }
+                    }
+                }
+            }
+
+            offset += length
+        }
+
+        val linkedTerminal = terminalLink
+        val result = linkedTerminal?.let {
+            inputTerminalClockIds[it] ?: outputTerminalClockIds[it]
+        } ?: firstClockSourceId
+        Log.i(
+            tag,
+            "parsed UAC2 clock source: streamingInterface=$streamingInterfaceNumber, " +
+                "alt=$streamingAlternateSetting, terminalLink=$terminalLink, clockSourceId=$result",
+        )
+        return result
+    }
+
+    private fun requiredIsoPacketBytes(
+        sampleRate: Int,
+        packetsPerSecond: Int,
+        channels: Int,
+        bytesPerSample: Int,
+    ): Int {
+        val maxFramesPerPacket = (sampleRate + packetsPerSecond - 1) / packetsPerSecond
+        return maxFramesPerPacket * channels * bytesPerSample
+    }
+
+    private fun isoIntervalMicroframes(interval: Int): Int {
+        return 1 shl (interval.coerceIn(1, 4) - 1)
+    }
+
+    private fun bytesPerSampleForBitDepth(bitDepth: Int): Int {
+        return when {
+            bitDepth <= 8 -> 1
+            bitDepth <= 16 -> 2
+            bitDepth <= 24 -> 3
+            else -> 4
+        }
+    }
+
+    private fun isSupportedFile(filePath: String, sourceFormat: String?): Boolean {
+        if (sourceFormat == "flac" || sourceFormat == "wav" || sourceFormat == "wave") {
+            return true
+        }
         val lower = filePath.lowercase(Locale.ROOT)
         return lower.endsWith(".flac") || lower.endsWith(".wav") || lower.endsWith(".wave")
     }
@@ -443,6 +1191,8 @@ class UsbExclusiveAudioEngine(
     private data class OutputTarget(
         val usbInterface: UsbInterface,
         val endpoint: UsbEndpoint,
+        val feedbackEndpoint: UsbEndpoint? = null,
+        val formatInfo: StreamingFormatInfo? = null,
     ) {
         val alternateSetting: Int
             get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
@@ -455,5 +1205,264 @@ class UsbExclusiveAudioEngine(
             get() = "interface=${usbInterface.id}, alt=$alternateSetting, endpoint=0x${
                 endpoint.address.toString(16)
             }"
+
+        val feedbackEndpointLabel: String
+            get() = feedbackEndpoint?.let {
+                "0x${it.address.toString(16)}/max=${it.maxPacketSize}/interval=${it.interval}/attr=0x${
+                    it.attributes.toString(16)
+                }"
+            } ?: "none"
+
+        val packetsPerSecond: Int
+            get() {
+                if (usbInterface.interfaceProtocol == 32) {
+                    val interval = endpoint.interval.coerceIn(1, 4)
+                    return 8000 / (1 shl (interval - 1))
+                }
+                return 1000
+            }
+
+        val usbBytesPerSample: Int
+            get() = formatInfo?.subslotSize?.takeIf { it > 0 } ?: 2
+
+        val usbBitResolution: Int?
+            get() = formatInfo?.bitResolution?.takeIf { it > 0 }
+    }
+
+    private data class StreamingFormatInfo(
+        val interfaceNumber: Int,
+        val alternateSetting: Int,
+        val protocol: Int,
+        val terminalLink: Int? = null,
+        val formatType: Int? = null,
+        val channels: Int? = null,
+        val subslotSize: Int? = null,
+        val bitResolution: Int? = null,
+    )
+
+    private class PcmIsoPacketizer(
+        private val sampleRate: Int,
+        private val packetsPerSecond: Int,
+        channels: Int,
+        private val inputBytesPerSample: Int,
+        private val inputBitDepth: Int,
+        private val usbBytesPerSample: Int,
+        private val usbBitResolution: Int,
+        private val feedbackOutputPacketDivisor: Int,
+        private val feedbackFramesPerPacketQ16: (() -> Int)? = null,
+        private val writePackets: (ByteArray, IntArray, Int) -> Unit,
+    ) {
+        private val pending = ByteArrayOutputStream()
+        private val transfer = ByteArrayOutputStream()
+        private val transferPacketLengths = IntArray(16)
+        private val bytesPerFrame = channels * usbBytesPerSample
+        private val inputBytesPerFrame = channels * inputBytesPerSample
+        private var sampleRemainder = 0
+        private var feedbackRemainderQ16 = 0L
+        private var transferPacketCount = 0
+        private var packetLogCount = 0
+        private var feedbackRejectLogCount = 0
+        private var pcmPreviewLogged = false
+        private var pcmPreviewAttempts = 0
+
+        fun write(data: ByteArray) {
+            val converted = convertPcmToUsbSlots(data)
+            if (!pcmPreviewLogged) {
+                pcmPreviewAttempts++
+                val forcePreview = pcmPreviewAttempts >= 64
+                if (hasAudibleSamples(data) || forcePreview) {
+                    pcmPreviewLogged = true
+                    logPcmPreview(
+                        data,
+                        converted,
+                        if (forcePreview) "forced-after-silence" else "first-nonzero",
+                    )
+                }
+            }
+            pending.write(converted)
+            drain(fullPacketsOnly = true)
+        }
+
+        fun flush() {
+            drain(fullPacketsOnly = false)
+        }
+
+        private fun drain(fullPacketsOnly: Boolean) {
+            while (pending.size() > 0) {
+                val packetBytes = nextPacketBytes()
+                if (fullPacketsOnly && pending.size() < packetBytes) {
+                    return
+                }
+                val source = pending.toByteArray()
+                val length = minOf(packetBytes, source.size)
+                val packet = ByteArray(packetBytes)
+                System.arraycopy(source, 0, packet, 0, length)
+                pending.reset()
+                if (source.size > length) {
+                    pending.write(source, length, source.size - length)
+                }
+                if (packetLogCount < 5) {
+                    ++packetLogCount
+                    Log.d(
+                        "UsbExclusiveAudioEngine",
+                        "USB PCM packet bytes=${packet.size}, filled=$length",
+                    )
+                }
+                transfer.write(packet)
+                transferPacketLengths[transferPacketCount] = packet.size
+                transferPacketCount++
+                if (transferPacketCount >= transferPacketLengths.size) {
+                    flushTransfer()
+                }
+            }
+
+            if (!fullPacketsOnly) {
+                flushTransfer()
+            }
+        }
+
+        private fun flushTransfer() {
+            if (transferPacketCount == 0) {
+                return
+            }
+            writePackets(
+                transfer.toByteArray(),
+                transferPacketLengths.copyOf(transferPacketCount),
+                transferPacketCount,
+            )
+            transfer.reset()
+            transferPacketCount = 0
+        }
+
+        private fun nextPacketBytes(): Int {
+            val feedbackQ16 = feedbackFramesPerPacketQ16?.invoke() ?: 0
+            if (feedbackQ16 > 0) {
+                val outputFeedbackQ16 = feedbackQ16 / feedbackOutputPacketDivisor
+                val nominalFramesQ16 = ((sampleRate.toLong() shl 16) / packetsPerSecond).toInt()
+                val minFeedbackQ16 = nominalFramesQ16 - (nominalFramesQ16 / 8)
+                val maxFeedbackQ16 = nominalFramesQ16 + (nominalFramesQ16 / 2)
+                if (outputFeedbackQ16 in minFeedbackQ16..maxFeedbackQ16) {
+                    feedbackRemainderQ16 += outputFeedbackQ16.toLong()
+                    val frames = (feedbackRemainderQ16 ushr 16).toInt()
+                    feedbackRemainderQ16 = feedbackRemainderQ16 and 0xffff
+                    if (frames > 0) {
+                        return maxOf(bytesPerFrame, frames * bytesPerFrame)
+                    }
+                } else if (feedbackRejectLogCount < 8) {
+                    ++feedbackRejectLogCount
+                    Log.w(
+                        "UsbExclusiveAudioEngine",
+                        "USB feedback ignored outputFrames=${q16ToFrames(outputFeedbackQ16)}, " +
+                            "nominalFrames=${q16ToFrames(nominalFramesQ16)}, " +
+                            "sampleRate=$sampleRate, packetsPerSecond=$packetsPerSecond",
+                    )
+                }
+            }
+
+            sampleRemainder += sampleRate
+            val frames = sampleRemainder / packetsPerSecond
+            sampleRemainder %= packetsPerSecond
+            return maxOf(bytesPerFrame, frames * bytesPerFrame)
+        }
+
+        private fun q16ToFrames(value: Int): String =
+            String.format(Locale.US, "%.6f", value.toDouble() / 65536.0)
+
+        private fun convertPcmToUsbSlots(data: ByteArray): ByteArray {
+            if (inputBytesPerSample == usbBytesPerSample && inputBitDepth == usbBitResolution) {
+                return data
+            }
+
+            val frames = data.size / inputBytesPerFrame
+            val output = ByteArray(frames * bytesPerFrame)
+            var inputOffset = 0
+            var outputOffset = 0
+            repeat(frames) {
+                repeat(inputBytesPerFrame / inputBytesPerSample) {
+                    val sample = readSignedLittleEndian(data, inputOffset, inputBytesPerSample, inputBitDepth)
+                    val shifted = if (usbBitResolution >= inputBitDepth) {
+                        sample shl (usbBitResolution - inputBitDepth)
+                    } else {
+                        sample shr (inputBitDepth - usbBitResolution)
+                    }
+                    writeLittleEndian(output, outputOffset, usbBytesPerSample, shifted)
+                    inputOffset += inputBytesPerSample
+                    outputOffset += usbBytesPerSample
+                }
+            }
+            return output
+        }
+
+        private fun hasAudibleSamples(input: ByteArray): Boolean {
+            val frames = input.size / inputBytesPerFrame
+            val samplesPerFrame = inputBytesPerFrame / inputBytesPerSample
+            val samplesToInspect = minOf(4096, frames * samplesPerFrame)
+            var sumAbs = 0L
+            for (index in 0 until samplesToInspect) {
+                val offset = index * inputBytesPerSample
+                val sample = readSignedLittleEndian(input, offset, inputBytesPerSample, inputBitDepth)
+                val abs = kotlin.math.abs(sample.toLong())
+                sumAbs += abs
+                if (abs > 512) {
+                    return true
+                }
+            }
+            return samplesToInspect > 0 && (sumAbs / samplesToInspect) > 64
+        }
+
+        private fun logPcmPreview(input: ByteArray, converted: ByteArray, reason: String) {
+            val frames = input.size / inputBytesPerFrame
+            val samplesPerFrame = inputBytesPerFrame / inputBytesPerSample
+            val samplesToInspect = minOf(4096, frames * samplesPerFrame)
+            var minSample = 0
+            var maxSample = 0
+            var sumAbs = 0L
+            for (index in 0 until samplesToInspect) {
+                val offset = index * inputBytesPerSample
+                val sample = readSignedLittleEndian(input, offset, inputBytesPerSample, inputBitDepth)
+                if (index == 0 || sample < minSample) minSample = sample
+                if (index == 0 || sample > maxSample) maxSample = sample
+                sumAbs += kotlin.math.abs(sample.toLong())
+            }
+            val averageAbs = if (samplesToInspect > 0) sumAbs / samplesToInspect else 0
+            Log.i(
+                "UsbExclusiveAudioEngine",
+                "USB PCM preview reason=$reason, inputBytes=${input.size}, convertedBytes=${converted.size}, frames=$frames, " +
+                    "inputBitDepth=$inputBitDepth, usbBytesPerSample=$usbBytesPerSample, " +
+                    "usbBitResolution=$usbBitResolution, min=$minSample, max=$maxSample, avgAbs=$averageAbs, " +
+                    "inputHead=${input.toHexPreview()}, usbHead=${converted.toHexPreview()}",
+            )
+        }
+
+        private fun ByteArray.toHexPreview(limit: Int = 64): String {
+            return take(minOf(size, limit)).joinToString(" ") { byte ->
+                (byte.toInt() and 0xff).toString(16).padStart(2, '0')
+            }
+        }
+
+        private fun readSignedLittleEndian(
+            data: ByteArray,
+            offset: Int,
+            bytes: Int,
+            bitDepth: Int,
+        ): Int {
+            var value = 0
+            for (index in 0 until bytes) {
+                value = value or ((data[offset + index].toInt() and 0xff) shl (index * 8))
+            }
+            val shift = (32 - bitDepth).coerceIn(0, 31)
+            return (value shl shift) shr shift
+        }
+
+        private fun writeLittleEndian(
+            data: ByteArray,
+            offset: Int,
+            bytes: Int,
+            value: Int,
+        ) {
+            for (index in 0 until bytes) {
+                data[offset + index] = ((value ushr (index * 8)) and 0xff).toByte()
+            }
+        }
     }
 }

--- a/android/app/src/main/kotlin/com/afalphy/particle_music/UsbExclusiveAudioEngine.kt
+++ b/android/app/src/main/kotlin/com/afalphy/particle_music/UsbExclusiveAudioEngine.kt
@@ -12,7 +12,6 @@ import android.media.MediaExtractor
 import android.media.MediaFormat
 import android.os.Build
 import android.os.SystemClock
-import android.util.Log
 import java.io.ByteArrayOutputStream
 import java.io.File
 import java.nio.ByteBuffer
@@ -143,7 +142,7 @@ class UsbExclusiveAudioEngine(
         if (!file.exists()) {
             return updateState(inactiveState("Exclusive playback file does not exist: $filePath"))
         }
-        Log.i(
+        UsbDiagnostics.i(
             tag,
             "start exclusive playback file=${file.name}, sourceFormat=$sourceFormat, size=${file.length()}",
         )
@@ -176,7 +175,7 @@ class UsbExclusiveAudioEngine(
                 openedConnection.close()
                 return updateState(inactiveState("No isochronous USB Audio OUT endpoint was found."))
             }
-        Log.i(
+        UsbDiagnostics.i(
             tag,
             "exclusive target interface=${target.usbInterface.id}, alt=${target.alternateSetting}, " +
                 "endpoint=0x${target.endpoint.address.toString(16)}, maxPacket=${target.endpoint.maxPacketSize}, " +
@@ -199,7 +198,7 @@ class UsbExclusiveAudioEngine(
             openedConnection.close()
             return updateState(inactiveState(openError))
         }
-        Log.i(tag, "native USB exclusive endpoint opened.")
+        UsbDiagnostics.i(tag, "native USB exclusive endpoint opened.")
 
         if (requestedSampleRate != null) {
             configureUsbAudioClock(openedConnection, device, target, requestedSampleRate)
@@ -231,17 +230,17 @@ class UsbExclusiveAudioEngine(
     }
 
     fun pause(): Map<String, Any?> {
-        Log.i(tag, "pause exclusive playback.")
+        UsbDiagnostics.i(tag, "pause exclusive playback.")
         paused.set(true)
         return updateState(currentState + mapOf("playing" to false, "message" to "Paused."))
     }
 
     fun resume(): Map<String, Any?> {
         if (currentState["active"] != true) {
-            Log.w(tag, "resume ignored because exclusive playback is not active: $currentState")
+            UsbDiagnostics.w(tag, "resume ignored because exclusive playback is not active: $currentState")
             return updateState(inactiveState("No exclusive playback is active."))
         }
-        Log.i(
+        UsbDiagnostics.i(
             tag,
             "resume exclusive playback position=${currentState["positionMs"]}, wasPaused=${paused.get()}",
         )
@@ -251,7 +250,7 @@ class UsbExclusiveAudioEngine(
 
     fun seek(positionMs: Long): Map<String, Any?> {
         if (currentState["active"] != true) {
-            Log.w(tag, "seek ignored because exclusive playback is not active: $currentState")
+            UsbDiagnostics.w(tag, "seek ignored because exclusive playback is not active: $currentState")
             return updateState(inactiveState("No exclusive playback is active."))
         }
         val safePositionMs = positionMs.coerceAtLeast(0L)
@@ -356,7 +355,7 @@ class UsbExclusiveAudioEngine(
         val packetCount = ((targetBufferMs.toLong() * packetsPerSecond) + 999L) / 1000L
         val maxPendingUrbs = ((packetCount + 15L) / 16L).coerceIn(8L, 512L).toInt()
         UsbExclusiveNative.setMaxPendingOutputUrbs(maxPendingUrbs)
-        Log.i(
+        UsbDiagnostics.i(
             tag,
             "USB target buffer targetMs=$targetBufferMs packetsPerSecond=$packetsPerSecond " +
                 "maxPendingUrbs=$maxPendingUrbs",
@@ -405,7 +404,7 @@ class UsbExclusiveAudioEngine(
                 null
             }
 
-            Log.i(
+            UsbDiagnostics.i(
                 tag,
                 "decoder input format=$format, mime=$mime, sampleRate=$sampleRate, channels=$channels, " +
                     "durationMs=$durationMs, endpointInterval=${target.endpoint.interval}",
@@ -438,19 +437,19 @@ class UsbExclusiveAudioEngine(
             while (!stopped.get() && !outputDone) {
                 val wasPaused = paused.get()
                 if (wasPaused) {
-                    Log.i(tag, "exclusive worker waiting because playback is paused.")
+                    UsbDiagnostics.i(tag, "exclusive worker waiting because playback is paused.")
                 }
                 while (paused.get() && !stopped.get()) {
                     Thread.sleep(25)
                 }
                 if (wasPaused && !stopped.get()) {
-                    Log.i(tag, "exclusive worker resumed.")
+                    UsbDiagnostics.i(tag, "exclusive worker resumed.")
                 }
                 if (stopped.get()) break
 
                 consumePendingSeekMs()?.let { seekMs ->
                     val seekUs = seekMs * 1000
-                    Log.i(tag, "exclusive decoder seek to ${seekMs}ms.")
+                    UsbDiagnostics.i(tag, "exclusive decoder seek to ${seekMs}ms.")
                     extractor.seekTo(seekUs, MediaExtractor.SEEK_TO_CLOSEST_SYNC)
                     codec.flush()
                     packetizer?.reset()
@@ -552,7 +551,7 @@ class UsbExclusiveAudioEngine(
                         channels
                     }
                     val outputBitDepth = bitDepthFromPcmEncoding(pcmEncoding)
-                    Log.i(
+                    UsbDiagnostics.i(
                         tag,
                         "decoder output format changed: $outputFormat, pcmEncoding=$pcmEncoding, " +
                             "decoderBitDepth=$outputBitDepth, usbBitDepth=${target.usbBitResolution}",
@@ -580,7 +579,7 @@ class UsbExclusiveAudioEngine(
                 updateState(inactiveState("USB exclusive playback completed."))
             }
         } catch (error: Throwable) {
-            Log.w("UsbExclusiveAudioEngine", "Exclusive playback failed.", error)
+            UsbDiagnostics.w("UsbExclusiveAudioEngine", "Exclusive playback failed.", error)
             emitError(error.message ?: "USB exclusive playback failed.")
         } finally {
             try {
@@ -638,7 +637,7 @@ class UsbExclusiveAudioEngine(
         var lastSampleTimeUs: Long? = null
         var rawChunkLogCount = 0
 
-        Log.i(
+        UsbDiagnostics.i(
             tag,
             "raw PCM direct path sampleRate=$sampleRate, channels=$channels, " +
                 "sourceBitDepth=$sourceBitDepth, pcmEncoding=$pcmEncoding, " +
@@ -659,19 +658,19 @@ class UsbExclusiveAudioEngine(
         while (!stopped.get()) {
             val wasPaused = paused.get()
             if (wasPaused) {
-                Log.i(tag, "exclusive worker waiting because playback is paused.")
+                UsbDiagnostics.i(tag, "exclusive worker waiting because playback is paused.")
             }
             while (paused.get() && !stopped.get()) {
                 Thread.sleep(25)
             }
             if (wasPaused && !stopped.get()) {
-                Log.i(tag, "exclusive worker resumed.")
+                UsbDiagnostics.i(tag, "exclusive worker resumed.")
             }
             if (stopped.get()) break
 
             consumePendingSeekMs()?.let { seekMs ->
                 val seekUs = seekMs * 1000
-                Log.i(tag, "exclusive raw PCM seek to ${seekMs}ms.")
+                UsbDiagnostics.i(tag, "exclusive raw PCM seek to ${seekMs}ms.")
                 extractor.seekTo(seekUs, MediaExtractor.SEEK_TO_CLOSEST_SYNC)
                 packetizer.reset()
                 lastPositionEmitMs = -1L
@@ -700,7 +699,7 @@ class UsbExclusiveAudioEngine(
                 val frameBytes = channels * bytesPerSampleForBitDepth(sourceBitDepth)
                 val frames = if (frameBytes > 0) sampleSize / frameBytes else 0
                 val deltaUs = lastSampleTimeUs?.let { sampleTimeUs - it }
-                Log.i(
+                UsbDiagnostics.i(
                     tag,
                     "raw PCM chunk size=$sampleSize, sampleTimeUs=$sampleTimeUs, " +
                         "deltaUs=${deltaUs ?: "n/a"}, frames=$frames, frameBytes=$frameBytes, " +
@@ -744,7 +743,7 @@ class UsbExclusiveAudioEngine(
         val inputBytesPerSample = bytesPerSampleForBitDepth(bitDepth)
         val usbBytesPerSample = target.usbBytesPerSample
         val usbBitResolution = target.usbBitResolution ?: (usbBytesPerSample * 8)
-        Log.i(
+        UsbDiagnostics.i(
             tag,
             "USB PCM packetizer sampleRate=$sampleRate, channels=$channels, " +
                 "decoderBitDepth=$bitDepth, inputBytesPerSample=$inputBytesPerSample, " +
@@ -764,14 +763,14 @@ class UsbExclusiveAudioEngine(
         val outputIntervalMicroframes = isoIntervalMicroframes(target.endpoint.interval)
         val feedbackOutputPacketDivisor = target.feedbackEndpoint?.let {
             val feedbackIntervalMicroframes = isoIntervalMicroframes(it.interval)
-            Log.i(
+            UsbDiagnostics.i(
                 tag,
                 "USB feedback intervals outputMicroframes=$outputIntervalMicroframes, " +
                     "feedbackMicroframes=$feedbackIntervalMicroframes",
             )
             1
         } ?: 1
-        Log.i(
+        UsbDiagnostics.i(
             tag,
             "USB feedback scaling outputIntervalMicroframes=$outputIntervalMicroframes, " +
                 "feedbackDivisor=$feedbackOutputPacketDivisor, feedback=${target.feedbackEndpointLabel}",
@@ -837,7 +836,7 @@ class UsbExclusiveAudioEngine(
                     data.size,
                     1000,
                 )
-                Log.i(
+                UsbDiagnostics.i(
                     tag,
                     "UAC2 clock SET_CUR sampleRate=$sampleRate, clockSourceId=$clockSourceId, " +
                     "controlInterface=$controlInterfaceNumber, result=$result",
@@ -865,14 +864,14 @@ class UsbExclusiveAudioEngine(
                 data.size,
                 1000,
             )
-            Log.i(
+            UsbDiagnostics.i(
                 tag,
                 "UAC1 endpoint SET_CUR sampleRate=$sampleRate, endpoint=0x${
                     target.endpoint.address.toString(16)
                 }, result=$result",
             )
         } catch (error: RuntimeException) {
-            Log.w(tag, "USB audio clock configuration failed.", error)
+            UsbDiagnostics.w(tag, "USB audio clock configuration failed.", error)
         } finally {
             if (claimedControl && controlInterface != null) {
                 runCatching { connection.releaseInterface(controlInterface) }
@@ -904,7 +903,7 @@ class UsbExclusiveAudioEngine(
         } else {
             null
         }
-        Log.i(
+        UsbDiagnostics.i(
             tag,
             "UAC2 clock GET_CUR $label result=$result, clockSourceId=$clockSourceId, " +
                 "controlInterface=$controlInterfaceNumber, sampleRate=${sampleRate ?: "n/a"}, " +
@@ -954,13 +953,10 @@ class UsbExclusiveAudioEngine(
         return -1
     }
 
-    private fun findOutputTarget(
+    private fun collectOutputCandidates(
         device: UsbDevice,
-        streamingFormats: Map<Pair<Int, Int>, StreamingFormatInfo> = emptyMap(),
-        sampleRate: Int? = null,
-        channels: Int = 2,
-        bitDepth: Int? = null,
-    ): OutputTarget? {
+        streamingFormats: Map<Pair<Int, Int>, StreamingFormatInfo>,
+    ): List<OutputTarget> {
         val candidates = mutableListOf<OutputTarget>()
         for (index in 0 until device.interfaceCount) {
             val usbInterface = device.getInterface(index)
@@ -987,6 +983,93 @@ class UsbExclusiveAudioEngine(
                 }
             }
         }
+        return candidates
+    }
+
+    /**
+     * 汇总诊断报告所需的“App 解析结果”部分（原始描述符、AS 格式、输出候选、UAC2 时钟源）。
+     * 只在有权限时临时打开设备读取描述符，读完即关，不影响正在进行的独占播放。
+     */
+    fun collectDiagnostics(usbManager: UsbManager, device: UsbDevice?): Map<String, Any?> {
+        if (device == null) {
+            return mapOf("available" to false, "message" to "未检测到 USB 音频设备。")
+        }
+        if (!usbManager.hasPermission(device)) {
+            return mapOf(
+                "available" to false,
+                "permissionGranted" to false,
+                "message" to "未授权，无法读取描述符。",
+            )
+        }
+
+        val connection = usbManager.openDevice(device)
+            ?: return mapOf(
+                "available" to false,
+                "permissionGranted" to true,
+                "message" to "无法打开 USB 设备读取描述符。",
+            )
+
+        return try {
+            val descriptors = connection.rawDescriptors
+            val streamingFormats = parseStreamingFormatInfo(descriptors)
+            val candidates = collectOutputCandidates(device, streamingFormats)
+                .sortedWith(compareBy<OutputTarget> { it.endpoint.maxPacketSize }.thenBy { it.alternateSetting })
+            val clockSourceId = candidates.firstOrNull()?.let {
+                findUac2ClockSourceId(descriptors, it.usbInterface.id, it.alternateSetting)
+            }
+            mapOf(
+                "available" to true,
+                "permissionGranted" to true,
+                "rawDescriptorLength" to (descriptors?.size ?: 0),
+                "rawDescriptorsHex" to descriptors?.let { hexDump(it) },
+                "streamingFormats" to streamingFormats.values
+                    .sortedWith(compareBy<StreamingFormatInfo> { it.interfaceNumber }.thenBy { it.alternateSetting })
+                    .map { it.toString() },
+                "outputCandidates" to candidates.map { candidate ->
+                    "alt=${candidate.alternateSetting}/max=${candidate.endpoint.maxPacketSize}/" +
+                        "outAttr=0x${candidate.endpoint.attributes.toString(16)}/" +
+                        "interval=${candidate.endpoint.interval}/" +
+                        "feedback=${candidate.feedbackEndpointLabel}/" +
+                        "usbBytes=${candidate.usbBytesPerSample}/bits=${candidate.usbBitResolution}/" +
+                        "format=${candidate.formatInfo}"
+                },
+                "clockSourceId" to clockSourceId,
+            )
+        } catch (error: RuntimeException) {
+            mapOf(
+                "available" to false,
+                "permissionGranted" to true,
+                "message" to "读取描述符失败：${error.message}",
+            )
+        } finally {
+            connection.close()
+        }
+    }
+
+    private fun hexDump(bytes: ByteArray): String {
+        val builder = StringBuilder(bytes.size * 3)
+        for (index in bytes.indices) {
+            if (index % 16 == 0) {
+                if (index != 0) {
+                    builder.append('\n')
+                }
+                builder.append(String.format(Locale.US, "%04x: ", index))
+            } else {
+                builder.append(' ')
+            }
+            builder.append(String.format(Locale.US, "%02x", bytes[index].toInt() and 0xff))
+        }
+        return builder.toString()
+    }
+
+    private fun findOutputTarget(
+        device: UsbDevice,
+        streamingFormats: Map<Pair<Int, Int>, StreamingFormatInfo> = emptyMap(),
+        sampleRate: Int? = null,
+        channels: Int = 2,
+        bitDepth: Int? = null,
+    ): OutputTarget? {
+        val candidates = collectOutputCandidates(device, streamingFormats)
 
         if (candidates.isEmpty()) {
             return null
@@ -1039,14 +1122,14 @@ class UsbExclusiveAudioEngine(
             selected.usbBytesPerSample,
         )
         if (selected.endpoint.maxPacketSize < selectedRequiredPacketBytes) {
-            Log.w(
+            UsbDiagnostics.w(
                 tag,
                 "selected USB alt may be too small: requiredPacketBytes=$selectedRequiredPacketBytes, " +
                     "selectedMaxPacket=${selected.endpoint.maxPacketSize}, sampleRate=$sampleRate, " +
                     "channels=$channels, bitDepth=${bitDepth ?: "auto"}",
             )
         }
-        Log.i(
+        UsbDiagnostics.i(
             tag,
             "selected USB alt=${selected.alternateSetting}, maxPacket=${selected.endpoint.maxPacketSize}, " +
                 "requiredPacketBytes=$selectedRequiredPacketBytes, " +
@@ -1083,7 +1166,7 @@ class UsbExclusiveAudioEngine(
 
     private fun parseStreamingFormatInfo(descriptors: ByteArray?): Map<Pair<Int, Int>, StreamingFormatInfo> {
         if (descriptors == null) {
-            Log.w(tag, "USB raw descriptors unavailable; cannot parse AS format descriptors.")
+            UsbDiagnostics.w(tag, "USB raw descriptors unavailable; cannot parse AS format descriptors.")
             return emptyMap()
         }
 
@@ -1163,7 +1246,7 @@ class UsbExclusiveAudioEngine(
             offset += length
         }
 
-        Log.i(
+        UsbDiagnostics.i(
             tag,
             "USB AS formats parsed: ${formats.values.sortedWith(
                 compareBy<StreamingFormatInfo> { it.interfaceNumber }.thenBy { it.alternateSetting },
@@ -1243,7 +1326,7 @@ class UsbExclusiveAudioEngine(
         val result = linkedTerminal?.let {
             inputTerminalClockIds[it] ?: outputTerminalClockIds[it]
         } ?: firstClockSourceId
-        Log.i(
+        UsbDiagnostics.i(
             tag,
             "parsed UAC2 clock source: streamingInterface=$streamingInterfaceNumber, " +
                 "alt=$streamingAlternateSetting, terminalLink=$terminalLink, clockSourceId=$result",
@@ -1472,7 +1555,7 @@ class UsbExclusiveAudioEngine(
                 }
                 if (packetLogCount < 5) {
                     ++packetLogCount
-                    Log.d(
+                    UsbDiagnostics.d(
                         "UsbExclusiveAudioEngine",
                         "USB PCM packet bytes=${packet.size}, filled=$length",
                     )
@@ -1519,7 +1602,7 @@ class UsbExclusiveAudioEngine(
                     }
                 } else if (feedbackRejectLogCount < 8) {
                     ++feedbackRejectLogCount
-                    Log.w(
+                    UsbDiagnostics.w(
                         "UsbExclusiveAudioEngine",
                         "USB feedback ignored outputFrames=${q16ToFrames(outputFeedbackQ16)}, " +
                             "nominalFrames=${q16ToFrames(nominalFramesQ16)}, " +
@@ -1594,7 +1677,7 @@ class UsbExclusiveAudioEngine(
                 sumAbs += kotlin.math.abs(sample.toLong())
             }
             val averageAbs = if (samplesToInspect > 0) sumAbs / samplesToInspect else 0
-            Log.i(
+            UsbDiagnostics.i(
                 "UsbExclusiveAudioEngine",
                 "USB PCM preview reason=$reason, inputBytes=${input.size}, convertedBytes=${converted.size}, frames=$frames, " +
                     "inputBitDepth=$inputBitDepth, usbBytesPerSample=$usbBytesPerSample, " +

--- a/android/app/src/main/res/xml/usb_audio_device_filter.xml
+++ b/android/app/src/main/res/xml/usb_audio_device_filter.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Standard USB Audio Class devices. -->
+    <usb-device class="1" />
+
+    <!-- iBasso Macaron fallback for devices that do not expose class at device level. -->
+    <usb-device vendor-id="9770" product-id="6667" />
+</resources>

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -2,6 +2,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        maven("https://jitpack.io")
     }
 }
 

--- a/docs/usb-output-settings-status.md
+++ b/docs/usb-output-settings-status.md
@@ -1,0 +1,44 @@
+# USB 输出设置接入状态
+
+本文档记录 `USB 输出设置` 页面里哪些项目已经接入真实链路，哪些只是先放在 UI 和偏好层，作为后续 USB 独占链路改造的参考。
+
+## 已接入运行链路
+
+| 项目 | 状态 | 说明 |
+| --- | --- | --- |
+| Android USB 插入声明 | 已接入 | `AndroidManifest.xml` 已声明 `android.hardware.usb.action.USB_DEVICE_ATTACHED`，`usb_audio_device_filter.xml` 已包含 USB Audio Class 和 Macaron VID/PID。`dumpsys usb` 能看到 `com.afalphy.sylvakru.debug` 注册到 `device_attached_activities`。 |
+| USB 设备识别 | 已接入 | 通过 Android 侧 USB/AudioDevice 状态回传，设置页能显示 DAC 名称、USB ID、系统输出设备、采样率和编码等信息。 |
+| USB 权限与独占诊断 | 已接入 | `probeExclusiveAccess()` 会检查 USB 权限、Audio Interface 数量、claim 能力和原始描述符长度。 |
+| 固定采样率输出 | 部分接入 | 偏好已用于 `preferredExclusiveSampleRate()` 和系统 preferred output 请求；真实独占写流仍要看底层能力是否支持对应采样率。 |
+| PCM 位深偏好 | 部分接入 | `UsbAudioPreferences.preferredEncoding()` 会把 `16/24/32 bits` 映射到 Android PCM encoding，用于输出偏好请求。 |
+| USB 独占播放状态 | 已接入快照 | `UsbExclusivePlaybackState` 会由 start/pause/resume/seek/stop 等 native 调用回传，页面监听这个 notifier 展示当前快照。它不是连续实时水位。 |
+| 后台保活 | 已接入偏好 | 偏好已持久化，并用于 App 内 USB 输出策略判断；是否能完全防止系统杀后台取决于系统电池策略。 |
+| 播放后释放 USB 带宽 | 已接入偏好 | 偏好已保存，供停止播放后释放 USB 资源策略使用。 |
+| DSD 模式和 DSD 转 PCM 采样率 | 已接入偏好 | `PCM / DoP / Native` 和 DSD64/128/256/512 转 PCM 目标采样率均已持久化。底层 Native DSD/DoP 是否真正输出取决于后续独占链路实现。 |
+| 音量锁定和 DSD 增益补偿 | 已接入偏好 | 设置已持久化，供播放链路读取；硬件音量实时检测暂未接入。 |
+
+## 参考或占位项
+
+| 项目 | 状态 | 当前用途 |
+| --- | --- | --- |
+| 位深兼容 | UI/偏好占位 | 可保存，用于后续在独占链路里按 DAC 能力回退位深。当前不直接改变 PCM 数据写入。 |
+| 采样率兼容 | UI/偏好占位 | 可保存，用于后续按 DAC 支持列表自动回退采样率。当前主要还是固定采样率和系统 preferred output 在生效。 |
+| 声道兼容 | UI/偏好占位 | 可保存，用于后续处理单声道/多声道回退。当前不做实际声道重排。 |
+| TPDF 抖动 | UI/偏好占位 | 可保存，但当前没有接入高位深转 16-bit 的音频处理链路。 |
+| 前台缓冲区 / 后台缓冲区 | UI/偏好占位 | 可保存，并用于设置页显示目标水位；当前未接入底层 USB isochronous 写入队列。 |
+| 音量平滑交接 | UI/偏好占位 | 可保存，用于后续数字音量和 DAC 硬件音量切换时做淡入淡出。当前没有实时硬件音量检测。 |
+| 延迟建立 USB 输出链路 | UI/偏好占位 | 可保存，用于后续把 claim/open endpoint 推迟到播放开始。当前不改变建链时机。 |
+| USB 总线速度 | UI/偏好占位 | 可保存，用于后续诊断或策略选择。普通 Android App 通常不能强制 USB bus speed。 |
+| DAC 端点格式 | 信息占位 | 无独占播放时显示系统/设备能力；真实 endpoint alt setting 需要底层能力解析后再展示。 |
+
+## 传输状态卡说明
+
+传输状态卡现在按快照表达，不再伪装成实时仪表：
+
+- 主数值：`UsbExclusivePlaybackState.position`，目前代表 native 回传的播放/水位快照。
+- 状态：`active + playing` 显示为稳定，`active + !playing` 显示为暂停，否则为待机。
+- ISO：当前没有底层 isochronous 传输实时计数，固定显示 `ISO 0`。
+- 目标：来自前台缓冲区偏好，默认 `200 ms`，只作为目标水位参考。
+- 最低：当前没有底层最低水位统计，播放中暂用本次快照值；待机显示 `最低 --`。
+
+如果后续要让它真正实时，需要 native 层周期性上报 USB 写入队列水位、iso packet 计数、underrun 次数和最低水位，再更新 `UsbExclusivePlaybackState` 或新增专门的传输 telemetry notifier。

--- a/lib/base/audio_handler.dart
+++ b/lib/base/audio_handler.dart
@@ -795,12 +795,7 @@ class MyAudioHandler extends BaseAudioHandler with WidgetsBindingObserver {
   }
 
   int? _preferredExclusiveBitDepth() {
-    return switch (usbAudioPreferences.bitDepthModeNotifier.value) {
-      UsbBitDepthMode.pcm16 => 24,
-      UsbBitDepthMode.pcm24 => 24,
-      UsbBitDepthMode.pcm32 => 24,
-      UsbBitDepthMode.auto => 24,
-    };
+    return preferredUsbExclusiveBitDepth();
   }
 
   int? _preferredExclusiveSampleRate(MyAudioMetadata song) {

--- a/lib/base/audio_handler.dart
+++ b/lib/base/audio_handler.dart
@@ -66,11 +66,20 @@ Future<void> initAudioService() async {
   }
 
   _session.becomingNoisyEventStream.listen((_) {
+    debugPrint(
+      "audio session becoming noisy; usbExclusiveActive=${audioHandler._usbExclusiveActive}",
+    );
+    if (audioHandler._usbExclusiveActive) {
+      return;
+    }
     audioHandler.pause();
   });
 
   _session.interruptionEventStream.listen((event) {
-    if (event.begin) {
+    debugPrint(
+      "audio session interruption begin=${event.begin}; usbExclusiveActive=${audioHandler._usbExclusiveActive}",
+    );
+    if (event.begin && !audioHandler._usbExclusiveActive) {
       audioHandler.pause();
     }
   });
@@ -87,6 +96,7 @@ class MyAudioHandler extends BaseAudioHandler {
   Duration _playedDuration = Duration.zero;
   Duration _usbExclusivePosition = Duration.zero;
   bool _usbExclusiveActive = false;
+  bool _suppressPlayerCompleted = false;
 
   late final File _playQueueState;
   late final File _playState;
@@ -109,6 +119,9 @@ class MyAudioHandler extends BaseAudioHandler {
     });
 
     _player.stream.completed.listen((completed) async {
+      if (_suppressPlayerCompleted) {
+        return;
+      }
       if (completed) {
         final position = _player.state.position;
         final duration = _player.state.duration;
@@ -205,6 +218,17 @@ class MyAudioHandler extends BaseAudioHandler {
 
     if (wasActive && state.message?.contains('completed') == true) {
       unawaited(skipToNext());
+    }
+  }
+
+  Future<void> _stopPlayerForUsbExclusive() async {
+    _suppressPlayerCompleted = true;
+    try {
+      await _player.stop();
+    } finally {
+      scheduleMicrotask(() {
+        _suppressPlayerCompleted = false;
+      });
     }
   }
 
@@ -559,46 +583,51 @@ class MyAudioHandler extends BaseAudioHandler {
 
       final openedExclusive = await _tryOpenUsbExclusive(currentSong);
       if (openedExclusive) {
-        _player.stop();
+        await _stopPlayerForUsbExclusive();
         if (isPlayingNotifier.value) {
           _playLastSyncTime = DateTime.now();
         }
-      } else if (currentSong.cacheExist) {
-        await _player.open(
-          Media(currentSong.cachePath!),
-          play: isPlayingNotifier.value,
-        );
       } else {
-        String? resource;
-        bool needHeader = false;
-        switch (currentSong.sourceType) {
-          case .webdav:
-            final tmpPath = await convertToRealPathIfNeed(currentSong.path!);
-            if (tmpPath == null) {
-              needHeader = true;
-            } else {
-              resource = tmpPath;
-            }
-            break;
-          case .navidrome:
-            currentSong.path ??= navidromeClient!.getStreamUrl(currentSong.id);
-            break;
-          case .emby:
-            currentSong.path ??= embyClient!.audioUrl(currentSong.id);
-            break;
-          default:
-            break;
+        await _applyUsbOutputForSong(currentSong);
+        if (currentSong.cacheExist) {
+          await _player.open(
+            Media(currentSong.cachePath!),
+            play: isPlayingNotifier.value,
+          );
+        } else {
+          String? resource;
+          bool needHeader = false;
+          switch (currentSong.sourceType) {
+            case .webdav:
+              final tmpPath = await convertToRealPathIfNeed(currentSong.path!);
+              if (tmpPath == null) {
+                needHeader = true;
+              } else {
+                resource = tmpPath;
+              }
+              break;
+            case .navidrome:
+              currentSong.path ??= navidromeClient!.getStreamUrl(
+                currentSong.id,
+              );
+              break;
+            case .emby:
+              currentSong.path ??= embyClient!.audioUrl(currentSong.id);
+              break;
+            default:
+              break;
+          }
+
+          resource ??= currentSong.path!;
+
+          await _player.open(
+            Media(
+              resource,
+              httpHeaders: needHeader ? webdavClient?.headers : null,
+            ),
+            play: isPlayingNotifier.value,
+          );
         }
-
-        resource ??= currentSong.path!;
-
-        await _player.open(
-          Media(
-            resource,
-            httpHeaders: needHeader ? webdavClient?.headers : null,
-          ),
-          play: isPlayingNotifier.value,
-        );
       }
 
       if (isPlayingNotifier.value) {
@@ -627,8 +656,23 @@ class MyAudioHandler extends BaseAudioHandler {
     }
 
     final capability = await usbAudioService.getExclusiveCapabilities();
-    if (!capability.available || !capability.permissionGranted) {
-      logger.output("usb exclusive unavailable:${capability.message}");
+    var exclusiveCapability = capability;
+    if (exclusiveCapability.available &&
+        !exclusiveCapability.permissionGranted) {
+      logger.output(
+        "usb exclusive requesting permission:${exclusiveCapability.message}",
+      );
+      debugPrint(
+        "usb exclusive requesting permission:${exclusiveCapability.message}",
+      );
+      await usbAudioService.probeExclusiveAccess();
+      exclusiveCapability = await usbAudioService.getExclusiveCapabilities();
+    }
+
+    if (!exclusiveCapability.available ||
+        !exclusiveCapability.permissionGranted) {
+      logger.output("usb exclusive unavailable:${exclusiveCapability.message}");
+      debugPrint("usb exclusive unavailable:${exclusiveCapability.message}");
       return false;
     }
 
@@ -641,6 +685,7 @@ class MyAudioHandler extends BaseAudioHandler {
       UsbExclusivePlaybackRequest(
         filePath: filePath,
         title: getTitle(song),
+        sourceFormat: _normalizedExclusiveFormat(song),
         sampleRate: _preferredExclusiveSampleRate(song),
         bitDepth: _preferredExclusiveBitDepth(),
         startPaused: !isPlayingNotifier.value,
@@ -649,31 +694,46 @@ class MyAudioHandler extends BaseAudioHandler {
 
     if (!state.active) {
       logger.output("usb exclusive fallback:${state.message}");
+      debugPrint("usb exclusive fallback:${state.message}");
       return false;
     }
 
     _usbExclusiveActive = true;
     _usbExclusivePosition = state.position;
+    updateIsPlaying(state.playing);
+    updatePlaybackState(postion: state.position);
+    debugPrint(
+      "usb exclusive opened: active=${state.active}, playing=${state.playing}, position=${state.position.inMilliseconds}",
+    );
     return true;
   }
 
   bool _shouldTryUsbExclusive(MyAudioMetadata song) {
-    if (!Platform.isAndroid ||
-        !usbAudioPreferences.performanceModeNotifier.value) {
+    if (!Platform.isAndroid) {
+      logger.output("usb exclusive skipped:not android");
+      debugPrint("usb exclusive skipped:not android");
       return false;
     }
-    return _isUsbExclusiveSupportedFormat(song);
+    if (!usbAudioPreferences.performanceModeNotifier.value) {
+      logger.output("usb exclusive skipped:performance mode off");
+      debugPrint("usb exclusive skipped:performance mode off");
+      return false;
+    }
+    return true;
   }
 
-  bool _isUsbExclusiveSupportedFormat(MyAudioMetadata song) {
+  String? _normalizedExclusiveFormat(MyAudioMetadata song) {
     final format = song.format?.toLowerCase().trim();
-    if (format == 'flac' || format == 'wav' || format == 'wave') {
-      return true;
+    if (format != null && format.isNotEmpty) {
+      if (format.contains('flac')) return 'flac';
+      if (format.contains('wav') || format.contains('wave')) return 'wav';
+      return format;
     }
+
     final path = (song.cachePath ?? song.path ?? '').toLowerCase();
-    return path.endsWith('.flac') ||
-        path.endsWith('.wav') ||
-        path.endsWith('.wave');
+    if (path.endsWith('.flac')) return 'flac';
+    if (path.endsWith('.wav') || path.endsWith('.wave')) return 'wav';
+    return null;
   }
 
   Future<String?> _exclusivePlayablePath(MyAudioMetadata song) async {
@@ -700,15 +760,116 @@ class MyAudioHandler extends BaseAudioHandler {
 
   int? _preferredExclusiveBitDepth() {
     return switch (usbAudioPreferences.bitDepthModeNotifier.value) {
-      UsbBitDepthMode.pcm16 => 16,
+      UsbBitDepthMode.pcm16 => 24,
       UsbBitDepthMode.pcm24 => 24,
-      UsbBitDepthMode.pcm32 => 32,
-      UsbBitDepthMode.auto => null,
+      UsbBitDepthMode.pcm32 => 24,
+      UsbBitDepthMode.auto => 24,
     };
   }
 
   int? _preferredExclusiveSampleRate(MyAudioMetadata song) {
-    return usbAudioPreferences.preferredFixedSampleRate() ?? song.samplerate;
+    return usbAudioPreferences.preferredFixedSampleRate() ??
+        _matchedSafeSampleRate(song.samplerate);
+  }
+
+  Future<void> _applyUsbOutputForSong(MyAudioMetadata song) async {
+    if (!Platform.isAndroid ||
+        !usbAudioPreferences.performanceModeNotifier.value) {
+      return;
+    }
+
+    try {
+      final status = await usbAudioService.refreshStatus();
+      final sampleRate = _preferredSystemUsbSampleRate(status, song);
+      logger.output(
+        "usb output apply song samplerate=${song.samplerate}, request=$sampleRate",
+      );
+      debugPrint(
+        "usb output apply song samplerate=${song.samplerate}, request=$sampleRate",
+      );
+      await usbAudioService.applyPreferredOutput(
+        deviceId: status.bestAvailableDeviceId,
+        sampleRate: sampleRate,
+        encoding: usbAudioPreferences.preferredEncoding(),
+      );
+    } catch (error) {
+      logger.output("usb output apply failed:$error");
+      debugPrint("usb output apply failed:$error");
+    }
+  }
+
+  int? _matchedSafeSampleRate(int? sourceSampleRate) {
+    if (sourceSampleRate == null || sourceSampleRate <= 0) {
+      return null;
+    }
+
+    final supportedRates = UsbAudioPreferences.sampleRates;
+    if (supportedRates.contains(sourceSampleRate)) {
+      return sourceSampleRate;
+    }
+
+    final sameFamilyRates =
+        supportedRates.where((rate) => sourceSampleRate % rate == 0).toList()
+          ..sort();
+    if (sameFamilyRates.isNotEmpty) {
+      return sameFamilyRates.last;
+    }
+
+    return supportedRates
+        .where((rate) => rate <= sourceSampleRate)
+        .fold<int?>(
+          null,
+          (best, rate) => best == null || rate > best ? rate : best,
+        );
+  }
+
+  int? _preferredSystemUsbSampleRate(
+    UsbAudioStatus status,
+    MyAudioMetadata song,
+  ) {
+    final fixedRate = usbAudioPreferences.preferredFixedSampleRate();
+    if (fixedRate != null) {
+      return fixedRate;
+    }
+
+    final matchedSourceRate = _matchedSafeSampleRate(song.samplerate);
+    if (matchedSourceRate != null &&
+        _statusSupportsSampleRate(status, matchedSourceRate)) {
+      return matchedSourceRate;
+    }
+    return _bestSystemUsbSampleRate(status);
+  }
+
+  bool _statusSupportsSampleRate(UsbAudioStatus status, int sampleRate) {
+    final deviceId = status.bestAvailableDeviceId;
+    for (final device in status.devices) {
+      if (device.id != deviceId) {
+        continue;
+      }
+      final rates = device.supportedMixerSampleRates.isNotEmpty
+          ? device.supportedMixerSampleRates
+          : device.sampleRates;
+      return rates.contains(sampleRate);
+    }
+    return false;
+  }
+
+  int? _bestSystemUsbSampleRate(UsbAudioStatus status) {
+    final deviceId = status.bestAvailableDeviceId;
+    for (final device in status.devices) {
+      if (device.id != deviceId) {
+        continue;
+      }
+      final rates = device.supportedMixerSampleRates.isNotEmpty
+          ? device.supportedMixerSampleRates
+          : device.sampleRates;
+      final validRates = rates
+          .where(UsbAudioPreferences.sampleRates.contains)
+          .toList()
+        ..sort();
+      return validRates.isEmpty ? status.bestAvailableSampleRate : validRates.last;
+    }
+    return status.bestAvailableSampleRate;
   }
 
   void updateServiceMediaItem(MyAudioMetadata currentSong) {
@@ -734,22 +895,41 @@ class MyAudioHandler extends BaseAudioHandler {
   Future<void> play() async {
     if (playQueue.isEmpty) return;
     if (_usbExclusiveActive) {
+      debugPrint(
+        "usb exclusive resume requested: playing=${isPlayingNotifier.value}, position=${_usbExclusivePosition.inMilliseconds}",
+      );
       final state = await usbAudioService.resumeExclusivePlayback();
+      debugPrint(
+        "usb exclusive resume result: active=${state.active}, playing=${state.playing}, position=${state.position.inMilliseconds}, message=${state.message}",
+      );
       updateIsPlaying(state.playing);
       unawaited(_superLyricPublisher.publishAt(state.position));
       updatePlaybackState(postion: state.position);
       return;
     }
 
+    final currentSong = playQueue[currentIndex];
+    updateIsPlaying(true);
+    final openedExclusive = await _tryOpenUsbExclusive(currentSong);
+    if (openedExclusive) {
+      await _stopPlayerForUsbExclusive();
+      unawaited(_superLyricPublisher.publishAt(_usbExclusivePosition));
+      updatePlaybackState(postion: _usbExclusivePosition);
+      return;
+    }
+
+    await _applyUsbOutputForSong(currentSong);
     _player.play();
 
-    updateIsPlaying(true);
     unawaited(_superLyricPublisher.publishAt(_player.state.position));
     updatePlaybackState();
   }
 
   @override
   Future<void> pause() async {
+    debugPrint(
+      "audio handler pause requested: usbExclusiveActive=$_usbExclusiveActive, playing=${isPlayingNotifier.value}",
+    );
     if (_usbExclusiveActive) {
       final state = await usbAudioService.pauseExclusivePlayback();
       unawaited(SuperLyricBridge.sendStop());

--- a/lib/base/audio_handler.dart
+++ b/lib/base/audio_handler.dart
@@ -8,6 +8,7 @@ import 'package:media_kit/media_kit.dart';
 import 'package:sylvakru/base/services/emby_client.dart';
 import 'package:sylvakru/base/services/metadata_service.dart';
 import 'package:sylvakru/base/services/super_lyric_bridge.dart';
+import 'package:sylvakru/base/services/super_lyric_position_publisher.dart';
 import 'package:sylvakru/base/services/webdav_client.dart';
 import 'package:sylvakru/base/services/color_manager.dart';
 import 'package:sylvakru/base/app.dart';
@@ -60,11 +61,7 @@ Future<void> initAudioService() async {
 
   final usbAudioStatus = await usbAudioService.refreshStatus();
   if (usbAudioStatus.supported) {
-    final optimizedStatus = await usbAudioService.applyPreferredOutput(
-      deviceId: usbAudioStatus.bestAvailableDeviceId,
-      sampleRate: usbAudioStatus.bestAvailableSampleRate,
-    );
-    logger.output("usb audio:${optimizedStatus.message}");
+    logger.output("usb audio:${usbAudioStatus.message}");
   }
 
   _session.becomingNoisyEventStream.listen((_) {
@@ -80,6 +77,7 @@ Future<void> initAudioService() async {
 
 class MyAudioHandler extends BaseAudioHandler {
   final _player = Player();
+  late final SuperLyricPositionPublisher _superLyricPublisher;
   bool _started = false;
   int currentIndex = -1;
   List<MyAudioMetadata> _playQueueTmp = [];
@@ -95,6 +93,11 @@ class MyAudioHandler extends BaseAudioHandler {
   bool isSyncing = false;
 
   MyAudioHandler() {
+    _superLyricPublisher = SuperLyricPositionPublisher(
+      sendLyricLine: SuperLyricBridge.sendLyricLine,
+      sendStop: SuperLyricBridge.sendStop,
+    );
+
     // avoid reading .lrc files
     (_player.platform as NativePlayer).setProperty('sub-auto', 'no');
 
@@ -140,6 +143,10 @@ class MyAudioHandler extends BaseAudioHandler {
       if (isLoading || isSyncing) {
         return;
       }
+      if (!isPlayingNotifier.value) {
+        return;
+      }
+      unawaited(_superLyricPublisher.publishAt(position));
     });
   }
 
@@ -510,6 +517,7 @@ class MyAudioHandler extends BaseAudioHandler {
     final currentSong = playQueue[currentIndex];
 
     await _setLyricsAndUpdateColors(currentSong);
+    _superLyricPublisher.updateLines(currentSong.parsedLyrics!.lines);
 
     currentSongNotifier.value = currentSong;
 
@@ -564,6 +572,12 @@ class MyAudioHandler extends BaseAudioHandler {
 
     updateServiceMediaItem(currentSong);
 
+    if (isPlayingNotifier.value) {
+      unawaited(_superLyricPublisher.publishAt(Duration.zero));
+    } else {
+      _superLyricPublisher.reset();
+      unawaited(SuperLyricBridge.sendStop());
+    }
     updatePlaybackState(postion: Duration.zero);
   }
 
@@ -592,6 +606,7 @@ class MyAudioHandler extends BaseAudioHandler {
     _player.play();
 
     updateIsPlaying(true);
+    unawaited(_superLyricPublisher.publishAt(_player.state.position));
     updatePlaybackState();
   }
 
@@ -599,6 +614,7 @@ class MyAudioHandler extends BaseAudioHandler {
   Future<void> pause() async {
     _player.pause();
     unawaited(SuperLyricBridge.sendStop());
+    _superLyricPublisher.reset();
     updateIsPlaying(false);
     updatePlaybackState();
   }
@@ -607,6 +623,7 @@ class MyAudioHandler extends BaseAudioHandler {
   Future<void> stop() async {
     _player.stop();
     unawaited(SuperLyricBridge.sendStop());
+    _superLyricPublisher.reset();
     updateIsPlaying(false);
     updatePlaybackState(stop: true);
   }
@@ -617,6 +634,9 @@ class MyAudioHandler extends BaseAudioHandler {
     await _player.seek(position);
     // ensure position is updated
     await Future.delayed(Duration(milliseconds: 50));
+    if (isPlayingNotifier.value) {
+      unawaited(_superLyricPublisher.publishAt(position));
+    }
     updateLyricsNotifier.value++;
   }
 

--- a/lib/base/audio_handler.dart
+++ b/lib/base/audio_handler.dart
@@ -23,6 +23,7 @@ import 'package:sylvakru/base/utils/contrast_color_generator.dart';
 import 'package:sylvakru/base/data/library.dart';
 import 'package:sylvakru/base/my_audio_metadata.dart';
 import 'package:sylvakru/base/services/navidrome_client.dart';
+import 'package:sylvakru/base/services/usb_audio_preferences.dart';
 import 'package:sylvakru/base/services/usb_audio_service.dart';
 import 'package:sylvakru/base/utils/metadata_utils.dart';
 import 'package:sylvakru/mini_view/mini_view.dart';
@@ -84,6 +85,8 @@ class MyAudioHandler extends BaseAudioHandler {
   int _tmpPlayMode = 0;
   DateTime? _playLastSyncTime;
   Duration _playedDuration = Duration.zero;
+  Duration _usbExclusivePosition = Duration.zero;
+  bool _usbExclusiveActive = false;
 
   late final File _playQueueState;
   late final File _playState;
@@ -148,6 +151,8 @@ class MyAudioHandler extends BaseAudioHandler {
       }
       unawaited(_superLyricPublisher.publishAt(position));
     });
+
+    usbExclusivePlaybackStateNotifier.addListener(_handleUsbExclusiveState);
   }
 
   void updateIsPlaying(bool isPlaying) {
@@ -162,6 +167,9 @@ class MyAudioHandler extends BaseAudioHandler {
   }
 
   void updatePlaybackState({Duration? postion, bool stop = false}) {
+    final position =
+        postion ??
+        (_usbExclusiveActive ? _usbExclusivePosition : _player.state.position);
     playbackState.add(
       PlaybackState(
         controls: [
@@ -172,10 +180,32 @@ class MyAudioHandler extends BaseAudioHandler {
         systemActions: {MediaAction.seek},
         playing: isPlayingNotifier.value,
         processingState: stop ? .idle : .ready,
-        speed: _player.state.rate,
-        updatePosition: postion ?? _player.state.position,
+        speed: _usbExclusiveActive ? 1.0 : _player.state.rate,
+        updatePosition: position,
       ),
     );
+  }
+
+  void _handleUsbExclusiveState() {
+    final state = usbExclusivePlaybackStateNotifier.value;
+    final wasActive = _usbExclusiveActive;
+    _usbExclusivePosition = state.position;
+    _usbExclusiveActive = state.active;
+
+    if (state.active) {
+      if (isPlayingNotifier.value != state.playing) {
+        updateIsPlaying(state.playing);
+      }
+      updatePlaybackState(postion: state.position);
+      if (state.playing) {
+        unawaited(_superLyricPublisher.publishAt(state.position));
+      }
+      return;
+    }
+
+    if (wasActive && state.message?.contains('completed') == true) {
+      unawaited(skipToNext());
+    }
   }
 
   void initStateFiles() {
@@ -523,7 +553,17 @@ class MyAudioHandler extends BaseAudioHandler {
 
     isLoading = true;
     try {
-      if (currentSong.cacheExist) {
+      await usbAudioService.stopExclusivePlayback();
+      _usbExclusiveActive = false;
+      _usbExclusivePosition = Duration.zero;
+
+      final openedExclusive = await _tryOpenUsbExclusive(currentSong);
+      if (openedExclusive) {
+        _player.stop();
+        if (isPlayingNotifier.value) {
+          _playLastSyncTime = DateTime.now();
+        }
+      } else if (currentSong.cacheExist) {
         await _player.open(
           Media(currentSong.cachePath!),
           play: isPlayingNotifier.value,
@@ -581,6 +621,96 @@ class MyAudioHandler extends BaseAudioHandler {
     updatePlaybackState(postion: Duration.zero);
   }
 
+  Future<bool> _tryOpenUsbExclusive(MyAudioMetadata song) async {
+    if (!_shouldTryUsbExclusive(song)) {
+      return false;
+    }
+
+    final capability = await usbAudioService.getExclusiveCapabilities();
+    if (!capability.available || !capability.permissionGranted) {
+      logger.output("usb exclusive unavailable:${capability.message}");
+      return false;
+    }
+
+    final filePath = await _exclusivePlayablePath(song);
+    if (filePath == null) {
+      return false;
+    }
+
+    final state = await usbAudioService.startExclusivePlayback(
+      UsbExclusivePlaybackRequest(
+        filePath: filePath,
+        title: getTitle(song),
+        sampleRate: _preferredExclusiveSampleRate(song),
+        bitDepth: _preferredExclusiveBitDepth(),
+        startPaused: !isPlayingNotifier.value,
+      ),
+    );
+
+    if (!state.active) {
+      logger.output("usb exclusive fallback:${state.message}");
+      return false;
+    }
+
+    _usbExclusiveActive = true;
+    _usbExclusivePosition = state.position;
+    return true;
+  }
+
+  bool _shouldTryUsbExclusive(MyAudioMetadata song) {
+    if (!Platform.isAndroid ||
+        !usbAudioPreferences.performanceModeNotifier.value) {
+      return false;
+    }
+    return _isUsbExclusiveSupportedFormat(song);
+  }
+
+  bool _isUsbExclusiveSupportedFormat(MyAudioMetadata song) {
+    final format = song.format?.toLowerCase().trim();
+    if (format == 'flac' || format == 'wav' || format == 'wave') {
+      return true;
+    }
+    final path = (song.cachePath ?? song.path ?? '').toLowerCase();
+    return path.endsWith('.flac') ||
+        path.endsWith('.wav') ||
+        path.endsWith('.wave');
+  }
+
+  Future<String?> _exclusivePlayablePath(MyAudioMetadata song) async {
+    if (song.sourceType == .local && song.path != null) {
+      return await convertToRealPathIfNeed(song.path!) ?? song.path;
+    }
+
+    if (song.cacheExist && song.cachePath != null) {
+      return song.cachePath;
+    }
+
+    try {
+      await library.tryAddCache(song);
+    } catch (error) {
+      logger.output("usb exclusive cache failed:$error");
+      return null;
+    }
+
+    if (song.cacheExist && song.cachePath != null) {
+      return song.cachePath;
+    }
+    return null;
+  }
+
+  int? _preferredExclusiveBitDepth() {
+    return switch (usbAudioPreferences.bitDepthModeNotifier.value) {
+      UsbBitDepthMode.pcm16 => 16,
+      UsbBitDepthMode.pcm24 => 24,
+      UsbBitDepthMode.pcm32 => 32,
+      UsbBitDepthMode.auto => null,
+    };
+  }
+
+  int? _preferredExclusiveSampleRate(MyAudioMetadata song) {
+    return usbAudioPreferences.preferredFixedSampleRate() ?? song.samplerate;
+  }
+
   void updateServiceMediaItem(MyAudioMetadata currentSong) {
     Uri? artUri;
 
@@ -603,6 +733,14 @@ class MyAudioHandler extends BaseAudioHandler {
   @override
   Future<void> play() async {
     if (playQueue.isEmpty) return;
+    if (_usbExclusiveActive) {
+      final state = await usbAudioService.resumeExclusivePlayback();
+      updateIsPlaying(state.playing);
+      unawaited(_superLyricPublisher.publishAt(state.position));
+      updatePlaybackState(postion: state.position);
+      return;
+    }
+
     _player.play();
 
     updateIsPlaying(true);
@@ -612,6 +750,15 @@ class MyAudioHandler extends BaseAudioHandler {
 
   @override
   Future<void> pause() async {
+    if (_usbExclusiveActive) {
+      final state = await usbAudioService.pauseExclusivePlayback();
+      unawaited(SuperLyricBridge.sendStop());
+      _superLyricPublisher.reset();
+      updateIsPlaying(state.playing);
+      updatePlaybackState(postion: state.position);
+      return;
+    }
+
     _player.pause();
     unawaited(SuperLyricBridge.sendStop());
     _superLyricPublisher.reset();
@@ -621,6 +768,12 @@ class MyAudioHandler extends BaseAudioHandler {
 
   @override
   Future<void> stop() async {
+    if (_usbExclusiveActive) {
+      await usbAudioService.stopExclusivePlayback();
+      _usbExclusiveActive = false;
+      _usbExclusivePosition = Duration.zero;
+    }
+
     _player.stop();
     unawaited(SuperLyricBridge.sendStop());
     _superLyricPublisher.reset();
@@ -631,6 +784,16 @@ class MyAudioHandler extends BaseAudioHandler {
   @override
   Future<void> seek(Duration position) async {
     updatePlaybackState(postion: position);
+    if (_usbExclusiveActive) {
+      final state = await usbAudioService.seekExclusivePlayback(position);
+      if (isPlayingNotifier.value) {
+        unawaited(_superLyricPublisher.publishAt(state.position));
+      }
+      updateLyricsNotifier.value++;
+      updatePlaybackState(postion: state.position);
+      return;
+    }
+
     await _player.seek(position);
     // ensure position is updated
     await Future.delayed(Duration(milliseconds: 50));

--- a/lib/base/audio_handler.dart
+++ b/lib/base/audio_handler.dart
@@ -86,7 +86,7 @@ Future<void> initAudioService() async {
   });
 }
 
-class MyAudioHandler extends BaseAudioHandler {
+class MyAudioHandler extends BaseAudioHandler with WidgetsBindingObserver {
   final _player = Player();
   late final SuperLyricPositionPublisher _superLyricPublisher;
   bool _started = false;
@@ -173,6 +173,9 @@ class MyAudioHandler extends BaseAudioHandler {
       exclusiveStateListenable: usbExclusivePlaybackStateNotifier,
     );
     usbExclusivePlaybackStateNotifier.addListener(_handleUsbExclusiveState);
+    if (Platform.isAndroid) {
+      WidgetsBinding.instance.addObserver(this);
+    }
   }
 
   void updateIsPlaying(bool isPlaying) {
@@ -237,6 +240,29 @@ class MyAudioHandler extends BaseAudioHandler {
         _suppressPlayerCompleted = false;
       });
     }
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (!_usbExclusiveActive) {
+      return;
+    }
+    final targetBufferMs = _exclusiveTargetBufferMsForLifecycle(state);
+    debugPrint("usb exclusive lifecycle=$state targetBufferMs=$targetBufferMs");
+    unawaited(usbAudioService.setExclusiveTargetBufferMs(targetBufferMs));
+  }
+
+  int _exclusiveTargetBufferMsForLifecycle(AppLifecycleState? state) {
+    return preferredUsbExclusiveTargetBufferMs(
+      background: switch (state) {
+        AppLifecycleState.resumed => false,
+        AppLifecycleState.inactive ||
+        AppLifecycleState.hidden ||
+        AppLifecycleState.paused ||
+        AppLifecycleState.detached => true,
+        null => false,
+      },
+    );
   }
 
   void initStateFiles() {
@@ -695,6 +721,9 @@ class MyAudioHandler extends BaseAudioHandler {
         sourceFormat: _normalizedExclusiveFormat(song),
         sampleRate: _preferredExclusiveSampleRate(song),
         bitDepth: _preferredExclusiveBitDepth(),
+        targetBufferMs: _exclusiveTargetBufferMsForLifecycle(
+          WidgetsBinding.instance.lifecycleState,
+        ),
         startPaused: !isPlayingNotifier.value,
       ),
     );

--- a/lib/base/audio_handler.dart
+++ b/lib/base/audio_handler.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:sylvakru/base/services/emby_client.dart';
 import 'package:sylvakru/base/services/metadata_service.dart';
+import 'package:sylvakru/base/services/playback_position_bridge.dart';
 import 'package:sylvakru/base/services/super_lyric_bridge.dart';
 import 'package:sylvakru/base/services/super_lyric_position_publisher.dart';
 import 'package:sylvakru/base/services/webdav_client.dart';
@@ -97,6 +98,7 @@ class MyAudioHandler extends BaseAudioHandler {
   Duration _usbExclusivePosition = Duration.zero;
   bool _usbExclusiveActive = false;
   bool _suppressPlayerCompleted = false;
+  late final PlaybackPositionBridge _positionBridge;
 
   late final File _playQueueState;
   late final File _playState;
@@ -165,6 +167,11 @@ class MyAudioHandler extends BaseAudioHandler {
       unawaited(_superLyricPublisher.publishAt(position));
     });
 
+    _positionBridge = PlaybackPositionBridge(
+      playerPositionStream: _player.stream.position,
+      playerPosition: () => _player.state.position,
+      exclusiveStateListenable: usbExclusivePlaybackStateNotifier,
+    );
     usbExclusivePlaybackStateNotifier.addListener(_handleUsbExclusiveState);
   }
 
@@ -863,11 +870,12 @@ class MyAudioHandler extends BaseAudioHandler {
       final rates = device.supportedMixerSampleRates.isNotEmpty
           ? device.supportedMixerSampleRates
           : device.sampleRates;
-      final validRates = rates
-          .where(UsbAudioPreferences.sampleRates.contains)
-          .toList()
-        ..sort();
-      return validRates.isEmpty ? status.bestAvailableSampleRate : validRates.last;
+      final validRates =
+          rates.where(UsbAudioPreferences.sampleRates.contains).toList()
+            ..sort();
+      return validRates.isEmpty
+          ? status.bestAvailableSampleRate
+          : validRates.last;
     }
     return status.bestAvailableSampleRate;
   }
@@ -1008,11 +1016,11 @@ class MyAudioHandler extends BaseAudioHandler {
   }
 
   Stream<Duration> getPositionStream() {
-    return _player.stream.position;
+    return _positionBridge.stream;
   }
 
   Duration getPosition() {
-    return _player.state.position;
+    return _positionBridge.position;
   }
 
   void setVolume(double volume) {

--- a/lib/base/audio_handler.dart
+++ b/lib/base/audio_handler.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:sylvakru/base/services/emby_client.dart';
 import 'package:sylvakru/base/services/metadata_service.dart';
+import 'package:sylvakru/base/services/super_lyric_bridge.dart';
 import 'package:sylvakru/base/services/webdav_client.dart';
 import 'package:sylvakru/base/services/color_manager.dart';
 import 'package:sylvakru/base/app.dart';
@@ -21,6 +22,7 @@ import 'package:sylvakru/base/utils/contrast_color_generator.dart';
 import 'package:sylvakru/base/data/library.dart';
 import 'package:sylvakru/base/my_audio_metadata.dart';
 import 'package:sylvakru/base/services/navidrome_client.dart';
+import 'package:sylvakru/base/services/usb_audio_service.dart';
 import 'package:sylvakru/base/utils/metadata_utils.dart';
 import 'package:sylvakru/mini_view/mini_view.dart';
 import 'dart:async';
@@ -55,6 +57,15 @@ Future<void> initAudioService() async {
   await _session.configure(AudioSessionConfiguration.music());
 
   await _session.setActive(true);
+
+  final usbAudioStatus = await usbAudioService.refreshStatus();
+  if (usbAudioStatus.supported) {
+    final optimizedStatus = await usbAudioService.applyPreferredOutput(
+      deviceId: usbAudioStatus.bestAvailableDeviceId,
+      sampleRate: usbAudioStatus.bestAvailableSampleRate,
+    );
+    logger.output("usb audio:${optimizedStatus.message}");
+  }
 
   _session.becomingNoisyEventStream.listen((_) {
     audioHandler.pause();
@@ -587,6 +598,7 @@ class MyAudioHandler extends BaseAudioHandler {
   @override
   Future<void> pause() async {
     _player.pause();
+    unawaited(SuperLyricBridge.sendStop());
     updateIsPlaying(false);
     updatePlaybackState();
   }
@@ -594,6 +606,7 @@ class MyAudioHandler extends BaseAudioHandler {
   @override
   Future<void> stop() async {
     _player.stop();
+    unawaited(SuperLyricBridge.sendStop());
     updateIsPlaying(false);
     updatePlaybackState(stop: true);
   }

--- a/lib/base/data/setting.dart
+++ b/lib/base/data/setting.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:sylvakru/base/audio_handler.dart';
 import 'package:sylvakru/base/data/playlist.dart';
 import 'package:sylvakru/base/services/interaction.dart';
+import 'package:sylvakru/base/services/usb_audio_preferences.dart';
 import 'package:sylvakru/base/widgets/lyric_list_view.dart';
 import 'package:sylvakru/base/data/artist_album.dart';
 import 'package:sylvakru/base/app.dart';
@@ -29,6 +30,7 @@ class Setting {
         jsonDecode(content) as Map<String, dynamic>;
 
     artistAlbumManager.loadSetting(json);
+    usbAudioPreferences.load(json);
 
     playlistManager.useLargePictureNotifier.value =
         json['playlistsUseLargePicture'] as bool? ??
@@ -76,6 +78,7 @@ class Setting {
     file.writeAsStringSync(
       jsonEncode({
         ...artistAlbumManager.settingToMap(),
+        ...usbAudioPreferences.toMap(),
 
         'playlistsUseLargePicture':
             playlistManager.useLargePictureNotifier.value,

--- a/lib/base/services/logger.dart
+++ b/lib/base/services/logger.dart
@@ -35,6 +35,23 @@ class Logger {
     );
   }
 
+  /// 返回当前会话日志文件里包含 [needle] 的行（不区分大小写），最多保留尾部 [max] 行。
+  /// 供 USB 诊断报告拼接 Dart 侧日志使用。
+  List<String> tailContaining(String needle, {int max = 200}) {
+    try {
+      if (!_file.existsSync()) return const [];
+      final lower = needle.toLowerCase();
+      final filtered = _file
+          .readAsLinesSync()
+          .where((line) => line.toLowerCase().contains(lower))
+          .toList();
+      if (filtered.length <= max) return filtered;
+      return filtered.sublist(filtered.length - max);
+    } catch (_) {
+      return const [];
+    }
+  }
+
   void export2Directory(String directory) {
     final fileName = basename(_file.path);
     final newPath = join(directory, fileName);

--- a/lib/base/services/playback_position_bridge.dart
+++ b/lib/base/services/playback_position_bridge.dart
@@ -1,0 +1,64 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:sylvakru/base/services/usb_audio_service.dart';
+
+class PlaybackPositionBridge {
+  final Duration Function() _playerPosition;
+  final ValueListenable<UsbExclusivePlaybackState> _exclusiveStateListenable;
+  final _controller = StreamController<Duration>.broadcast();
+  late final StreamSubscription<Duration> _playerPositionSubscription;
+  late final VoidCallback _exclusiveStateListener;
+
+  Duration _exclusivePosition = Duration.zero;
+  bool _exclusiveActive = false;
+  bool _disposed = false;
+
+  PlaybackPositionBridge({
+    required Stream<Duration> playerPositionStream,
+    required Duration Function() playerPosition,
+    required ValueListenable<UsbExclusivePlaybackState>
+    exclusiveStateListenable,
+  }) : _playerPosition = playerPosition,
+       _exclusiveStateListenable = exclusiveStateListenable {
+    _exclusiveStateListener = _handleExclusiveState;
+    _exclusiveStateListenable.addListener(_exclusiveStateListener);
+    _handleExclusiveState();
+
+    _playerPositionSubscription = playerPositionStream.listen((position) {
+      if (!_exclusiveActive) {
+        _emit(position);
+      }
+    });
+  }
+
+  Stream<Duration> get stream => _controller.stream;
+
+  Duration get position =>
+      _exclusiveActive ? _exclusivePosition : _playerPosition();
+
+  void dispose() {
+    if (_disposed) {
+      return;
+    }
+    _disposed = true;
+    _exclusiveStateListenable.removeListener(_exclusiveStateListener);
+    unawaited(_playerPositionSubscription.cancel());
+    unawaited(_controller.close());
+  }
+
+  void _handleExclusiveState() {
+    final state = _exclusiveStateListenable.value;
+    _exclusiveActive = state.active;
+    if (state.active) {
+      _exclusivePosition = state.position;
+      _emit(state.position);
+    }
+  }
+
+  void _emit(Duration position) {
+    if (!_disposed && !_controller.isClosed) {
+      _controller.add(position);
+    }
+  }
+}

--- a/lib/base/services/super_lyric_bridge.dart
+++ b/lib/base/services/super_lyric_bridge.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/services.dart';
+import 'package:sylvakru/base/services/lyric.dart';
 
 class SuperLyricBridge {
   static const MethodChannel _defaultChannel = MethodChannel(
@@ -31,8 +32,34 @@ class SuperLyricBridge {
       return;
     }
 
+    await _invokeSendLyric({'lyric': text});
+  }
+
+  static Future<void> sendLyricLine(LyricLine line) async {
+    final text = line.text.trim();
+    if (_shouldStopForLyric(text)) {
+      await sendStop();
+      return;
+    }
+
+    final arguments = _lineToArguments(line, text);
+    final dedupeKey = arguments.toString();
+    if (dedupeKey == _lastLyric) {
+      return;
+    }
+
+    _lastLyric = dedupeKey;
+    _hasSentStop = false;
+    if (!_isAndroid) {
+      return;
+    }
+
+    await _invokeSendLyric(arguments);
+  }
+
+  static Future<void> _invokeSendLyric(Map<String, Object?> arguments) async {
     try {
-      await _channel.invokeMethod<void>('sendLyric', {'lyric': text});
+      await _channel.invokeMethod<void>('sendLyric', arguments);
     } on PlatformException {
       return;
     } on MissingPluginException {
@@ -64,6 +91,31 @@ class SuperLyricBridge {
     return lyric.isEmpty ||
         lyric == 'There are no lyrics' ||
         lyric == 'Lyrics parsing failed';
+  }
+
+  static Map<String, Object?> _lineToArguments(LyricLine line, String text) {
+    return {
+      'lyric': text,
+      'startTime': line.start.inMilliseconds,
+      'endTime': _lineEnd(line)?.inMilliseconds,
+      'tokens': line.tokens
+          .where((token) => token.text.isNotEmpty && token.end != null)
+          .map(
+            (token) => {
+              'text': token.text,
+              'startTime': token.start.inMilliseconds,
+              'endTime': token.end!.inMilliseconds,
+            },
+          )
+          .toList(growable: false),
+    };
+  }
+
+  static Duration? _lineEnd(LyricLine line) {
+    if (line.tokens.isEmpty) {
+      return null;
+    }
+    return line.tokens.last.end;
   }
 
   static void configureForTest({

--- a/lib/base/services/super_lyric_bridge.dart
+++ b/lib/base/services/super_lyric_bridge.dart
@@ -1,0 +1,85 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+
+class SuperLyricBridge {
+  static const MethodChannel _defaultChannel = MethodChannel(
+    'com.afalphy.sylvakru/super_lyric',
+  );
+
+  static MethodChannel _channel = _defaultChannel;
+  static bool _isAndroid = Platform.isAndroid;
+  static String? _lastLyric;
+  static bool _hasSentStop = false;
+
+  SuperLyricBridge._();
+
+  static Future<void> sendLyric(String lyric) async {
+    final text = lyric.trim();
+    if (_shouldStopForLyric(text)) {
+      await sendStop();
+      return;
+    }
+
+    if (text == _lastLyric) {
+      return;
+    }
+
+    _lastLyric = text;
+    _hasSentStop = false;
+    if (!_isAndroid) {
+      return;
+    }
+
+    try {
+      await _channel.invokeMethod<void>('sendLyric', {'lyric': text});
+    } on PlatformException {
+      return;
+    } on MissingPluginException {
+      return;
+    }
+  }
+
+  static Future<void> sendStop() async {
+    if (_hasSentStop) {
+      return;
+    }
+
+    _lastLyric = null;
+    _hasSentStop = true;
+    if (!_isAndroid) {
+      return;
+    }
+
+    try {
+      await _channel.invokeMethod<void>('sendStop');
+    } on PlatformException {
+      return;
+    } on MissingPluginException {
+      return;
+    }
+  }
+
+  static bool _shouldStopForLyric(String lyric) {
+    return lyric.isEmpty ||
+        lyric == 'There are no lyrics' ||
+        lyric == 'Lyrics parsing failed';
+  }
+
+  static void configureForTest({
+    required MethodChannel channel,
+    required bool isAndroid,
+  }) {
+    _channel = channel;
+    _isAndroid = isAndroid;
+    _lastLyric = null;
+    _hasSentStop = false;
+  }
+
+  static void resetForTest() {
+    _channel = _defaultChannel;
+    _isAndroid = Platform.isAndroid;
+    _lastLyric = null;
+    _hasSentStop = false;
+  }
+}

--- a/lib/base/services/super_lyric_position_publisher.dart
+++ b/lib/base/services/super_lyric_position_publisher.dart
@@ -1,0 +1,57 @@
+import 'package:sylvakru/base/services/lyric.dart';
+
+class SuperLyricPositionPublisher {
+  final Future<void> Function(LyricLine line) sendLyricLine;
+  final Future<void> Function() sendStop;
+
+  List<LyricLine> _lines = const [];
+  int? _lastPublishedIndex;
+
+  SuperLyricPositionPublisher({
+    required this.sendLyricLine,
+    required this.sendStop,
+  });
+
+  void updateLines(List<LyricLine> lines) {
+    _lines = lines;
+    reset();
+  }
+
+  void reset() {
+    _lastPublishedIndex = null;
+  }
+
+  Future<void> publishAt(Duration position) async {
+    if (position < Duration.zero) {
+      return;
+    }
+
+    final currentIndex = _currentIndexAt(position);
+    if (currentIndex == _lastPublishedIndex) {
+      return;
+    }
+
+    _lastPublishedIndex = currentIndex;
+    if (currentIndex >= 0 && currentIndex < _lines.length) {
+      await sendLyricLine(_lines[currentIndex]);
+    } else {
+      await sendStop();
+    }
+  }
+
+  int _currentIndexAt(Duration position) {
+    var current = -1;
+
+    for (var i = 0; i < _lines.length; i++) {
+      final line = _lines[i];
+      if (position < line.start) {
+        break;
+      }
+      if (current == -1 || line.start > _lines[current].start) {
+        current = i;
+      }
+    }
+
+    return current;
+  }
+}

--- a/lib/base/services/usb_audio_preferences.dart
+++ b/lib/base/services/usb_audio_preferences.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/foundation.dart';
+
+final usbAudioPreferences = UsbAudioPreferences();
+
+enum UsbDsdMode { pcm, dop, native }
+
+enum UsbVolumeLockMode { off, dsdOnly, always }
+
+enum UsbBusSpeedMode { auto, full, high, superSpeed }
+
+enum UsbBitDepthMode { auto, pcm16, pcm24, pcm32 }
+
+class UsbAudioPreferences {
+  static const sampleRates = [44100, 48000, 88200, 96000, 176400, 192000];
+
+  final fixedSampleRateEnabledNotifier = ValueNotifier(false);
+  final fixedSampleRateNotifier = ValueNotifier<int?>(null);
+  final dsdModeNotifier = ValueNotifier(UsbDsdMode.dop);
+  final dsd64PcmRateNotifier = ValueNotifier(88200);
+  final dsd128PcmRateNotifier = ValueNotifier(88200);
+  final dsd256PcmRateNotifier = ValueNotifier(88200);
+  final dsd512PcmRateNotifier = ValueNotifier(88200);
+  final performanceModeNotifier = ValueNotifier(true);
+  final volumeLockModeNotifier = ValueNotifier(UsbVolumeLockMode.dsdOnly);
+  final dsdGainCompensationNotifier = ValueNotifier(0);
+  final busSpeedModeNotifier = ValueNotifier(UsbBusSpeedMode.auto);
+  final bitDepthModeNotifier = ValueNotifier(UsbBitDepthMode.auto);
+  final releaseUsbBandwidthAfterPlaybackNotifier = ValueNotifier(false);
+  final keepAliveInBackgroundNotifier = ValueNotifier(true);
+
+  void load(Map<String, dynamic> json) {
+    fixedSampleRateEnabledNotifier.value =
+        json['usbFixedSampleRateEnabled'] as bool? ?? false;
+    fixedSampleRateNotifier.value = _validRate(
+      json['usbFixedSampleRate'] as int?,
+    );
+    dsdModeNotifier.value = _enumByName(
+      UsbDsdMode.values,
+      json['usbDsdMode'] as String?,
+      UsbDsdMode.dop,
+    );
+    dsd64PcmRateNotifier.value =
+        _validRate(json['usbDsd64PcmRate'] as int?) ?? 88200;
+    dsd128PcmRateNotifier.value =
+        _validRate(json['usbDsd128PcmRate'] as int?) ?? 88200;
+    dsd256PcmRateNotifier.value =
+        _validRate(json['usbDsd256PcmRate'] as int?) ?? 88200;
+    dsd512PcmRateNotifier.value =
+        _validRate(json['usbDsd512PcmRate'] as int?) ?? 88200;
+    performanceModeNotifier.value = json['usbPerformanceMode'] as bool? ?? true;
+    volumeLockModeNotifier.value = _enumByName(
+      UsbVolumeLockMode.values,
+      json['usbVolumeLockMode'] as String?,
+      UsbVolumeLockMode.dsdOnly,
+    );
+    dsdGainCompensationNotifier.value =
+        json['usbDsdGainCompensation'] as int? ?? 0;
+    busSpeedModeNotifier.value = _enumByName(
+      UsbBusSpeedMode.values,
+      json['usbBusSpeedMode'] as String?,
+      UsbBusSpeedMode.auto,
+    );
+    bitDepthModeNotifier.value = _enumByName(
+      UsbBitDepthMode.values,
+      json['usbBitDepthMode'] as String?,
+      UsbBitDepthMode.auto,
+    );
+    releaseUsbBandwidthAfterPlaybackNotifier.value =
+        json['usbReleaseBandwidthAfterPlayback'] as bool? ?? false;
+    keepAliveInBackgroundNotifier.value =
+        json['usbKeepAliveInBackground'] as bool? ?? true;
+  }
+
+  Map<String, Object?> toMap() {
+    return {
+      'usbFixedSampleRateEnabled': fixedSampleRateEnabledNotifier.value,
+      'usbFixedSampleRate': fixedSampleRateNotifier.value,
+      'usbDsdMode': dsdModeNotifier.value.name,
+      'usbDsd64PcmRate': dsd64PcmRateNotifier.value,
+      'usbDsd128PcmRate': dsd128PcmRateNotifier.value,
+      'usbDsd256PcmRate': dsd256PcmRateNotifier.value,
+      'usbDsd512PcmRate': dsd512PcmRateNotifier.value,
+      'usbPerformanceMode': performanceModeNotifier.value,
+      'usbVolumeLockMode': volumeLockModeNotifier.value.name,
+      'usbDsdGainCompensation': dsdGainCompensationNotifier.value,
+      'usbBusSpeedMode': busSpeedModeNotifier.value.name,
+      'usbBitDepthMode': bitDepthModeNotifier.value.name,
+      'usbReleaseBandwidthAfterPlayback':
+          releaseUsbBandwidthAfterPlaybackNotifier.value,
+      'usbKeepAliveInBackground': keepAliveInBackgroundNotifier.value,
+    };
+  }
+
+  int? preferredFixedSampleRate() {
+    if (!fixedSampleRateEnabledNotifier.value) {
+      return null;
+    }
+    return _validRate(fixedSampleRateNotifier.value);
+  }
+
+  String preferredEncoding() {
+    return switch (bitDepthModeNotifier.value) {
+      UsbBitDepthMode.pcm16 => 'pcm_16bit',
+      UsbBitDepthMode.pcm24 => 'pcm_24bit_packed',
+      UsbBitDepthMode.pcm32 => 'pcm_32bit',
+      UsbBitDepthMode.auto => 'pcm_24bit_packed',
+    };
+  }
+
+  void resetForTest() {
+    load(const {});
+  }
+
+  T _enumByName<T extends Enum>(List<T> values, String? name, T fallback) {
+    for (final value in values) {
+      if (value.name == name) {
+        return value;
+      }
+    }
+    return fallback;
+  }
+
+  int? _validRate(int? rate) {
+    if (rate == null) return null;
+    return sampleRates.contains(rate) ? rate : null;
+  }
+}

--- a/lib/base/services/usb_audio_preferences.dart
+++ b/lib/base/services/usb_audio_preferences.dart
@@ -9,6 +9,15 @@ int preferredUsbExclusiveTargetBufferMs({required bool background}) {
   return usbAudioPreferences.foregroundBufferMsNotifier.value;
 }
 
+int? preferredUsbExclusiveBitDepth() {
+  return switch (usbAudioPreferences.bitDepthModeNotifier.value) {
+    UsbBitDepthMode.auto => null,
+    UsbBitDepthMode.pcm16 => 16,
+    UsbBitDepthMode.pcm24 => 24,
+    UsbBitDepthMode.pcm32 => 32,
+  };
+}
+
 enum UsbDsdMode { pcm, dop, native }
 
 enum UsbVolumeLockMode { off, dsdOnly, always }

--- a/lib/base/services/usb_audio_preferences.dart
+++ b/lib/base/services/usb_audio_preferences.dart
@@ -27,6 +27,14 @@ class UsbAudioPreferences {
   final bitDepthModeNotifier = ValueNotifier(UsbBitDepthMode.auto);
   final releaseUsbBandwidthAfterPlaybackNotifier = ValueNotifier(false);
   final keepAliveInBackgroundNotifier = ValueNotifier(true);
+  final bitDepthCompatNotifier = ValueNotifier(true);
+  final sampleRateCompatNotifier = ValueNotifier(true);
+  final channelCompatNotifier = ValueNotifier(true);
+  final tpdfDitherNotifier = ValueNotifier(false);
+  final foregroundBufferMsNotifier = ValueNotifier(200);
+  final backgroundBufferMsNotifier = ValueNotifier(1500);
+  final volumeSmoothHandoffNotifier = ValueNotifier(true);
+  final delayedUsbLinkNotifier = ValueNotifier(false);
 
   void load(Map<String, dynamic> json) {
     fixedSampleRateEnabledNotifier.value =
@@ -69,6 +77,22 @@ class UsbAudioPreferences {
         json['usbReleaseBandwidthAfterPlayback'] as bool? ?? false;
     keepAliveInBackgroundNotifier.value =
         json['usbKeepAliveInBackground'] as bool? ?? true;
+    bitDepthCompatNotifier.value = json['usbBitDepthCompat'] as bool? ?? true;
+    sampleRateCompatNotifier.value =
+        json['usbSampleRateCompat'] as bool? ?? true;
+    channelCompatNotifier.value = json['usbChannelCompat'] as bool? ?? true;
+    tpdfDitherNotifier.value = json['usbTpdfDither'] as bool? ?? false;
+    foregroundBufferMsNotifier.value = _validBufferMs(
+      json['usbForegroundBufferMs'] as int?,
+      200,
+    );
+    backgroundBufferMsNotifier.value = _validBufferMs(
+      json['usbBackgroundBufferMs'] as int?,
+      1500,
+    );
+    volumeSmoothHandoffNotifier.value =
+        json['usbVolumeSmoothHandoff'] as bool? ?? true;
+    delayedUsbLinkNotifier.value = json['usbDelayedUsbLink'] as bool? ?? false;
   }
 
   Map<String, Object?> toMap() {
@@ -88,6 +112,14 @@ class UsbAudioPreferences {
       'usbReleaseBandwidthAfterPlayback':
           releaseUsbBandwidthAfterPlaybackNotifier.value,
       'usbKeepAliveInBackground': keepAliveInBackgroundNotifier.value,
+      'usbBitDepthCompat': bitDepthCompatNotifier.value,
+      'usbSampleRateCompat': sampleRateCompatNotifier.value,
+      'usbChannelCompat': channelCompatNotifier.value,
+      'usbTpdfDither': tpdfDitherNotifier.value,
+      'usbForegroundBufferMs': foregroundBufferMsNotifier.value,
+      'usbBackgroundBufferMs': backgroundBufferMsNotifier.value,
+      'usbVolumeSmoothHandoff': volumeSmoothHandoffNotifier.value,
+      'usbDelayedUsbLink': delayedUsbLinkNotifier.value,
     };
   }
 
@@ -123,5 +155,10 @@ class UsbAudioPreferences {
   int? _validRate(int? rate) {
     if (rate == null) return null;
     return sampleRates.contains(rate) ? rate : null;
+  }
+
+  int _validBufferMs(int? value, int fallback) {
+    if (value == null) return fallback;
+    return value.clamp(50, 5000);
   }
 }

--- a/lib/base/services/usb_audio_preferences.dart
+++ b/lib/base/services/usb_audio_preferences.dart
@@ -2,6 +2,13 @@ import 'package:flutter/foundation.dart';
 
 final usbAudioPreferences = UsbAudioPreferences();
 
+int preferredUsbExclusiveTargetBufferMs({required bool background}) {
+  if (background && usbAudioPreferences.keepAliveInBackgroundNotifier.value) {
+    return usbAudioPreferences.backgroundBufferMsNotifier.value;
+  }
+  return usbAudioPreferences.foregroundBufferMsNotifier.value;
+}
+
 enum UsbDsdMode { pcm, dop, native }
 
 enum UsbVolumeLockMode { off, dsdOnly, always }

--- a/lib/base/services/usb_audio_service.dart
+++ b/lib/base/services/usb_audio_service.dart
@@ -69,6 +69,39 @@ class UsbAudioService {
     return _invokeStatus('clearPreferredOutput');
   }
 
+  Future<UsbExclusiveProbeResult> probeExclusiveAccess() async {
+    if (!_isAndroid) {
+      return const UsbExclusiveProbeResult(
+        supported: false,
+        permissionGranted: false,
+        deviceName: null,
+        deviceId: null,
+        audioInterfaceCount: 0,
+        claimedInterfaceCount: 0,
+        rawDescriptorLength: 0,
+        message: 'USB exclusive access probing is only available on Android.',
+      );
+    }
+
+    try {
+      final result = await _channel.invokeMapMethod<String, Object?>(
+        'probeExclusiveAccess',
+      );
+      return UsbExclusiveProbeResult.fromMap(result ?? const {});
+    } on PlatformException catch (error) {
+      return UsbExclusiveProbeResult(
+        supported: false,
+        permissionGranted: false,
+        deviceName: null,
+        deviceId: null,
+        audioInterfaceCount: 0,
+        claimedInterfaceCount: 0,
+        rawDescriptorLength: 0,
+        message: error.message,
+      );
+    }
+  }
+
   Future<UsbAudioStatus> _invokeStatus(
     String method, [
     Map<String, Object?>? arguments,
@@ -103,6 +136,44 @@ class UsbAudioService {
     usbAudioEventNotifier.value = event;
     return null;
   }
+}
+
+@immutable
+class UsbExclusiveProbeResult {
+  final bool supported;
+  final bool permissionGranted;
+  final String? deviceName;
+  final int? deviceId;
+  final int audioInterfaceCount;
+  final int claimedInterfaceCount;
+  final int rawDescriptorLength;
+  final String? message;
+
+  const UsbExclusiveProbeResult({
+    required this.supported,
+    required this.permissionGranted,
+    required this.deviceName,
+    required this.deviceId,
+    required this.audioInterfaceCount,
+    required this.claimedInterfaceCount,
+    required this.rawDescriptorLength,
+    required this.message,
+  });
+
+  factory UsbExclusiveProbeResult.fromMap(Map<String, Object?> map) {
+    return UsbExclusiveProbeResult(
+      supported: map['supported'] == true,
+      permissionGranted: map['permissionGranted'] == true,
+      deviceName: map['deviceName'] as String?,
+      deviceId: _asInt(map['deviceId']),
+      audioInterfaceCount: _asInt(map['audioInterfaceCount']) ?? 0,
+      claimedInterfaceCount: _asInt(map['claimedInterfaceCount']) ?? 0,
+      rawDescriptorLength: _asInt(map['rawDescriptorLength']) ?? 0,
+      message: map['message'] as String?,
+    );
+  }
+
+  bool get interfaceClaimed => claimedInterfaceCount > 0;
 }
 
 @immutable

--- a/lib/base/services/usb_audio_service.dart
+++ b/lib/base/services/usb_audio_service.dart
@@ -2,6 +2,8 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:sylvakru/base/app.dart';
+import 'package:sylvakru/base/services/logger.dart';
 import 'package:sylvakru/base/services/usb_audio_preferences.dart';
 
 final usbAudioService = UsbAudioService();
@@ -173,6 +175,24 @@ class UsbAudioService {
 
   Future<UsbExclusivePlaybackState> releaseExclusiveDevice() {
     return _invokeExclusiveState('releaseExclusiveDevice');
+  }
+
+  /// 生成一键复制/导出的 DAC 适配诊断报告（纯文本 Markdown）。
+  /// 报告不要求 DAC 在线：未连接设备时也会带上环境、偏好与最近日志。
+  Future<String> getDiagnosticsReport() async {
+    Map<String, Object?> native = const {};
+    if (_isAndroid) {
+      try {
+        native =
+            await _channel.invokeMapMethod<String, Object?>(
+              'getUsbDiagnosticsReport',
+            ) ??
+            const {};
+      } on PlatformException catch (error) {
+        native = {'error': error.message};
+      }
+    }
+    return buildUsbDiagnosticsReport(native, platformSupported: _isAndroid);
   }
 
   Future<UsbAudioStatus> _invokeStatus(
@@ -672,6 +692,182 @@ class UsbAudioDevice {
     }
     return null;
   }
+}
+
+/// 把原生侧采集的诊断数据与 Dart 侧的偏好/状态/日志拼装成单个纯文本报告。
+/// 首行固定为版本标识，便于后续解析工具识别。抽成顶层函数便于单元测试。
+String buildUsbDiagnosticsReport(
+  Map<String, Object?> native, {
+  bool platformSupported = true,
+}) {
+  final buffer = StringBuffer();
+  buffer.writeln('Sylvakru USB 诊断报告 v1');
+
+  final error = native['error'];
+  if (error != null) {
+    buffer.writeln();
+    buffer.writeln('> 采集原生数据失败: $error');
+  }
+
+  // 1. 环境
+  buffer.writeln();
+  buffer.writeln('## 环境');
+  buffer.writeln('- App 版本: $versionNumber');
+  if (!platformSupported) {
+    buffer.writeln('- 平台: 非 Android（原生 USB 数据不可用）');
+  } else {
+    final release = native['androidRelease'] ?? '未知';
+    final sdk = _asInt(native['androidSdk']) ?? '未知';
+    buffer.writeln('- Android: $release (SDK $sdk)');
+    buffer.writeln(
+      '- 机型: ${'${native['manufacturer'] ?? '未知'} ${native['model'] ?? ''}'.trim()}',
+    );
+  }
+  buffer.writeln('- 生成时间: ${_formatTimestamp(native['generatedAtMs'])}');
+
+  // 2. USB 设备标识
+  buffer.writeln();
+  buffer.writeln('## USB 设备标识');
+  final device = native['device'];
+  if (device is Map) {
+    final d = device.cast<String, Object?>();
+    buffer.writeln(
+      '- VID/PID: ${d['vendorIdHex'] ?? d['vendorId']} / ${d['productIdHex'] ?? d['productId']}',
+    );
+    buffer.writeln('- 厂商: ${d['manufacturerName'] ?? '未知'}');
+    buffer.writeln('- 产品: ${d['productName'] ?? '未知'}');
+    buffer.writeln(
+      '- deviceClass/subclass: ${d['deviceClass']} / ${d['deviceSubclass']}',
+    );
+    buffer.writeln(
+      '- 接口总数 / Audio 接口数: ${d['interfaceCount']} / ${d['audioInterfaceCount']}',
+    );
+    buffer.writeln('- 序列号(脱敏): ${d['serialTail'] ?? '不可用'}');
+    buffer.writeln(
+      '- USB 权限: ${native['permissionGranted'] == true ? '已授权' : '未授权'}',
+    );
+    buffer.writeln('> 序列号仅显示末 4 位，不包含完整序列号。');
+  } else {
+    buffer.writeln('- 未检测到 USB 音频设备。');
+  }
+
+  final diagnostics =
+      (native['diagnostics'] as Map?)?.cast<String, Object?>() ?? const {};
+
+  // 3. 原始描述符 hex dump（离线还原设备行为的核心数据）
+  buffer.writeln();
+  buffer.writeln('## 原始描述符 (hex dump)');
+  final hex = diagnostics['rawDescriptorsHex'];
+  if (hex is String && hex.isNotEmpty) {
+    buffer.writeln('长度: ${diagnostics['rawDescriptorLength'] ?? '未知'} bytes');
+    buffer.writeln('```');
+    buffer.writeln(hex);
+    buffer.writeln('```');
+  } else {
+    buffer.writeln('- ${diagnostics['message'] ?? '描述符不可用。'}');
+  }
+
+  // 4. App 解析结果
+  buffer.writeln();
+  buffer.writeln('## App 解析结果');
+  buffer.writeln('### AS 格式');
+  _writeListSection(buffer, diagnostics['streamingFormats']);
+  buffer.writeln('### 输出候选 (alt/maxPacket/attr/feedback/bits/format)');
+  _writeListSection(buffer, diagnostics['outputCandidates']);
+  buffer.writeln('- UAC2 时钟源 id: ${diagnostics['clockSourceId'] ?? '未知'}');
+  buffer.writeln('- 最近一次 probe: ${native['lastProbe'] ?? '无'}');
+
+  // 5. 系统侧能力
+  buffer.writeln();
+  buffer.writeln('## 系统侧能力');
+  final status = (native['systemStatus'] as Map?)?.cast<String, Object?>();
+  final devices = status?['devices'];
+  if (devices is List && devices.isNotEmpty) {
+    for (final dev in devices) {
+      buffer.writeln('- $dev');
+    }
+  } else {
+    buffer.writeln('- 无 USB 音频输出设备。');
+  }
+
+  // 6. 偏好快照
+  buffer.writeln();
+  buffer.writeln('## 偏好快照');
+  usbAudioPreferences.toMap().forEach((key, value) {
+    buffer.writeln('- $key: $value');
+  });
+
+  // 7. 运行状态快照
+  buffer.writeln();
+  buffer.writeln('## 运行状态快照');
+  final state = usbExclusivePlaybackStateNotifier.value;
+  buffer.writeln(
+    '- 独占: active=${state.active}, playing=${state.playing}, '
+    'format=${state.format}, sampleRate=${state.sampleRate}, '
+    'bitDepth=${state.bitDepth}, position=${state.position.inMilliseconds}ms',
+  );
+  buffer.writeln('  message=${state.message}');
+  final telemetry = usbTransportTelemetryNotifier.value;
+  buffer.writeln(
+    '- telemetry: active=${telemetry.active}, '
+    'buffer=${telemetry.bufferLevel.inMilliseconds}ms, '
+    'min=${telemetry.minimumBufferLevel?.inMilliseconds}, '
+    'target=${telemetry.targetBuffer?.inMilliseconds}, '
+    'iso=${telemetry.isoPacketCount}, pendingUrbs=${telemetry.pendingUrbs}, '
+    'underrun=${telemetry.underrunCount}',
+  );
+
+  // 8. 最近日志
+  buffer.writeln();
+  buffer.writeln('## 最近日志 (Kotlin/native)');
+  _writeLogLines(buffer, native['logs']);
+  final nativeLog = native['nativeLogcat'];
+  if (nativeLog is List && nativeLog.isNotEmpty) {
+    buffer.writeln();
+    buffer.writeln('### native logcat (SylvakruUsbExclusive)');
+    _writeLogLines(buffer, nativeLog);
+  }
+
+  buffer.writeln();
+  buffer.writeln('## 最近日志 (Dart)');
+  final dartLogs = logger.tailContaining('usb', max: 200);
+  if (dartLogs.isEmpty) {
+    buffer.writeln('（无）');
+  } else {
+    for (final l in dartLogs) {
+      buffer.writeln(l);
+    }
+  }
+
+  return buffer.toString();
+}
+
+void _writeListSection(StringBuffer buffer, Object? value) {
+  if (value is List && value.isNotEmpty) {
+    for (final item in value) {
+      buffer.writeln('- $item');
+    }
+  } else {
+    buffer.writeln('- 无');
+  }
+}
+
+void _writeLogLines(StringBuffer buffer, Object? value) {
+  if (value is List && value.isNotEmpty) {
+    for (final line in value) {
+      buffer.writeln(line.toString());
+    }
+  } else {
+    buffer.writeln('（无）');
+  }
+}
+
+String _formatTimestamp(Object? millis) {
+  final ms = _asInt(millis);
+  if (ms == null || ms == 0) {
+    return DateTime.now().toString();
+  }
+  return DateTime.fromMillisecondsSinceEpoch(ms).toString();
 }
 
 int? _asInt(Object? value) {

--- a/lib/base/services/usb_audio_service.dart
+++ b/lib/base/services/usb_audio_service.dart
@@ -6,6 +6,9 @@ import 'package:flutter/services.dart';
 final usbAudioService = UsbAudioService();
 final usbAudioStatusNotifier = ValueNotifier(UsbAudioStatus.unavailable());
 final usbAudioEventNotifier = ValueNotifier<UsbAudioDeviceEvent?>(null);
+final usbExclusivePlaybackStateNotifier = ValueNotifier(
+  UsbExclusivePlaybackState.inactive(),
+);
 
 enum UsbAudioDeviceEventType { added, removed }
 
@@ -102,6 +105,62 @@ class UsbAudioService {
     }
   }
 
+  Future<UsbExclusiveCapability> getExclusiveCapabilities() async {
+    if (!_isAndroid) {
+      return const UsbExclusiveCapability(
+        available: false,
+        permissionGranted: false,
+        deviceName: null,
+        deviceId: null,
+        interfaceNumber: null,
+        alternateSetting: null,
+        endpointAddress: null,
+        maxPacketSize: null,
+        sampleRates: [],
+        bitDepths: [],
+        channelCounts: [],
+        message: 'USB exclusive playback is only available on Android.',
+      );
+    }
+
+    try {
+      final result = await _channel.invokeMapMethod<String, Object?>(
+        'getExclusiveCapabilities',
+      );
+      return UsbExclusiveCapability.fromMap(result ?? const {});
+    } on PlatformException catch (error) {
+      return UsbExclusiveCapability.unavailable(message: error.message);
+    }
+  }
+
+  Future<UsbExclusivePlaybackState> startExclusivePlayback(
+    UsbExclusivePlaybackRequest request,
+  ) {
+    return _invokeExclusiveState('startExclusivePlayback', request.toMap());
+  }
+
+  Future<UsbExclusivePlaybackState> pauseExclusivePlayback() {
+    return _invokeExclusiveState('pauseExclusivePlayback');
+  }
+
+  Future<UsbExclusivePlaybackState> resumeExclusivePlayback() {
+    return _invokeExclusiveState('resumeExclusivePlayback');
+  }
+
+  Future<UsbExclusivePlaybackState> seekExclusivePlayback(Duration position) {
+    return _invokeExclusiveState('seekExclusivePlayback', {
+      'positionMs': position.inMilliseconds,
+    });
+  }
+
+  Future<UsbExclusivePlaybackState> stopExclusivePlayback() {
+    return _invokeExclusiveState('stopExclusivePlayback');
+  }
+
+  Future<UsbExclusivePlaybackState> releaseExclusiveDevice() {
+    return _invokeExclusiveState('releaseExclusiveDevice');
+  }
+
   Future<UsbAudioStatus> _invokeStatus(
     String method, [
     Map<String, Object?>? arguments,
@@ -121,20 +180,200 @@ class UsbAudioService {
     }
   }
 
-  Future<Object?> _handleNativeCall(MethodCall call) async {
-    if (call.method != 'onUsbAudioDeviceEvent') {
-      throw PlatformException(
-        code: 'unimplemented',
-        message: 'Unknown USB audio callback: ${call.method}',
+  Future<UsbExclusivePlaybackState> _invokeExclusiveState(
+    String method, [
+    Map<String, Object?>? arguments,
+  ]) async {
+    if (!_isAndroid) {
+      final state = UsbExclusivePlaybackState.inactive(
+        message: 'USB exclusive playback is only available on Android.',
       );
+      usbExclusivePlaybackStateNotifier.value = state;
+      return state;
     }
 
-    final event = UsbAudioDeviceEvent.fromMap(
-      (call.arguments as Map).cast<String, Object?>(),
+    try {
+      final result = await _channel.invokeMapMethod<String, Object?>(
+        method,
+        arguments,
+      );
+      final state = UsbExclusivePlaybackState.fromMap(result ?? const {});
+      usbExclusivePlaybackStateNotifier.value = state;
+      return state;
+    } on PlatformException catch (error) {
+      final state = UsbExclusivePlaybackState.inactive(message: error.message);
+      usbExclusivePlaybackStateNotifier.value = state;
+      return state;
+    }
+  }
+
+  Future<Object?> _handleNativeCall(MethodCall call) async {
+    if (call.method == 'onUsbAudioDeviceEvent') {
+      final event = UsbAudioDeviceEvent.fromMap(
+        (call.arguments as Map).cast<String, Object?>(),
+      );
+      usbAudioStatusNotifier.value = event.status;
+      usbAudioEventNotifier.value = event;
+      return null;
+    }
+
+    if (call.method == 'onUsbExclusiveStateChanged' ||
+        call.method == 'onUsbExclusivePosition' ||
+        call.method == 'onUsbExclusiveError') {
+      final state = UsbExclusivePlaybackState.fromMap(
+        (call.arguments as Map?)?.cast<String, Object?>() ?? const {},
+      );
+      usbExclusivePlaybackStateNotifier.value = state;
+      return null;
+    }
+
+    throw PlatformException(
+      code: 'unimplemented',
+      message: 'Unknown USB audio callback: ${call.method}',
     );
-    usbAudioStatusNotifier.value = event.status;
-    usbAudioEventNotifier.value = event;
-    return null;
+  }
+}
+
+@immutable
+class UsbExclusiveCapability {
+  final bool available;
+  final bool permissionGranted;
+  final String? deviceName;
+  final int? deviceId;
+  final int? interfaceNumber;
+  final int? alternateSetting;
+  final int? endpointAddress;
+  final int? maxPacketSize;
+  final List<int> sampleRates;
+  final List<int> bitDepths;
+  final List<int> channelCounts;
+  final String? message;
+
+  const UsbExclusiveCapability({
+    required this.available,
+    required this.permissionGranted,
+    required this.deviceName,
+    required this.deviceId,
+    required this.interfaceNumber,
+    required this.alternateSetting,
+    required this.endpointAddress,
+    required this.maxPacketSize,
+    required this.sampleRates,
+    required this.bitDepths,
+    required this.channelCounts,
+    required this.message,
+  });
+
+  factory UsbExclusiveCapability.unavailable({String? message}) {
+    return UsbExclusiveCapability(
+      available: false,
+      permissionGranted: false,
+      deviceName: null,
+      deviceId: null,
+      interfaceNumber: null,
+      alternateSetting: null,
+      endpointAddress: null,
+      maxPacketSize: null,
+      sampleRates: const [],
+      bitDepths: const [],
+      channelCounts: const [],
+      message: message,
+    );
+  }
+
+  factory UsbExclusiveCapability.fromMap(Map<String, Object?> map) {
+    return UsbExclusiveCapability(
+      available: map['available'] == true,
+      permissionGranted: map['permissionGranted'] == true,
+      deviceName: map['deviceName'] as String?,
+      deviceId: _asInt(map['deviceId']),
+      interfaceNumber: _asInt(map['interfaceNumber']),
+      alternateSetting: _asInt(map['alternateSetting']),
+      endpointAddress: _asInt(map['endpointAddress']),
+      maxPacketSize: _asInt(map['maxPacketSize']),
+      sampleRates: _asIntList(map['sampleRates']),
+      bitDepths: _asIntList(map['bitDepths']),
+      channelCounts: _asIntList(map['channelCounts']),
+      message: map['message'] as String?,
+    );
+  }
+}
+
+@immutable
+class UsbExclusivePlaybackRequest {
+  final String filePath;
+  final String? title;
+  final int? sampleRate;
+  final int? bitDepth;
+  final bool startPaused;
+
+  const UsbExclusivePlaybackRequest({
+    required this.filePath,
+    required this.title,
+    required this.sampleRate,
+    required this.bitDepth,
+    required this.startPaused,
+  });
+
+  Map<String, Object?> toMap() {
+    return {
+      'filePath': filePath,
+      'title': title,
+      'sampleRate': sampleRate,
+      'bitDepth': bitDepth,
+      'startPaused': startPaused,
+    };
+  }
+}
+
+@immutable
+class UsbExclusivePlaybackState {
+  final bool active;
+  final bool playing;
+  final Duration position;
+  final Duration? duration;
+  final int? sampleRate;
+  final int? bitDepth;
+  final String? format;
+  final String? message;
+
+  const UsbExclusivePlaybackState({
+    required this.active,
+    required this.playing,
+    required this.position,
+    required this.duration,
+    required this.sampleRate,
+    required this.bitDepth,
+    required this.format,
+    required this.message,
+  });
+
+  factory UsbExclusivePlaybackState.inactive({String? message}) {
+    return UsbExclusivePlaybackState(
+      active: false,
+      playing: false,
+      position: Duration.zero,
+      duration: null,
+      sampleRate: null,
+      bitDepth: null,
+      format: null,
+      message: message,
+    );
+  }
+
+  factory UsbExclusivePlaybackState.fromMap(Map<String, Object?> map) {
+    return UsbExclusivePlaybackState(
+      active: map['active'] == true,
+      playing: map['playing'] == true,
+      position: Duration(milliseconds: _asInt(map['positionMs']) ?? 0),
+      duration: _asInt(map['durationMs']) == null
+          ? null
+          : Duration(milliseconds: _asInt(map['durationMs'])!),
+      sampleRate: _asInt(map['sampleRate']),
+      bitDepth: _asInt(map['bitDepth']),
+      format: map['format'] as String?,
+      message: map['message'] as String?,
+    );
   }
 }
 

--- a/lib/base/services/usb_audio_service.dart
+++ b/lib/base/services/usb_audio_service.dart
@@ -10,6 +10,9 @@ final usbAudioEventNotifier = ValueNotifier<UsbAudioDeviceEvent?>(null);
 final usbExclusivePlaybackStateNotifier = ValueNotifier(
   UsbExclusivePlaybackState.inactive(),
 );
+final usbTransportTelemetryNotifier = ValueNotifier(
+  UsbTransportTelemetry.inactive(),
+);
 
 enum UsbAudioDeviceEventType { added, removed }
 
@@ -148,6 +151,16 @@ class UsbAudioService {
     return _invokeExclusiveState('resumeExclusivePlayback');
   }
 
+  Future<void> setExclusiveTargetBufferMs(int targetBufferMs) async {
+    if (!_isAndroid) {
+      return;
+    }
+
+    await _channel.invokeMethod<void>('setExclusiveTargetBufferMs', {
+      'targetBufferMs': targetBufferMs.clamp(50, 5000),
+    });
+  }
+
   Future<UsbExclusivePlaybackState> seekExclusivePlayback(Duration position) {
     return _invokeExclusiveState('seekExclusivePlayback', {
       'positionMs': position.inMilliseconds,
@@ -225,6 +238,14 @@ class UsbAudioService {
         (call.arguments as Map?)?.cast<String, Object?>() ?? const {},
       );
       usbExclusivePlaybackStateNotifier.value = state;
+      return null;
+    }
+
+    if (call.method == 'onUsbTransportTelemetryChanged') {
+      final telemetry = UsbTransportTelemetry.fromMap(
+        (call.arguments as Map?)?.cast<String, Object?>() ?? const {},
+      );
+      usbTransportTelemetryNotifier.value = telemetry;
       return null;
     }
 
@@ -307,6 +328,7 @@ class UsbExclusivePlaybackRequest {
   final String? sourceFormat;
   final int? sampleRate;
   final int? bitDepth;
+  final int? targetBufferMs;
   final bool startPaused;
 
   const UsbExclusivePlaybackRequest({
@@ -315,6 +337,7 @@ class UsbExclusivePlaybackRequest {
     required this.sourceFormat,
     required this.sampleRate,
     required this.bitDepth,
+    required this.targetBufferMs,
     required this.startPaused,
   });
 
@@ -325,6 +348,7 @@ class UsbExclusivePlaybackRequest {
       'sourceFormat': sourceFormat,
       'sampleRate': sampleRate,
       'bitDepth': bitDepth,
+      'targetBufferMs': targetBufferMs,
       'startPaused': startPaused,
     };
   }
@@ -377,6 +401,57 @@ class UsbExclusivePlaybackState {
       bitDepth: _asInt(map['bitDepth']),
       format: map['format'] as String?,
       message: map['message'] as String?,
+    );
+  }
+}
+
+@immutable
+class UsbTransportTelemetry {
+  final bool active;
+  final Duration bufferLevel;
+  final Duration? minimumBufferLevel;
+  final Duration? targetBuffer;
+  final int isoPacketCount;
+  final int pendingUrbs;
+  final int underrunCount;
+  final int updatedAtMs;
+
+  const UsbTransportTelemetry({
+    required this.active,
+    required this.bufferLevel,
+    required this.minimumBufferLevel,
+    required this.targetBuffer,
+    required this.isoPacketCount,
+    required this.pendingUrbs,
+    required this.underrunCount,
+    required this.updatedAtMs,
+  });
+
+  factory UsbTransportTelemetry.inactive() {
+    return const UsbTransportTelemetry(
+      active: false,
+      bufferLevel: Duration.zero,
+      minimumBufferLevel: null,
+      targetBuffer: null,
+      isoPacketCount: 0,
+      pendingUrbs: 0,
+      underrunCount: 0,
+      updatedAtMs: 0,
+    );
+  }
+
+  factory UsbTransportTelemetry.fromMap(Map<String, Object?> map) {
+    return UsbTransportTelemetry(
+      active: map['active'] == true,
+      bufferLevel: Duration(
+        milliseconds: _asInt(map['bufferLevelMs'])?.clamp(0, 60000) ?? 0,
+      ),
+      minimumBufferLevel: _durationFromMs(map['minimumBufferLevelMs']),
+      targetBuffer: _durationFromMs(map['targetBufferMs']),
+      isoPacketCount: _asInt(map['isoPacketCount']) ?? 0,
+      pendingUrbs: _asInt(map['pendingUrbs']) ?? 0,
+      underrunCount: _asInt(map['underrunCount']) ?? 0,
+      updatedAtMs: _asInt(map['updatedAtMs']) ?? 0,
     );
   }
 }
@@ -603,6 +678,12 @@ int? _asInt(Object? value) {
   if (value is int) return value;
   if (value is num) return value.toInt();
   return null;
+}
+
+Duration? _durationFromMs(Object? value) {
+  final milliseconds = _asInt(value);
+  if (milliseconds == null) return null;
+  return Duration(milliseconds: milliseconds.clamp(0, 60000));
 }
 
 List<int> _asIntList(Object? value) {

--- a/lib/base/services/usb_audio_service.dart
+++ b/lib/base/services/usb_audio_service.dart
@@ -1,0 +1,241 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+final usbAudioService = UsbAudioService();
+final usbAudioStatusNotifier = ValueNotifier(UsbAudioStatus.unavailable());
+
+class UsbAudioService {
+  static const MethodChannel _defaultChannel = MethodChannel(
+    'com.afalphy.sylvakru/usb_audio',
+  );
+
+  final MethodChannel _channel;
+  final bool _isAndroid;
+
+  UsbAudioService({MethodChannel channel = _defaultChannel, bool? isAndroid})
+    : _channel = channel,
+      _isAndroid = isAndroid ?? Platform.isAndroid;
+
+  Future<UsbAudioStatus> refreshStatus() async {
+    if (!_isAndroid) {
+      final status = UsbAudioStatus.unavailable(
+        message: 'USB audio optimization is only available on Android.',
+      );
+      usbAudioStatusNotifier.value = status;
+      return status;
+    }
+
+    return _invokeStatus('getStatus');
+  }
+
+  Future<UsbAudioStatus> applyPreferredOutput({
+    int? deviceId,
+    int? sampleRate,
+    String encoding = 'pcm_24bit_packed',
+    bool bitPerfect = true,
+  }) async {
+    if (!_isAndroid) {
+      final status = UsbAudioStatus.unavailable(
+        message: 'USB audio optimization is only available on Android.',
+      );
+      usbAudioStatusNotifier.value = status;
+      return status;
+    }
+
+    return _invokeStatus('applyPreferredOutput', {
+      'deviceId': ?deviceId,
+      'sampleRate': ?sampleRate,
+      'encoding': encoding,
+      'bitPerfect': bitPerfect,
+    });
+  }
+
+  Future<UsbAudioStatus> clearPreferredOutput() async {
+    if (!_isAndroid) {
+      final status = UsbAudioStatus.unavailable(
+        message: 'USB audio optimization is only available on Android.',
+      );
+      usbAudioStatusNotifier.value = status;
+      return status;
+    }
+
+    return _invokeStatus('clearPreferredOutput');
+  }
+
+  Future<UsbAudioStatus> _invokeStatus(
+    String method, [
+    Map<String, Object?>? arguments,
+  ]) async {
+    try {
+      final result = await _channel.invokeMapMethod<String, Object?>(
+        method,
+        arguments,
+      );
+      final status = UsbAudioStatus.fromMap(result ?? const {});
+      usbAudioStatusNotifier.value = status;
+      return status;
+    } on PlatformException catch (error) {
+      final status = UsbAudioStatus.unavailable(message: error.message);
+      usbAudioStatusNotifier.value = status;
+      return status;
+    }
+  }
+}
+
+@immutable
+class UsbAudioStatus {
+  final bool supported;
+  final int androidSdk;
+  final int? activeDeviceId;
+  final bool preferredApplied;
+  final int? preferredSampleRate;
+  final String? preferredEncoding;
+  final bool preferredBitPerfect;
+  final String? message;
+  final List<UsbAudioDevice> devices;
+
+  const UsbAudioStatus({
+    required this.supported,
+    required this.androidSdk,
+    required this.activeDeviceId,
+    required this.preferredApplied,
+    required this.preferredSampleRate,
+    required this.preferredEncoding,
+    required this.preferredBitPerfect,
+    required this.message,
+    required this.devices,
+  });
+
+  factory UsbAudioStatus.unavailable({String? message}) {
+    return UsbAudioStatus(
+      supported: false,
+      androidSdk: 0,
+      activeDeviceId: null,
+      preferredApplied: false,
+      preferredSampleRate: null,
+      preferredEncoding: null,
+      preferredBitPerfect: false,
+      message: message,
+      devices: const [],
+    );
+  }
+
+  factory UsbAudioStatus.fromMap(Map<String, Object?> map) {
+    final devicesRaw = map['devices'];
+    final devices = devicesRaw is List
+        ? devicesRaw
+              .whereType<Map>()
+              .map(
+                (device) =>
+                    UsbAudioDevice.fromMap(device.cast<String, Object?>()),
+              )
+              .toList(growable: false)
+        : const <UsbAudioDevice>[];
+
+    return UsbAudioStatus(
+      supported: map['supported'] == true,
+      androidSdk: _asInt(map['androidSdk']) ?? 0,
+      activeDeviceId: _asInt(map['activeDeviceId']),
+      preferredApplied: map['preferredApplied'] == true,
+      preferredSampleRate: _asInt(map['preferredSampleRate']),
+      preferredEncoding: map['preferredEncoding'] as String?,
+      preferredBitPerfect: map['preferredBitPerfect'] == true,
+      message: map['message'] as String?,
+      devices: devices,
+    );
+  }
+
+  int? get bestAvailableDeviceId {
+    if (activeDeviceId != null) {
+      return activeDeviceId;
+    }
+    return devices.isEmpty ? null : devices.first.id;
+  }
+
+  int? get bestAvailableSampleRate {
+    final deviceId = bestAvailableDeviceId;
+    if (deviceId == null) {
+      return null;
+    }
+    for (final device in devices) {
+      if (device.id == deviceId) {
+        return device.bestSampleRate;
+      }
+    }
+    return null;
+  }
+}
+
+@immutable
+class UsbAudioDevice {
+  final int id;
+  final String name;
+  final String type;
+  final String? address;
+  final List<int> sampleRates;
+  final List<String> encodings;
+  final List<int> channelCounts;
+  final List<int> supportedMixerSampleRates;
+  final bool supportsBitPerfectMixer;
+
+  const UsbAudioDevice({
+    required this.id,
+    required this.name,
+    required this.type,
+    required this.address,
+    required this.sampleRates,
+    required this.encodings,
+    required this.channelCounts,
+    required this.supportedMixerSampleRates,
+    required this.supportsBitPerfectMixer,
+  });
+
+  factory UsbAudioDevice.fromMap(Map<String, Object?> map) {
+    return UsbAudioDevice(
+      id: _asInt(map['id']) ?? -1,
+      name: (map['name'] as String?)?.trim().isNotEmpty == true
+          ? map['name'] as String
+          : 'USB audio device',
+      type: map['type'] as String? ?? 'unknown',
+      address: map['address'] as String?,
+      sampleRates: _asIntList(map['sampleRates']),
+      encodings: _asStringList(map['encodings']),
+      channelCounts: _asIntList(map['channelCounts']),
+      supportedMixerSampleRates: _asIntList(map['supportedMixerSampleRates']),
+      supportsBitPerfectMixer: map['supportsBitPerfectMixer'] == true,
+    );
+  }
+
+  int? get bestSampleRate {
+    final candidates = supportedMixerSampleRates.isNotEmpty
+        ? supportedMixerSampleRates
+        : sampleRates;
+    if (candidates.isEmpty) {
+      return null;
+    }
+    final sorted = [...candidates]..sort();
+    return sorted.last;
+  }
+}
+
+int? _asInt(Object? value) {
+  if (value is int) return value;
+  if (value is num) return value.toInt();
+  return null;
+}
+
+List<int> _asIntList(Object? value) {
+  if (value is! List) {
+    return const [];
+  }
+  return value.map(_asInt).whereType<int>().toList(growable: false);
+}
+
+List<String> _asStringList(Object? value) {
+  if (value is! List) {
+    return const [];
+  }
+  return value.whereType<String>().toList(growable: false);
+}

--- a/lib/base/services/usb_audio_service.dart
+++ b/lib/base/services/usb_audio_service.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:sylvakru/base/services/usb_audio_preferences.dart';
 
 final usbAudioService = UsbAudioService();
 final usbAudioStatusNotifier = ValueNotifier(UsbAudioStatus.unavailable());
@@ -303,6 +304,7 @@ class UsbExclusiveCapability {
 class UsbExclusivePlaybackRequest {
   final String filePath;
   final String? title;
+  final String? sourceFormat;
   final int? sampleRate;
   final int? bitDepth;
   final bool startPaused;
@@ -310,6 +312,7 @@ class UsbExclusivePlaybackRequest {
   const UsbExclusivePlaybackRequest({
     required this.filePath,
     required this.title,
+    required this.sourceFormat,
     required this.sampleRate,
     required this.bitDepth,
     required this.startPaused,
@@ -319,6 +322,7 @@ class UsbExclusivePlaybackRequest {
     return {
       'filePath': filePath,
       'title': title,
+      'sourceFormat': sourceFormat,
       'sampleRate': sampleRate,
       'bitDepth': bitDepth,
       'startPaused': startPaused,
@@ -583,8 +587,15 @@ class UsbAudioDevice {
     if (candidates.isEmpty) {
       return null;
     }
-    final sorted = [...candidates]..sort();
-    return sorted.last;
+    final validRates = candidates
+        .where(UsbAudioPreferences.sampleRates.contains)
+        .toSet();
+    for (final rate in const [48000, 44100, 96000, 88200, 192000, 176400]) {
+      if (validRates.contains(rate)) {
+        return rate;
+      }
+    }
+    return null;
   }
 }
 

--- a/lib/base/services/usb_audio_service.dart
+++ b/lib/base/services/usb_audio_service.dart
@@ -5,6 +5,9 @@ import 'package:flutter/services.dart';
 
 final usbAudioService = UsbAudioService();
 final usbAudioStatusNotifier = ValueNotifier(UsbAudioStatus.unavailable());
+final usbAudioEventNotifier = ValueNotifier<UsbAudioDeviceEvent?>(null);
+
+enum UsbAudioDeviceEventType { added, removed }
 
 class UsbAudioService {
   static const MethodChannel _defaultChannel = MethodChannel(
@@ -16,7 +19,9 @@ class UsbAudioService {
 
   UsbAudioService({MethodChannel channel = _defaultChannel, bool? isAndroid})
     : _channel = channel,
-      _isAndroid = isAndroid ?? Platform.isAndroid;
+      _isAndroid = isAndroid ?? Platform.isAndroid {
+    _channel.setMethodCallHandler(_handleNativeCall);
+  }
 
   Future<UsbAudioStatus> refreshStatus() async {
     if (!_isAndroid) {
@@ -82,6 +87,47 @@ class UsbAudioService {
       return status;
     }
   }
+
+  Future<Object?> _handleNativeCall(MethodCall call) async {
+    if (call.method != 'onUsbAudioDeviceEvent') {
+      throw PlatformException(
+        code: 'unimplemented',
+        message: 'Unknown USB audio callback: ${call.method}',
+      );
+    }
+
+    final event = UsbAudioDeviceEvent.fromMap(
+      (call.arguments as Map).cast<String, Object?>(),
+    );
+    usbAudioStatusNotifier.value = event.status;
+    usbAudioEventNotifier.value = event;
+    return null;
+  }
+}
+
+@immutable
+class UsbAudioDeviceEvent {
+  final UsbAudioDeviceEventType type;
+  final int? deviceId;
+  final UsbAudioStatus status;
+
+  const UsbAudioDeviceEvent({
+    required this.type,
+    required this.deviceId,
+    required this.status,
+  });
+
+  factory UsbAudioDeviceEvent.fromMap(Map<String, Object?> map) {
+    return UsbAudioDeviceEvent(
+      type: map['type'] == 'removed'
+          ? UsbAudioDeviceEventType.removed
+          : UsbAudioDeviceEventType.added,
+      deviceId: _asInt(map['deviceId']),
+      status: UsbAudioStatus.fromMap(
+        (map['status'] as Map?)?.cast<String, Object?>() ?? const {},
+      ),
+    );
+  }
 }
 
 @immutable
@@ -93,6 +139,9 @@ class UsbAudioStatus {
   final int? preferredSampleRate;
   final String? preferredEncoding;
   final bool preferredBitPerfect;
+  final String? outputDeviceName;
+  final int? outputSampleRate;
+  final String? outputEncoding;
   final String? message;
   final List<UsbAudioDevice> devices;
 
@@ -104,6 +153,9 @@ class UsbAudioStatus {
     required this.preferredSampleRate,
     required this.preferredEncoding,
     required this.preferredBitPerfect,
+    required this.outputDeviceName,
+    required this.outputSampleRate,
+    required this.outputEncoding,
     required this.message,
     required this.devices,
   });
@@ -117,6 +169,9 @@ class UsbAudioStatus {
       preferredSampleRate: null,
       preferredEncoding: null,
       preferredBitPerfect: false,
+      outputDeviceName: null,
+      outputSampleRate: null,
+      outputEncoding: null,
       message: message,
       devices: const [],
     );
@@ -142,6 +197,9 @@ class UsbAudioStatus {
       preferredSampleRate: _asInt(map['preferredSampleRate']),
       preferredEncoding: map['preferredEncoding'] as String?,
       preferredBitPerfect: map['preferredBitPerfect'] == true,
+      outputDeviceName: map['outputDeviceName'] as String?,
+      outputSampleRate: _asInt(map['outputSampleRate']),
+      outputEncoding: map['outputEncoding'] as String?,
       message: map['message'] as String?,
       devices: devices,
     );

--- a/lib/base/utils/path.dart
+++ b/lib/base/utils/path.dart
@@ -67,7 +67,15 @@ String getPicturesPath(SourceType sourceType) {
 final _httpClient = http.Client();
 
 Future<String?> convertToRealPathIfNeed(String path) async {
-  final request = http.Request('HEAD', Uri.parse(path))
+  final uri = Uri.tryParse(path);
+  if (uri == null ||
+      !(uri.isScheme('http') || uri.isScheme('https')) ||
+      !uri.hasAuthority ||
+      uri.host.isEmpty) {
+    return null;
+  }
+
+  final request = http.Request('HEAD', uri)
     ..followRedirects = false
     ..headers.addAll(webdavClient?.headers ?? {});
 

--- a/lib/base/widgets/audio_output_panel.dart
+++ b/lib/base/widgets/audio_output_panel.dart
@@ -1,0 +1,629 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:sylvakru/base/my_audio_metadata.dart';
+import 'package:sylvakru/base/services/interaction.dart';
+import 'package:sylvakru/base/services/usb_audio_service.dart';
+
+String formatSampleRate(int? sampleRate) {
+  if (sampleRate == null || sampleRate <= 0) {
+    return '未知';
+  }
+
+  final khz = sampleRate / 1000.0;
+  if (khz == khz.roundToDouble()) {
+    return '${khz.round()} kHz';
+  }
+  return '${khz.toStringAsFixed(1)} kHz';
+}
+
+String formatBitrate(int? bitrate) {
+  if (bitrate == null || bitrate <= 0) {
+    return '未知';
+  }
+  return '${(bitrate / 1000).round()} kbps';
+}
+
+List<int?> buildSampleRateOptions(
+  UsbAudioStatus status,
+  int? sourceSampleRate,
+) {
+  final options = <int?>[null];
+  final deviceId = status.bestAvailableDeviceId;
+  UsbAudioDevice? activeDevice;
+
+  for (final device in status.devices) {
+    if (device.id == deviceId) {
+      activeDevice = device;
+      break;
+    }
+  }
+
+  final preferredRates =
+      activeDevice?.supportedMixerSampleRates.isNotEmpty == true
+      ? activeDevice!.supportedMixerSampleRates
+      : activeDevice?.sampleRates ?? const <int>[];
+  final sortedRates = preferredRates.toSet().toList()..sort();
+
+  options.addAll(sortedRates);
+  if (sourceSampleRate != null &&
+      sourceSampleRate > 0 &&
+      !options.contains(sourceSampleRate)) {
+    options.add(sourceSampleRate);
+  }
+  return options;
+}
+
+class AudioOutputChip extends StatelessWidget {
+  final MyAudioMetadata? song;
+  final Color color;
+
+  const AudioOutputChip({super.key, required this.song, required this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder(
+      valueListenable: usbAudioStatusNotifier,
+      builder: (context, status, child) {
+        final sourceRate = formatSampleRate(song?.samplerate);
+        final outputName = _shortOutputName(status);
+        final bitDepth = _bitDepthLabel(status);
+
+        return Center(
+          child: Material(
+            color: Colors.transparent,
+            child: InkWell(
+              borderRadius: BorderRadius.circular(999),
+              onTap: () {
+                tryVibrate();
+                showAudioOutputSheet(context, song);
+              },
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(999),
+                child: BackdropFilter(
+                  filter: ImageFilter.blur(sigmaX: 18, sigmaY: 18),
+                  child: Container(
+                    constraints: const BoxConstraints(maxWidth: 320),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 14,
+                      vertical: 9,
+                    ),
+                    decoration: BoxDecoration(
+                      color: Colors.black.withAlpha(62),
+                      borderRadius: BorderRadius.circular(999),
+                      border: Border.all(color: color.withAlpha(62)),
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        _PulseDot(active: status.supported),
+                        const SizedBox(width: 9),
+                        Flexible(
+                          child: Text(
+                            '$sourceRate  |  $bitDepth  |  $outputName',
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              color: color.withAlpha(232),
+                              fontSize: 13,
+                              fontWeight: FontWeight.w600,
+                              letterSpacing: 0,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 7),
+                        Icon(
+                          Icons.tune_rounded,
+                          size: 17,
+                          color: color.withAlpha(214),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+Future<void> showAudioOutputSheet(
+  BuildContext context,
+  MyAudioMetadata? song,
+) async {
+  await usbAudioService.refreshStatus();
+  if (!context.mounted) return;
+
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    useSafeArea: true,
+    backgroundColor: Colors.transparent,
+    builder: (context) => _AudioOutputSheet(song: song),
+  );
+}
+
+class _AudioOutputSheet extends StatefulWidget {
+  final MyAudioMetadata? song;
+
+  const _AudioOutputSheet({required this.song});
+
+  @override
+  State<_AudioOutputSheet> createState() => _AudioOutputSheetState();
+}
+
+class _AudioOutputSheetState extends State<_AudioOutputSheet> {
+  int? _applyingRate;
+
+  Future<void> _applySampleRate(int? sampleRate) async {
+    setState(() {
+      _applyingRate = sampleRate ?? -1;
+    });
+
+    final status = usbAudioStatusNotifier.value;
+    final nextStatus = await usbAudioService.applyPreferredOutput(
+      deviceId: status.bestAvailableDeviceId,
+      sampleRate: sampleRate,
+    );
+
+    if (!mounted) return;
+    setState(() {
+      _applyingRate = null;
+    });
+
+    final message = nextStatus.message ?? '已发送采样率请求';
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(message), behavior: SnackBarBehavior.floating),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final foreground = Colors.white.withAlpha(235);
+    final muted = Colors.white.withAlpha(150);
+
+    return ValueListenableBuilder(
+      valueListenable: usbAudioStatusNotifier,
+      builder: (context, status, child) {
+        final selectedRate = status.preferredSampleRate;
+        final options = buildSampleRateOptions(status, widget.song?.samplerate);
+
+        return Padding(
+          padding: EdgeInsets.only(
+            left: 12,
+            right: 12,
+            bottom: MediaQuery.viewInsetsOf(context).bottom + 12,
+          ),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(28),
+            child: BackdropFilter(
+              filter: ImageFilter.blur(sigmaX: 24, sigmaY: 24),
+              child: Container(
+                constraints: BoxConstraints(
+                  maxHeight: MediaQuery.heightOf(context) * 0.82,
+                ),
+                decoration: BoxDecoration(
+                  color: const Color(0xE6111114),
+                  borderRadius: BorderRadius.circular(28),
+                  border: Border.all(color: Colors.white.withAlpha(18)),
+                ),
+                child: ListView(
+                  shrinkWrap: true,
+                  padding: const EdgeInsets.fromLTRB(18, 14, 18, 22),
+                  children: [
+                    Center(
+                      child: Container(
+                        width: 44,
+                        height: 4,
+                        decoration: BoxDecoration(
+                          color: Colors.white.withAlpha(45),
+                          borderRadius: BorderRadius.circular(99),
+                        ),
+                      ),
+                    ),
+                    const SizedBox(height: 20),
+                    Row(
+                      children: [
+                        _OutputGlyph(active: status.supported),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                '音频输出',
+                                style: TextStyle(
+                                  color: foreground,
+                                  fontSize: 22,
+                                  fontWeight: FontWeight.w800,
+                                  letterSpacing: 0,
+                                ),
+                              ),
+                              const SizedBox(height: 4),
+                              Text(
+                                status.message ?? '查看当前音频链路与采样率',
+                                maxLines: 2,
+                                overflow: TextOverflow.ellipsis,
+                                style: TextStyle(color: muted, fontSize: 13),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 18),
+                    _SignalSection(
+                      title: '音频源',
+                      accent: const Color(0xFFFFCF33),
+                      rows: [
+                        _InfoRow('文件', _sourcePathLabel(widget.song)),
+                        _InfoRow(
+                          '输入采样率',
+                          formatSampleRate(widget.song?.samplerate),
+                        ),
+                        _InfoRow(
+                          '格式',
+                          widget.song?.format?.toUpperCase() ?? '未知',
+                        ),
+                        _InfoRow('码率', formatBitrate(widget.song?.bitrate)),
+                      ],
+                    ),
+                    const SizedBox(height: 12),
+                    _SignalSection(
+                      title: '处理链',
+                      accent: const Color(0xFF8E8E94),
+                      rows: const [
+                        _InfoRow('均衡器', '关闭'),
+                        _InfoRow('PEQ', '关闭'),
+                        _InfoRow('DSP 插件', '未接入'),
+                      ],
+                    ),
+                    const SizedBox(height: 12),
+                    _SignalSection(
+                      title: '信号输出',
+                      accent: status.supported
+                          ? const Color(0xFF50D890)
+                          : const Color(0xFFFFA33A),
+                      rows: [
+                        _InfoRow('输出端口', _outputPortLabel(status)),
+                        _InfoRow(
+                          '输出采样率',
+                          formatSampleRate(status.preferredSampleRate),
+                        ),
+                        _InfoRow(
+                          '编码',
+                          status.preferredEncoding ?? 'PCM / 系统默认',
+                        ),
+                        _InfoRow(
+                          'Bit-perfect',
+                          status.preferredBitPerfect
+                              ? '已请求'
+                              : status.supported
+                              ? '未启用'
+                              : '不可用',
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 18),
+                    Text(
+                      '采样率',
+                      style: TextStyle(
+                        color: foreground,
+                        fontSize: 16,
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                    const SizedBox(height: 10),
+                    Wrap(
+                      spacing: 8,
+                      runSpacing: 8,
+                      children: [
+                        for (final rate in options)
+                          _SampleRateChoice(
+                            label: rate == null ? '自动' : formatSampleRate(rate),
+                            selected:
+                                rate == selectedRate ||
+                                (rate == null && selectedRate == null),
+                            enabled: status.supported,
+                            applying: _applyingRate == (rate ?? -1),
+                            onTap: () => _applySampleRate(rate),
+                          ),
+                      ],
+                    ),
+                    if (!status.supported) ...[
+                      const SizedBox(height: 14),
+                      Text(
+                        '未检测到 USB DAC。当前只能显示音频源信息，采样率选择会在连接 USB 音频设备后启用。',
+                        style: TextStyle(
+                          color: Colors.white.withAlpha(128),
+                          fontSize: 12,
+                          height: 1.45,
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _SignalSection extends StatelessWidget {
+  final String title;
+  final Color accent;
+  final List<_InfoRow> rows;
+
+  const _SignalSection({
+    required this.title,
+    required this.accent,
+    required this.rows,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: Colors.white.withAlpha(12),
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(color: Colors.white.withAlpha(16)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Column(
+            children: [
+              Container(
+                width: 12,
+                height: 12,
+                decoration: BoxDecoration(
+                  color: accent,
+                  shape: BoxShape.circle,
+                ),
+              ),
+              Container(
+                width: 2,
+                height: 78,
+                margin: const EdgeInsets.only(top: 6),
+                decoration: BoxDecoration(
+                  color: accent.withAlpha(76),
+                  borderRadius: BorderRadius.circular(99),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: TextStyle(
+                    color: Colors.white.withAlpha(232),
+                    fontSize: 15,
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+                const SizedBox(height: 10),
+                for (final row in rows) _InfoLine(row: row),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _InfoLine extends StatelessWidget {
+  final _InfoRow row;
+
+  const _InfoLine({required this.row});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 7),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 86,
+            child: Text(
+              row.label,
+              style: TextStyle(
+                color: Colors.white.withAlpha(126),
+                fontSize: 13,
+              ),
+            ),
+          ),
+          Expanded(
+            child: Text(
+              row.value,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                color: Colors.white.withAlpha(222),
+                fontSize: 13,
+                height: 1.25,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SampleRateChoice extends StatelessWidget {
+  final String label;
+  final bool selected;
+  final bool enabled;
+  final bool applying;
+  final VoidCallback onTap;
+
+  const _SampleRateChoice({
+    required this.label,
+    required this.selected,
+    required this.enabled,
+    required this.applying,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = selected ? const Color(0xFFFFCF33) : Colors.white;
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(999),
+        onTap: enabled && !applying ? onTap : null,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 180),
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+          decoration: BoxDecoration(
+            color: selected
+                ? const Color(0xFFFFCF33).withAlpha(42)
+                : Colors.white.withAlpha(13),
+            borderRadius: BorderRadius.circular(999),
+            border: Border.all(color: accent.withAlpha(selected ? 160 : 38)),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (applying) ...[
+                SizedBox(
+                  width: 12,
+                  height: 12,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    color: accent,
+                  ),
+                ),
+                const SizedBox(width: 7),
+              ],
+              Text(
+                label,
+                style: TextStyle(
+                  color: enabled ? accent.withAlpha(230) : Colors.white54,
+                  fontSize: 13,
+                  fontWeight: selected ? FontWeight.w800 : FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _OutputGlyph extends StatelessWidget {
+  final bool active;
+
+  const _OutputGlyph({required this.active});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 46,
+      height: 46,
+      decoration: BoxDecoration(
+        color: active
+            ? const Color(0xFFFFCF33).withAlpha(45)
+            : Colors.white.withAlpha(18),
+        shape: BoxShape.circle,
+        border: Border.all(
+          color: active ? const Color(0xFFFFCF33) : Colors.white24,
+        ),
+      ),
+      child: Icon(
+        active ? Icons.usb_rounded : Icons.graphic_eq_rounded,
+        color: active ? const Color(0xFFFFCF33) : Colors.white70,
+      ),
+    );
+  }
+}
+
+class _PulseDot extends StatelessWidget {
+  final bool active;
+
+  const _PulseDot({required this.active});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 8,
+      height: 8,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: active ? const Color(0xFFFFCF33) : Colors.white54,
+        boxShadow: active
+            ? [
+                BoxShadow(
+                  color: const Color(0xFFFFCF33).withAlpha(130),
+                  blurRadius: 12,
+                  spreadRadius: 2,
+                ),
+              ]
+            : null,
+      ),
+    );
+  }
+}
+
+class _InfoRow {
+  final String label;
+  final String value;
+
+  const _InfoRow(this.label, this.value);
+}
+
+String _shortOutputName(UsbAudioStatus status) {
+  if (!status.supported) {
+    return 'Android';
+  }
+  for (final device in status.devices) {
+    if (device.id == status.bestAvailableDeviceId) {
+      return device.name;
+    }
+  }
+  return 'USB DAC';
+}
+
+String _bitDepthLabel(UsbAudioStatus status) {
+  final encoding = status.preferredEncoding;
+  if (encoding == 'pcm_32bit') return '32 bits';
+  if (encoding == 'pcm_24bit_packed') return '24 bits';
+  if (encoding == 'pcm_16bit') return '16 bits';
+  return '未知';
+}
+
+String _outputPortLabel(UsbAudioStatus status) {
+  if (!status.supported) {
+    return 'Android';
+  }
+  final name = _shortOutputName(status);
+  return status.preferredApplied ? '$name · 已应用偏好' : '$name · 系统输出';
+}
+
+String _sourcePathLabel(MyAudioMetadata? song) {
+  final path = song?.cachePath ?? song?.path;
+  if (path == null || path.isEmpty) {
+    return '未知';
+  }
+  if (path.length <= 48) {
+    return path;
+  }
+  return '...${path.substring(path.length - 45)}';
+}

--- a/lib/base/widgets/audio_output_panel.dart
+++ b/lib/base/widgets/audio_output_panel.dart
@@ -47,7 +47,8 @@ String formatBitrate(int? bitrate) {
   if (bitrate == null || bitrate <= 0) {
     return '未知';
   }
-  return '${(bitrate / 1000).round()} kbps';
+  final kbps = bitrate >= 100000 ? (bitrate / 1000).round() : bitrate;
+  return '$kbps kbps';
 }
 
 String formatSourceFileName(String? path) {
@@ -63,8 +64,12 @@ String formatOutputPortLabel(UsbAudioStatus status) {
   if (!status.supported) {
     return formatOutputDeviceName(status);
   }
+  final exclusive = usbExclusivePlaybackStateNotifier.value;
+  if (exclusive.active) {
+    return 'USB 独占';
+  }
   final name = _shortOutputName(status);
-  return status.preferredApplied ? '$name · 已应用偏好' : '$name · 系统输出';
+  return status.preferredApplied ? '$name · 已应用偏好' : '$name · USB 输出';
 }
 
 List<int?> buildSampleRateOptions(

--- a/lib/base/widgets/audio_output_panel.dart
+++ b/lib/base/widgets/audio_output_panel.dart
@@ -28,11 +28,22 @@ String formatOutputSampleRate(UsbAudioStatus status) {
   );
 }
 
+String formatOutputDeviceName(UsbAudioStatus status) {
+  if (!status.supported) {
+    return status.outputDeviceName ?? 'Android';
+  }
+  final device = _activeUsbDevice(status);
+  if (device != null) {
+    return device.name;
+  }
+  return status.outputDeviceName ?? 'USB DAC';
+}
+
 String formatBitrate(int? bitrate) {
   if (bitrate == null || bitrate <= 0) {
     return '未知';
   }
-  return '${(bitrate / 1000).round()} kbps';
+  return '约 ${(bitrate / 1000).round()} kbps（源文件元数据）';
 }
 
 List<int?> buildSampleRateOptions(
@@ -440,30 +451,6 @@ class _AudioOutputSheet extends StatefulWidget {
 }
 
 class _AudioOutputSheetState extends State<_AudioOutputSheet> {
-  int? _applyingRate;
-
-  Future<void> _applySampleRate(int? sampleRate) async {
-    setState(() {
-      _applyingRate = sampleRate ?? -1;
-    });
-
-    final status = usbAudioStatusNotifier.value;
-    final nextStatus = await usbAudioService.applyPreferredOutput(
-      deviceId: status.bestAvailableDeviceId,
-      sampleRate: sampleRate,
-    );
-
-    if (!mounted) return;
-    setState(() {
-      _applyingRate = null;
-    });
-
-    final message = nextStatus.message ?? '已发送采样率请求';
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text(message), behavior: SnackBarBehavior.floating),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     final foreground = lyricsPageForegroundColor.value;
@@ -476,9 +463,6 @@ class _AudioOutputSheetState extends State<_AudioOutputSheet> {
     return ValueListenableBuilder(
       valueListenable: usbAudioStatusNotifier,
       builder: (context, status, child) {
-        final selectedRate = status.preferredSampleRate;
-        final options = buildSampleRateOptions(status, widget.song?.samplerate);
-
         return Padding(
           padding: EdgeInsets.only(
             left: 12,
@@ -531,7 +515,7 @@ class _AudioOutputSheetState extends State<_AudioOutputSheet> {
                             ),
                             const SizedBox(height: 4),
                             Text(
-                              status.message ?? '查看当前音频链路与采样率',
+                              formatOutputDeviceName(status),
                               maxLines: 2,
                               overflow: TextOverflow.ellipsis,
                               style: TextStyle(color: muted, fontSize: 13),
@@ -600,39 +584,10 @@ class _AudioOutputSheetState extends State<_AudioOutputSheet> {
                       ),
                     ],
                   ),
-                  const SizedBox(height: 18),
-                  Text(
-                    '采样率',
-                    style: TextStyle(
-                      color: foreground,
-                      fontSize: 16,
-                      fontWeight: FontWeight.w800,
-                    ),
-                  ),
-                  const SizedBox(height: 10),
-                  Wrap(
-                    spacing: 8,
-                    runSpacing: 8,
-                    children: [
-                      for (final rate in options)
-                        _SampleRateChoice(
-                          label: rate == null ? '自动' : formatSampleRate(rate),
-                          selected:
-                              rate == selectedRate ||
-                              (rate == null && selectedRate == null),
-                          enabled: status.supported,
-                          applying: _applyingRate == (rate ?? -1),
-                          accent: highlight,
-                          foreground: foreground,
-                          surface: surface,
-                          onTap: () => _applySampleRate(rate),
-                        ),
-                    ],
-                  ),
                   if (!status.supported) ...[
                     const SizedBox(height: 14),
                     Text(
-                      '未检测到 USB DAC。当前显示 Android 系统输出信息；采样率选择会在连接 USB 音频设备后启用。',
+                      '未检测到 USB DAC。当前显示 Android 系统输出信息。',
                       style: TextStyle(
                         color: muted,
                         fontSize: 12,
@@ -766,78 +721,6 @@ class _InfoLine extends StatelessWidget {
             ),
           ),
         ],
-      ),
-    );
-  }
-}
-
-class _SampleRateChoice extends StatelessWidget {
-  final String label;
-  final bool selected;
-  final bool enabled;
-  final bool applying;
-  final Color accent;
-  final Color foreground;
-  final Color surface;
-  final VoidCallback onTap;
-
-  const _SampleRateChoice({
-    required this.label,
-    required this.selected,
-    required this.enabled,
-    required this.applying,
-    required this.accent,
-    required this.foreground,
-    required this.surface,
-    required this.onTap,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final displayColor = selected ? accent : foreground;
-
-    return Material(
-      color: Colors.transparent,
-      child: InkWell(
-        borderRadius: BorderRadius.circular(999),
-        onTap: enabled && !applying ? onTap : null,
-        child: AnimatedContainer(
-          duration: const Duration(milliseconds: 180),
-          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
-          decoration: BoxDecoration(
-            color: selected ? accent.withAlpha(42) : surface,
-            borderRadius: BorderRadius.circular(999),
-            border: Border.all(
-              color: displayColor.withAlpha(selected ? 160 : 42),
-            ),
-          ),
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              if (applying) ...[
-                SizedBox(
-                  width: 12,
-                  height: 12,
-                  child: CircularProgressIndicator(
-                    strokeWidth: 2,
-                    color: displayColor,
-                  ),
-                ),
-                const SizedBox(width: 7),
-              ],
-              Text(
-                label,
-                style: TextStyle(
-                  color: enabled
-                      ? displayColor.withAlpha(230)
-                      : foreground.withAlpha(96),
-                  fontSize: 13,
-                  fontWeight: selected ? FontWeight.w800 : FontWeight.w600,
-                ),
-              ),
-            ],
-          ),
-        ),
       ),
     );
   }

--- a/lib/base/widgets/audio_output_panel.dart
+++ b/lib/base/widgets/audio_output_panel.dart
@@ -30,7 +30,11 @@ String formatOutputSampleRate(UsbAudioStatus status) {
 
 String formatOutputDeviceName(UsbAudioStatus status) {
   if (!status.supported) {
-    return status.outputDeviceName ?? 'Android';
+    final name = status.outputDeviceName?.toLowerCase();
+    if (name == null || name.contains('speaker') || name.contains('扬声器')) {
+      return '扬声器';
+    }
+    return status.outputDeviceName!;
   }
   final device = _activeUsbDevice(status);
   if (device != null) {
@@ -43,7 +47,24 @@ String formatBitrate(int? bitrate) {
   if (bitrate == null || bitrate <= 0) {
     return '未知';
   }
-  return '约 ${(bitrate / 1000).round()} kbps（源文件元数据）';
+  return '${(bitrate / 1000).round()} kbps';
+}
+
+String formatSourceFileName(String? path) {
+  if (path == null || path.isEmpty) {
+    return '未知';
+  }
+  final normalized = path.replaceAll('\\', '/');
+  final parts = normalized.split('/');
+  return parts.isEmpty ? normalized : parts.last;
+}
+
+String formatOutputPortLabel(UsbAudioStatus status) {
+  if (!status.supported) {
+    return formatOutputDeviceName(status);
+  }
+  final name = _shortOutputName(status);
+  return status.preferredApplied ? '$name · 已应用偏好' : '$name · 系统输出';
 }
 
 List<int?> buildSampleRateOptions(
@@ -794,11 +815,11 @@ class _InfoRow {
 String _shortOutputName(UsbAudioStatus status) {
   final exclusive = usbExclusivePlaybackStateNotifier.value;
   if (exclusive.active) {
-    return 'USB 真独占';
+    return 'USB';
   }
 
   if (!status.supported) {
-    return status.outputDeviceName ?? 'Android';
+    return formatOutputDeviceName(status);
   }
   final device = _activeUsbDevice(status);
   if (device != null) return device.name;
@@ -867,22 +888,11 @@ String _outputEncodingLabel(UsbAudioStatus status) {
 }
 
 String _outputPortLabel(UsbAudioStatus status) {
-  if (!status.supported) {
-    return status.outputDeviceName ?? 'Android';
-  }
-  final name = _shortOutputName(status);
-  return status.preferredApplied ? '$name · 已应用偏好' : '$name · 系统输出';
+  return formatOutputPortLabel(status);
 }
 
 String _sourcePathLabel(MyAudioMetadata? song) {
-  final path = song?.cachePath ?? song?.path;
-  if (path == null || path.isEmpty) {
-    return '未知';
-  }
-  if (path.length <= 48) {
-    return path;
-  }
-  return '...${path.substring(path.length - 45)}';
+  return formatSourceFileName(song?.path ?? song?.cachePath);
 }
 
 Color _chipColor(Color foreground) {

--- a/lib/base/widgets/audio_output_panel.dart
+++ b/lib/base/widgets/audio_output_panel.dart
@@ -1,8 +1,8 @@
-import 'dart:ui';
-
 import 'package:flutter/material.dart';
 import 'package:sylvakru/base/my_audio_metadata.dart';
+import 'package:sylvakru/base/services/color_manager.dart';
 import 'package:sylvakru/base/services/interaction.dart';
+import 'package:sylvakru/base/services/usb_audio_preferences.dart';
 import 'package:sylvakru/base/services/usb_audio_service.dart';
 
 String formatSampleRate(int? sampleRate) {
@@ -15,6 +15,12 @@ String formatSampleRate(int? sampleRate) {
     return '${khz.round()} kHz';
   }
   return '${khz.toStringAsFixed(1)} kHz';
+}
+
+String formatOutputSampleRate(UsbAudioStatus status) {
+  return formatSampleRate(
+    status.preferredSampleRate ?? status.outputSampleRate,
+  );
 }
 
 String formatBitrate(int? bitrate) {
@@ -54,6 +60,35 @@ List<int?> buildSampleRateOptions(
   return options;
 }
 
+int? preferredExclusiveSampleRate(
+  UsbAudioStatus status,
+  int? sourceSampleRate,
+) {
+  final fixedRate = usbAudioPreferences.preferredFixedSampleRate();
+  if (fixedRate != null) {
+    return fixedRate;
+  }
+
+  final deviceRates = buildSampleRateOptions(status, null).whereType<int>();
+  if (sourceSampleRate != null &&
+      sourceSampleRate > 0 &&
+      deviceRates.contains(sourceSampleRate)) {
+    return sourceSampleRate;
+  }
+  return status.bestAvailableSampleRate;
+}
+
+Future<UsbAudioStatus> applyExclusiveOutputForSong(
+  UsbAudioStatus status,
+  MyAudioMetadata? song,
+) {
+  return usbAudioService.applyPreferredOutput(
+    deviceId: status.bestAvailableDeviceId,
+    sampleRate: preferredExclusiveSampleRate(status, song?.samplerate),
+    encoding: usbAudioPreferences.preferredEncoding(),
+  );
+}
+
 class AudioOutputChip extends StatelessWidget {
   final MyAudioMetadata? song;
   final Color color;
@@ -65,9 +100,10 @@ class AudioOutputChip extends StatelessWidget {
     return ValueListenableBuilder(
       valueListenable: usbAudioStatusNotifier,
       builder: (context, status, child) {
-        final sourceRate = formatSampleRate(song?.samplerate);
+        final outputRate = formatOutputSampleRate(status);
         final outputName = _shortOutputName(status);
         final bitDepth = _bitDepthLabel(status);
+        final chipColor = _chipColor(color);
 
         return Center(
           child: Material(
@@ -78,48 +114,49 @@ class AudioOutputChip extends StatelessWidget {
                 tryVibrate();
                 showAudioOutputSheet(context, song);
               },
-              child: ClipRRect(
-                borderRadius: BorderRadius.circular(999),
-                child: BackdropFilter(
-                  filter: ImageFilter.blur(sigmaX: 18, sigmaY: 18),
-                  child: Container(
-                    constraints: const BoxConstraints(maxWidth: 320),
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 14,
-                      vertical: 9,
+              child: Container(
+                constraints: const BoxConstraints(maxWidth: 320),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 14,
+                  vertical: 9,
+                ),
+                decoration: BoxDecoration(
+                  color: chipColor,
+                  borderRadius: BorderRadius.circular(999),
+                  border: Border.all(color: color.withAlpha(62)),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withAlpha(34),
+                      blurRadius: 14,
+                      offset: const Offset(0, 6),
                     ),
-                    decoration: BoxDecoration(
-                      color: Colors.black.withAlpha(62),
-                      borderRadius: BorderRadius.circular(999),
-                      border: Border.all(color: color.withAlpha(62)),
-                    ),
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        _PulseDot(active: status.supported),
-                        const SizedBox(width: 9),
-                        Flexible(
-                          child: Text(
-                            '$sourceRate  |  $bitDepth  |  $outputName',
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: TextStyle(
-                              color: color.withAlpha(232),
-                              fontSize: 13,
-                              fontWeight: FontWeight.w600,
-                              letterSpacing: 0,
-                            ),
-                          ),
+                  ],
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    _PulseDot(active: status.supported, color: color),
+                    const SizedBox(width: 9),
+                    Flexible(
+                      child: Text(
+                        '$outputRate  |  $bitDepth  |  $outputName',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          color: color.withAlpha(232),
+                          fontSize: 13,
+                          fontWeight: FontWeight.w600,
+                          letterSpacing: 0,
                         ),
-                        const SizedBox(width: 7),
-                        Icon(
-                          Icons.tune_rounded,
-                          size: 17,
-                          color: color.withAlpha(214),
-                        ),
-                      ],
+                      ),
                     ),
-                  ),
+                    const SizedBox(width: 7),
+                    Icon(
+                      Icons.tune_rounded,
+                      size: 17,
+                      color: color.withAlpha(214),
+                    ),
+                  ],
                 ),
               ),
             ),
@@ -141,9 +178,217 @@ Future<void> showAudioOutputSheet(
     context: context,
     isScrollControlled: true,
     useSafeArea: true,
+    barrierColor: _barrierColor(),
     backgroundColor: Colors.transparent,
-    builder: (context) => _AudioOutputSheet(song: song),
+    builder: (context) => RepaintBoundary(child: _AudioOutputSheet(song: song)),
   );
+}
+
+Future<void> showUsbAudioDetectedSheet(
+  BuildContext context,
+  UsbAudioStatus status,
+  MyAudioMetadata? song,
+) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    useSafeArea: true,
+    barrierColor: _barrierColor(),
+    backgroundColor: Colors.transparent,
+    builder: (context) => RepaintBoundary(
+      child: _UsbAudioDetectedSheet(
+        parentContext: context,
+        initialStatus: status,
+        song: song,
+      ),
+    ),
+  );
+}
+
+class _UsbAudioDetectedSheet extends StatefulWidget {
+  final BuildContext parentContext;
+  final UsbAudioStatus initialStatus;
+  final MyAudioMetadata? song;
+
+  const _UsbAudioDetectedSheet({
+    required this.parentContext,
+    required this.initialStatus,
+    required this.song,
+  });
+
+  @override
+  State<_UsbAudioDetectedSheet> createState() => _UsbAudioDetectedSheetState();
+}
+
+class _UsbAudioDetectedSheetState extends State<_UsbAudioDetectedSheet> {
+  bool _applying = false;
+  late UsbAudioStatus _status = widget.initialStatus;
+
+  Future<void> _enableExclusive() async {
+    setState(() {
+      _applying = true;
+    });
+
+    final nextStatus = await applyExclusiveOutputForSong(_status, widget.song);
+    if (!mounted) return;
+
+    setState(() {
+      _status = nextStatus;
+      _applying = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final foreground = lyricsPageForegroundColor.value;
+    final highlight = lyricsPageHighlightTextColor.value;
+    final background = _panelBackgroundColor(foreground);
+    final surface = _panelSurfaceColor(background, foreground);
+    final border = foreground.withAlpha(28);
+    final muted = foreground.withAlpha(150);
+    final canRequestExclusive =
+        _status.supported &&
+        _status.androidSdk >= 34 &&
+        _activeUsbDevice(_status)?.supportsBitPerfectMixer == true;
+
+    return Padding(
+      padding: EdgeInsets.only(
+        left: 12,
+        right: 12,
+        bottom: MediaQuery.viewInsetsOf(context).bottom + 12,
+      ),
+      child: Material(
+        color: background,
+        borderRadius: BorderRadius.circular(28),
+        clipBehavior: Clip.antiAlias,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(18, 16, 18, 20),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Center(
+                child: Container(
+                  width: 44,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: Colors.white.withAlpha(45),
+                    borderRadius: BorderRadius.circular(99),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 18),
+              Row(
+                children: [
+                  _OutputGlyph(active: true, accent: highlight),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          '检测到 USB DAC',
+                          style: TextStyle(
+                            color: foreground,
+                            fontSize: 22,
+                            fontWeight: FontWeight.w800,
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          _exclusiveStatusLabel(_status),
+                          style: TextStyle(color: muted, fontSize: 13),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              _SignalSection(
+                title: '设备',
+                accent: highlight,
+                foreground: foreground,
+                muted: muted,
+                surface: surface,
+                border: border,
+                rows: [
+                  _InfoRow('名称', _shortOutputName(_status)),
+                  _InfoRow('输出采样率', formatOutputSampleRate(_status)),
+                  _InfoRow('支持采样率', _supportedRatesLabel(_status)),
+                  _InfoRow('当前歌曲', formatSampleRate(widget.song?.samplerate)),
+                ],
+              ),
+              const SizedBox(height: 12),
+              _SignalSection(
+                title: '独占',
+                accent: canRequestExclusive
+                    ? const Color(0xFF50D890)
+                    : const Color(0xFFFFA33A),
+                foreground: foreground,
+                muted: muted,
+                surface: surface,
+                border: border,
+                rows: [
+                  _InfoRow('Android', 'API ${_status.androidSdk}'),
+                  _InfoRow('Bit-perfect', _bitPerfectSupportLabel(_status)),
+                  _InfoRow(
+                    '请求采样率',
+                    formatSampleRate(
+                      preferredExclusiveSampleRate(
+                        _status,
+                        widget.song?.samplerate,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 18),
+              Row(
+                children: [
+                  Expanded(
+                    child: OutlinedButton(
+                      onPressed: () {
+                        Navigator.of(context).pop();
+                        WidgetsBinding.instance.addPostFrameCallback((_) {
+                          if (widget.parentContext.mounted) {
+                            showAudioOutputSheet(
+                              widget.parentContext,
+                              widget.song,
+                            );
+                          }
+                        });
+                      },
+                      child: const Text('查看链路'),
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: ElevatedButton.icon(
+                      onPressed: canRequestExclusive && !_applying
+                          ? _enableExclusive
+                          : null,
+                      icon: _applying
+                          ? SizedBox(
+                              width: 16,
+                              height: 16,
+                              child: CircularProgressIndicator(
+                                strokeWidth: 2,
+                                color: foreground,
+                              ),
+                            )
+                          : const Icon(Icons.lock_rounded, size: 18),
+                      label: Text(_applying ? '请求中' : '启用独占'),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
 }
 
 class _AudioOutputSheet extends StatefulWidget {
@@ -182,8 +427,12 @@ class _AudioOutputSheetState extends State<_AudioOutputSheet> {
 
   @override
   Widget build(BuildContext context) {
-    final foreground = Colors.white.withAlpha(235);
-    final muted = Colors.white.withAlpha(150);
+    final foreground = lyricsPageForegroundColor.value;
+    final highlight = lyricsPageHighlightTextColor.value;
+    final background = _panelBackgroundColor(foreground);
+    final surface = _panelSurfaceColor(background, foreground);
+    final border = foreground.withAlpha(28);
+    final muted = foreground.withAlpha(150);
 
     return ValueListenableBuilder(
       valueListenable: usbAudioStatusNotifier,
@@ -197,155 +446,162 @@ class _AudioOutputSheetState extends State<_AudioOutputSheet> {
             right: 12,
             bottom: MediaQuery.viewInsetsOf(context).bottom + 12,
           ),
-          child: ClipRRect(
+          child: Material(
+            color: background,
             borderRadius: BorderRadius.circular(28),
-            child: BackdropFilter(
-              filter: ImageFilter.blur(sigmaX: 24, sigmaY: 24),
-              child: Container(
-                constraints: BoxConstraints(
-                  maxHeight: MediaQuery.heightOf(context) * 0.82,
-                ),
-                decoration: BoxDecoration(
-                  color: const Color(0xE6111114),
-                  borderRadius: BorderRadius.circular(28),
-                  border: Border.all(color: Colors.white.withAlpha(18)),
-                ),
-                child: ListView(
-                  shrinkWrap: true,
-                  padding: const EdgeInsets.fromLTRB(18, 14, 18, 22),
-                  children: [
-                    Center(
-                      child: Container(
-                        width: 44,
-                        height: 4,
-                        decoration: BoxDecoration(
-                          color: Colors.white.withAlpha(45),
-                          borderRadius: BorderRadius.circular(99),
-                        ),
+            clipBehavior: Clip.antiAlias,
+            child: Container(
+              constraints: BoxConstraints(
+                maxHeight: MediaQuery.heightOf(context) * 0.82,
+              ),
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(28),
+                border: Border.all(color: border),
+              ),
+              child: ListView(
+                shrinkWrap: true,
+                padding: const EdgeInsets.fromLTRB(18, 14, 18, 22),
+                children: [
+                  Center(
+                    child: Container(
+                      width: 44,
+                      height: 4,
+                      decoration: BoxDecoration(
+                        color: Colors.white.withAlpha(45),
+                        borderRadius: BorderRadius.circular(99),
                       ),
                     ),
-                    const SizedBox(height: 20),
-                    Row(
-                      children: [
-                        _OutputGlyph(active: status.supported),
-                        const SizedBox(width: 12),
-                        Expanded(
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(
-                                '音频输出',
-                                style: TextStyle(
-                                  color: foreground,
-                                  fontSize: 22,
-                                  fontWeight: FontWeight.w800,
-                                  letterSpacing: 0,
-                                ),
+                  ),
+                  const SizedBox(height: 20),
+                  Row(
+                    children: [
+                      _OutputGlyph(active: status.supported, accent: highlight),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              '音频输出',
+                              style: TextStyle(
+                                color: foreground,
+                                fontSize: 22,
+                                fontWeight: FontWeight.w800,
+                                letterSpacing: 0,
                               ),
-                              const SizedBox(height: 4),
-                              Text(
-                                status.message ?? '查看当前音频链路与采样率',
-                                maxLines: 2,
-                                overflow: TextOverflow.ellipsis,
-                                style: TextStyle(color: muted, fontSize: 13),
-                              ),
-                            ],
-                          ),
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 18),
-                    _SignalSection(
-                      title: '音频源',
-                      accent: const Color(0xFFFFCF33),
-                      rows: [
-                        _InfoRow('文件', _sourcePathLabel(widget.song)),
-                        _InfoRow(
-                          '输入采样率',
-                          formatSampleRate(widget.song?.samplerate),
-                        ),
-                        _InfoRow(
-                          '格式',
-                          widget.song?.format?.toUpperCase() ?? '未知',
-                        ),
-                        _InfoRow('码率', formatBitrate(widget.song?.bitrate)),
-                      ],
-                    ),
-                    const SizedBox(height: 12),
-                    _SignalSection(
-                      title: '处理链',
-                      accent: const Color(0xFF8E8E94),
-                      rows: const [
-                        _InfoRow('均衡器', '关闭'),
-                        _InfoRow('PEQ', '关闭'),
-                        _InfoRow('DSP 插件', '未接入'),
-                      ],
-                    ),
-                    const SizedBox(height: 12),
-                    _SignalSection(
-                      title: '信号输出',
-                      accent: status.supported
-                          ? const Color(0xFF50D890)
-                          : const Color(0xFFFFA33A),
-                      rows: [
-                        _InfoRow('输出端口', _outputPortLabel(status)),
-                        _InfoRow(
-                          '输出采样率',
-                          formatSampleRate(status.preferredSampleRate),
-                        ),
-                        _InfoRow(
-                          '编码',
-                          status.preferredEncoding ?? 'PCM / 系统默认',
-                        ),
-                        _InfoRow(
-                          'Bit-perfect',
-                          status.preferredBitPerfect
-                              ? '已请求'
-                              : status.supported
-                              ? '未启用'
-                              : '不可用',
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 18),
-                    Text(
-                      '采样率',
-                      style: TextStyle(
-                        color: foreground,
-                        fontSize: 16,
-                        fontWeight: FontWeight.w800,
-                      ),
-                    ),
-                    const SizedBox(height: 10),
-                    Wrap(
-                      spacing: 8,
-                      runSpacing: 8,
-                      children: [
-                        for (final rate in options)
-                          _SampleRateChoice(
-                            label: rate == null ? '自动' : formatSampleRate(rate),
-                            selected:
-                                rate == selectedRate ||
-                                (rate == null && selectedRate == null),
-                            enabled: status.supported,
-                            applying: _applyingRate == (rate ?? -1),
-                            onTap: () => _applySampleRate(rate),
-                          ),
-                      ],
-                    ),
-                    if (!status.supported) ...[
-                      const SizedBox(height: 14),
-                      Text(
-                        '未检测到 USB DAC。当前只能显示音频源信息，采样率选择会在连接 USB 音频设备后启用。',
-                        style: TextStyle(
-                          color: Colors.white.withAlpha(128),
-                          fontSize: 12,
-                          height: 1.45,
+                            ),
+                            const SizedBox(height: 4),
+                            Text(
+                              status.message ?? '查看当前音频链路与采样率',
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
+                              style: TextStyle(color: muted, fontSize: 13),
+                            ),
+                          ],
                         ),
                       ),
                     ],
+                  ),
+                  const SizedBox(height: 18),
+                  _SignalSection(
+                    title: '音频源',
+                    accent: highlight,
+                    foreground: foreground,
+                    muted: muted,
+                    surface: surface,
+                    border: border,
+                    rows: [
+                      _InfoRow('文件', _sourcePathLabel(widget.song)),
+                      _InfoRow(
+                        '输入采样率',
+                        formatSampleRate(widget.song?.samplerate),
+                      ),
+                      _InfoRow(
+                        '格式',
+                        widget.song?.format?.toUpperCase() ?? '未知',
+                      ),
+                      _InfoRow('码率', formatBitrate(widget.song?.bitrate)),
+                    ],
+                  ),
+                  const SizedBox(height: 12),
+                  _SignalSection(
+                    title: '处理链',
+                    accent: muted,
+                    foreground: foreground,
+                    muted: muted,
+                    surface: surface,
+                    border: border,
+                    rows: const [
+                      _InfoRow('均衡器', '关闭'),
+                      _InfoRow('PEQ', '关闭'),
+                      _InfoRow('DSP 插件', '未接入'),
+                    ],
+                  ),
+                  const SizedBox(height: 12),
+                  _SignalSection(
+                    title: '信号输出',
+                    accent: status.supported
+                        ? const Color(0xFF50D890)
+                        : const Color(0xFFFFA33A),
+                    foreground: foreground,
+                    muted: muted,
+                    surface: surface,
+                    border: border,
+                    rows: [
+                      _InfoRow('输出端口', _outputPortLabel(status)),
+                      _InfoRow('输出采样率', formatOutputSampleRate(status)),
+                      _InfoRow('编码', _outputEncodingLabel(status)),
+                      _InfoRow(
+                        'Bit-perfect',
+                        status.preferredBitPerfect
+                            ? '已请求'
+                            : status.supported
+                            ? '未启用'
+                            : '不可用',
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 18),
+                  Text(
+                    '采样率',
+                    style: TextStyle(
+                      color: foreground,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w800,
+                    ),
+                  ),
+                  const SizedBox(height: 10),
+                  Wrap(
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: [
+                      for (final rate in options)
+                        _SampleRateChoice(
+                          label: rate == null ? '自动' : formatSampleRate(rate),
+                          selected:
+                              rate == selectedRate ||
+                              (rate == null && selectedRate == null),
+                          enabled: status.supported,
+                          applying: _applyingRate == (rate ?? -1),
+                          accent: highlight,
+                          foreground: foreground,
+                          surface: surface,
+                          onTap: () => _applySampleRate(rate),
+                        ),
+                    ],
+                  ),
+                  if (!status.supported) ...[
+                    const SizedBox(height: 14),
+                    Text(
+                      '未检测到 USB DAC。当前显示 Android 系统输出信息；采样率选择会在连接 USB 音频设备后启用。',
+                      style: TextStyle(
+                        color: muted,
+                        fontSize: 12,
+                        height: 1.45,
+                      ),
+                    ),
                   ],
-                ),
+                ],
               ),
             ),
           ),
@@ -358,11 +614,19 @@ class _AudioOutputSheetState extends State<_AudioOutputSheet> {
 class _SignalSection extends StatelessWidget {
   final String title;
   final Color accent;
+  final Color foreground;
+  final Color muted;
+  final Color surface;
+  final Color border;
   final List<_InfoRow> rows;
 
   const _SignalSection({
     required this.title,
     required this.accent,
+    required this.foreground,
+    required this.muted,
+    required this.surface,
+    required this.border,
     required this.rows,
   });
 
@@ -371,9 +635,9 @@ class _SignalSection extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.all(14),
       decoration: BoxDecoration(
-        color: Colors.white.withAlpha(12),
+        color: surface,
         borderRadius: BorderRadius.circular(18),
-        border: Border.all(color: Colors.white.withAlpha(16)),
+        border: Border.all(color: border),
       ),
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -407,13 +671,14 @@ class _SignalSection extends StatelessWidget {
                 Text(
                   title,
                   style: TextStyle(
-                    color: Colors.white.withAlpha(232),
+                    color: foreground.withAlpha(232),
                     fontSize: 15,
                     fontWeight: FontWeight.w800,
                   ),
                 ),
                 const SizedBox(height: 10),
-                for (final row in rows) _InfoLine(row: row),
+                for (final row in rows)
+                  _InfoLine(row: row, foreground: foreground, muted: muted),
               ],
             ),
           ),
@@ -425,8 +690,14 @@ class _SignalSection extends StatelessWidget {
 
 class _InfoLine extends StatelessWidget {
   final _InfoRow row;
+  final Color foreground;
+  final Color muted;
 
-  const _InfoLine({required this.row});
+  const _InfoLine({
+    required this.row,
+    required this.foreground,
+    required this.muted,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -439,10 +710,7 @@ class _InfoLine extends StatelessWidget {
             width: 86,
             child: Text(
               row.label,
-              style: TextStyle(
-                color: Colors.white.withAlpha(126),
-                fontSize: 13,
-              ),
+              style: TextStyle(color: muted.withAlpha(150), fontSize: 13),
             ),
           ),
           Expanded(
@@ -451,7 +719,7 @@ class _InfoLine extends StatelessWidget {
               maxLines: 2,
               overflow: TextOverflow.ellipsis,
               style: TextStyle(
-                color: Colors.white.withAlpha(222),
+                color: foreground.withAlpha(222),
                 fontSize: 13,
                 height: 1.25,
                 fontWeight: FontWeight.w600,
@@ -469,6 +737,9 @@ class _SampleRateChoice extends StatelessWidget {
   final bool selected;
   final bool enabled;
   final bool applying;
+  final Color accent;
+  final Color foreground;
+  final Color surface;
   final VoidCallback onTap;
 
   const _SampleRateChoice({
@@ -476,12 +747,15 @@ class _SampleRateChoice extends StatelessWidget {
     required this.selected,
     required this.enabled,
     required this.applying,
+    required this.accent,
+    required this.foreground,
+    required this.surface,
     required this.onTap,
   });
 
   @override
   Widget build(BuildContext context) {
-    final accent = selected ? const Color(0xFFFFCF33) : Colors.white;
+    final displayColor = selected ? accent : foreground;
 
     return Material(
       color: Colors.transparent,
@@ -492,11 +766,11 @@ class _SampleRateChoice extends StatelessWidget {
           duration: const Duration(milliseconds: 180),
           padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
           decoration: BoxDecoration(
-            color: selected
-                ? const Color(0xFFFFCF33).withAlpha(42)
-                : Colors.white.withAlpha(13),
+            color: selected ? accent.withAlpha(42) : surface,
             borderRadius: BorderRadius.circular(999),
-            border: Border.all(color: accent.withAlpha(selected ? 160 : 38)),
+            border: Border.all(
+              color: displayColor.withAlpha(selected ? 160 : 42),
+            ),
           ),
           child: Row(
             mainAxisSize: MainAxisSize.min,
@@ -507,7 +781,7 @@ class _SampleRateChoice extends StatelessWidget {
                   height: 12,
                   child: CircularProgressIndicator(
                     strokeWidth: 2,
-                    color: accent,
+                    color: displayColor,
                   ),
                 ),
                 const SizedBox(width: 7),
@@ -515,7 +789,9 @@ class _SampleRateChoice extends StatelessWidget {
               Text(
                 label,
                 style: TextStyle(
-                  color: enabled ? accent.withAlpha(230) : Colors.white54,
+                  color: enabled
+                      ? displayColor.withAlpha(230)
+                      : foreground.withAlpha(96),
                   fontSize: 13,
                   fontWeight: selected ? FontWeight.w800 : FontWeight.w600,
                 ),
@@ -530,8 +806,9 @@ class _SampleRateChoice extends StatelessWidget {
 
 class _OutputGlyph extends StatelessWidget {
   final bool active;
+  final Color accent;
 
-  const _OutputGlyph({required this.active});
+  const _OutputGlyph({required this.active, required this.accent});
 
   @override
   Widget build(BuildContext context) {
@@ -540,16 +817,18 @@ class _OutputGlyph extends StatelessWidget {
       height: 46,
       decoration: BoxDecoration(
         color: active
-            ? const Color(0xFFFFCF33).withAlpha(45)
-            : Colors.white.withAlpha(18),
+            ? accent.withAlpha(45)
+            : lyricsPageForegroundColor.value.withAlpha(18),
         shape: BoxShape.circle,
         border: Border.all(
-          color: active ? const Color(0xFFFFCF33) : Colors.white24,
+          color: active
+              ? accent
+              : lyricsPageForegroundColor.value.withAlpha(62),
         ),
       ),
       child: Icon(
         active ? Icons.usb_rounded : Icons.graphic_eq_rounded,
-        color: active ? const Color(0xFFFFCF33) : Colors.white70,
+        color: active ? accent : lyricsPageForegroundColor.value.withAlpha(180),
       ),
     );
   }
@@ -557,8 +836,9 @@ class _OutputGlyph extends StatelessWidget {
 
 class _PulseDot extends StatelessWidget {
   final bool active;
+  final Color color;
 
-  const _PulseDot({required this.active});
+  const _PulseDot({required this.active, required this.color});
 
   @override
   Widget build(BuildContext context) {
@@ -567,11 +847,11 @@ class _PulseDot extends StatelessWidget {
       height: 8,
       decoration: BoxDecoration(
         shape: BoxShape.circle,
-        color: active ? const Color(0xFFFFCF33) : Colors.white54,
+        color: active ? color : color.withAlpha(120),
         boxShadow: active
             ? [
                 BoxShadow(
-                  color: const Color(0xFFFFCF33).withAlpha(130),
+                  color: color.withAlpha(120),
                   blurRadius: 12,
                   spreadRadius: 2,
                 ),
@@ -591,27 +871,72 @@ class _InfoRow {
 
 String _shortOutputName(UsbAudioStatus status) {
   if (!status.supported) {
-    return 'Android';
+    return status.outputDeviceName ?? 'Android';
   }
+  final device = _activeUsbDevice(status);
+  if (device != null) return device.name;
+  return status.outputDeviceName ?? 'USB DAC';
+}
+
+UsbAudioDevice? _activeUsbDevice(UsbAudioStatus status) {
   for (final device in status.devices) {
     if (device.id == status.bestAvailableDeviceId) {
-      return device.name;
+      return device;
     }
   }
-  return 'USB DAC';
+  return null;
+}
+
+String _supportedRatesLabel(UsbAudioStatus status) {
+  final device = _activeUsbDevice(status);
+  final rates = device?.supportedMixerSampleRates.isNotEmpty == true
+      ? device!.supportedMixerSampleRates
+      : device?.sampleRates ?? const <int>[];
+  if (rates.isEmpty) return '未知';
+  return rates.map(formatSampleRate).join(' / ');
+}
+
+String _bitPerfectSupportLabel(UsbAudioStatus status) {
+  if (!status.supported) return '不可用';
+  if (status.androidSdk < 34) return '需要 Android 14+';
+  final device = _activeUsbDevice(status);
+  if (device?.supportsBitPerfectMixer == true) {
+    return status.preferredBitPerfect ? '已请求' : '可用';
+  }
+  return '设备未声明支持';
+}
+
+String _exclusiveStatusLabel(UsbAudioStatus status) {
+  if (!status.supported) return '未连接 USB 音频设备';
+  if (status.androidSdk < 34) return '当前系统不支持 USB 独占请求';
+  if (status.preferredBitPerfect && status.preferredSampleRate != null) {
+    return '已请求 USB 独占输出';
+  }
+  if (_activeUsbDevice(status)?.supportsBitPerfectMixer == true) {
+    return '可启用 USB 独占输出';
+  }
+  return '已连接 USB DAC，但未确认支持独占';
 }
 
 String _bitDepthLabel(UsbAudioStatus status) {
-  final encoding = status.preferredEncoding;
+  final encoding = status.preferredEncoding ?? status.outputEncoding;
+  if (encoding == 'pcm_float') return '32 bits';
   if (encoding == 'pcm_32bit') return '32 bits';
   if (encoding == 'pcm_24bit_packed') return '24 bits';
   if (encoding == 'pcm_16bit') return '16 bits';
   return '未知';
 }
 
+String _outputEncodingLabel(UsbAudioStatus status) {
+  final encoding = status.preferredEncoding ?? status.outputEncoding;
+  if (encoding == null) return 'PCM / 系统默认';
+  final bitDepth = _bitDepthLabel(status);
+  return bitDepth == '未知' ? encoding : 'PCM / $bitDepth';
+}
+
 String _outputPortLabel(UsbAudioStatus status) {
   if (!status.supported) {
-    return 'Android';
+    return status.outputDeviceName ?? 'Android';
   }
   final name = _shortOutputName(status);
   return status.preferredApplied ? '$name · 已应用偏好' : '$name · 系统输出';
@@ -626,4 +951,38 @@ String _sourcePathLabel(MyAudioMetadata? song) {
     return path;
   }
   return '...${path.substring(path.length - 45)}';
+}
+
+Color _chipColor(Color foreground) {
+  final background = _panelBackgroundColor(foreground);
+  return Color.alphaBlend(foreground.withAlpha(18), background.withAlpha(220));
+}
+
+Color _panelBackgroundColor(Color foreground) {
+  final tint = _panelTintColor();
+  final lightForeground = foreground.computeLuminance() > 0.45;
+  final neutral = lightForeground
+      ? const Color(0xFF24252B)
+      : const Color(0xFFF0F0F2);
+  return Color.alphaBlend(tint.withAlpha(lightForeground ? 96 : 136), neutral);
+}
+
+Color _panelSurfaceColor(Color background, Color foreground) {
+  final lightForeground = foreground.computeLuminance() > 0.45;
+  return Color.alphaBlend(
+    foreground.withAlpha(lightForeground ? 18 : 14),
+    background,
+  );
+}
+
+Color _barrierColor() {
+  final tint = _panelTintColor();
+  return Color.alphaBlend(tint.withAlpha(30), Colors.black.withAlpha(70));
+}
+
+Color _panelTintColor() {
+  final pageBackground = lyricsPageBackgroundColor.value;
+  return pageBackground == Colors.transparent
+      ? currentCoverArtColor
+      : pageBackground;
 }

--- a/lib/base/widgets/audio_output_panel.dart
+++ b/lib/base/widgets/audio_output_panel.dart
@@ -18,6 +18,11 @@ String formatSampleRate(int? sampleRate) {
 }
 
 String formatOutputSampleRate(UsbAudioStatus status) {
+  final exclusive = usbExclusivePlaybackStateNotifier.value;
+  if (exclusive.active && exclusive.sampleRate != null) {
+    return formatSampleRate(exclusive.sampleRate);
+  }
+
   return formatSampleRate(
     status.preferredSampleRate ?? status.outputSampleRate,
   );
@@ -870,6 +875,11 @@ class _InfoRow {
 }
 
 String _shortOutputName(UsbAudioStatus status) {
+  final exclusive = usbExclusivePlaybackStateNotifier.value;
+  if (exclusive.active) {
+    return 'USB 真独占';
+  }
+
   if (!status.supported) {
     return status.outputDeviceName ?? 'Android';
   }
@@ -919,6 +929,11 @@ String _exclusiveStatusLabel(UsbAudioStatus status) {
 }
 
 String _bitDepthLabel(UsbAudioStatus status) {
+  final exclusive = usbExclusivePlaybackStateNotifier.value;
+  if (exclusive.active && exclusive.bitDepth != null) {
+    return '${exclusive.bitDepth} bits';
+  }
+
   final encoding = status.preferredEncoding ?? status.outputEncoding;
   if (encoding == 'pcm_float') return '32 bits';
   if (encoding == 'pcm_32bit') return '32 bits';

--- a/lib/base/widgets/audio_output_panel.dart
+++ b/lib/base/widgets/audio_output_panel.dart
@@ -59,6 +59,7 @@ List<int?> buildSampleRateOptions(
   options.addAll(sortedRates);
   if (sourceSampleRate != null &&
       sourceSampleRate > 0 &&
+      UsbAudioPreferences.sampleRates.contains(sourceSampleRate) &&
       !options.contains(sourceSampleRate)) {
     options.add(sourceSampleRate);
   }
@@ -74,13 +75,46 @@ int? preferredExclusiveSampleRate(
     return fixedRate;
   }
 
+  final matchedSourceRate = matchedSafeSampleRate(sourceSampleRate);
   final deviceRates = buildSampleRateOptions(status, null).whereType<int>();
-  if (sourceSampleRate != null &&
-      sourceSampleRate > 0 &&
-      deviceRates.contains(sourceSampleRate)) {
+  if (matchedSourceRate != null && deviceRates.contains(matchedSourceRate)) {
+    return matchedSourceRate;
+  }
+  return bestExclusiveDeviceSampleRate(status);
+}
+
+int? bestExclusiveDeviceSampleRate(UsbAudioStatus status) {
+  final rates = buildSampleRateOptions(status, null).whereType<int>().toList();
+  if (rates.isEmpty) {
+    return status.bestAvailableSampleRate;
+  }
+  rates.sort();
+  return rates.last;
+}
+
+int? matchedSafeSampleRate(int? sourceSampleRate) {
+  if (sourceSampleRate == null || sourceSampleRate <= 0) {
+    return null;
+  }
+
+  final supportedRates = UsbAudioPreferences.sampleRates;
+  if (supportedRates.contains(sourceSampleRate)) {
     return sourceSampleRate;
   }
-  return status.bestAvailableSampleRate;
+
+  final sameFamilyRates =
+      supportedRates.where((rate) => sourceSampleRate % rate == 0).toList()
+        ..sort();
+  if (sameFamilyRates.isNotEmpty) {
+    return sameFamilyRates.last;
+  }
+
+  return supportedRates
+      .where((rate) => rate <= sourceSampleRate)
+      .fold<int?>(
+        null,
+        (best, rate) => best == null || rate > best ? rate : best,
+      );
 }
 
 Future<UsbAudioStatus> applyExclusiveOutputForSong(

--- a/lib/base/widgets/cover_art_widget.dart
+++ b/lib/base/widgets/cover_art_widget.dart
@@ -13,6 +13,8 @@ class CoverArtWidget extends StatelessWidget {
   final String? picturePath;
   final double elevation;
   final Color? color;
+  final int? cacheWidth;
+  final FilterQuality filterQuality;
   const CoverArtWidget({
     super.key,
     this.size,
@@ -21,6 +23,8 @@ class CoverArtWidget extends StatelessWidget {
     this.picturePath,
     this.elevation = 0,
     this.color,
+    this.cacheWidth,
+    this.filterQuality = FilterQuality.medium,
   });
 
   @override
@@ -65,6 +69,8 @@ class CoverArtWidget extends StatelessWidget {
           width: size,
           height: size,
           fit: BoxFit.cover,
+          cacheWidth: cacheWidth,
+          filterQuality: filterQuality,
           errorBuilder: (context, error, stackTrace) {
             return musicNote();
           },
@@ -79,6 +85,8 @@ class CoverArtWidget extends StatelessWidget {
       width: size,
       height: size,
       fit: BoxFit.cover,
+      cacheWidth: cacheWidth,
+      filterQuality: filterQuality,
       errorBuilder: (context, error, stackTrace) {
         return musicNote();
       },

--- a/lib/base/widgets/lyric_list_view.dart
+++ b/lib/base/widgets/lyric_list_view.dart
@@ -8,7 +8,6 @@ import 'package:sylvakru/base/audio_handler.dart';
 import 'package:sylvakru/base/services/color_manager.dart';
 import 'package:sylvakru/base/app.dart';
 import 'package:sylvakru/base/services/lyric.dart';
-import 'package:sylvakru/base/services/super_lyric_bridge.dart';
 import 'package:sylvakru/mini_view/mini_view.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 import 'package:smooth_corner/smooth_corner.dart';
@@ -61,14 +60,6 @@ class LyricsListViewState extends State<LyricsListView>
       }
     }
     currentIndexNotifier.value = current;
-
-    if (tmp != current) {
-      if (current >= 0 && current < lines.length) {
-        unawaited(SuperLyricBridge.sendLyric(lines[current].text));
-      } else if (current == -1) {
-        unawaited(SuperLyricBridge.sendStop());
-      }
-    }
 
     if (!userDragging && (tmp != current || userDragged)) {
       userDragged = false;

--- a/lib/base/widgets/lyric_list_view.dart
+++ b/lib/base/widgets/lyric_list_view.dart
@@ -8,6 +8,7 @@ import 'package:sylvakru/base/audio_handler.dart';
 import 'package:sylvakru/base/services/color_manager.dart';
 import 'package:sylvakru/base/app.dart';
 import 'package:sylvakru/base/services/lyric.dart';
+import 'package:sylvakru/base/services/super_lyric_bridge.dart';
 import 'package:sylvakru/mini_view/mini_view.dart';
 import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 import 'package:smooth_corner/smooth_corner.dart';
@@ -60,6 +61,14 @@ class LyricsListViewState extends State<LyricsListView>
       }
     }
     currentIndexNotifier.value = current;
+
+    if (tmp != current) {
+      if (current >= 0 && current < lines.length) {
+        unawaited(SuperLyricBridge.sendLyric(lines[current].text));
+      } else if (current == -1) {
+        unawaited(SuperLyricBridge.sendStop());
+      }
+    }
 
     if (!userDragging && (tmp != current || userDragged)) {
       userDragged = false;

--- a/lib/base/widgets/settings_list.dart
+++ b/lib/base/widgets/settings_list.dart
@@ -54,7 +54,7 @@ class SettingsList extends StatelessWidget {
                   subtitle: Text(
                     l10n.settingCount(
                       Platform.isAndroid
-                          ? 14
+                          ? 15
                           : Platform.isIOS
                           ? 14
                           : 12,
@@ -116,6 +116,9 @@ class SettingsList extends StatelessWidget {
           ),
 
         sliverBox(paddingIfNeed(isLandscape, equalizerListTile(context, l10n))),
+
+        if (Platform.isAndroid)
+          sliverBox(paddingIfNeed(isLandscape, audioOutputListTile(context))),
 
         sliverBox(paddingIfNeed(isLandscape, autoPlayOnStartupListTile(l10n))),
 
@@ -481,6 +484,18 @@ class SettingsList extends StatelessWidget {
           },
         ),
       ),
+    );
+  }
+
+  Widget audioOutputListTile(BuildContext context) {
+    return ListTile(
+      leading: Icon(Icons.usb_rounded, size: iconSize),
+      title: const Text('音频输出'),
+      subtitle: const Text('USB 独占、固定采样率、DSD 与位深'),
+      trailing: const Icon(Icons.chevron_right_rounded),
+      onTap: () {
+        layersManager.pushDetail('settings', 'audio_output');
+      },
     );
   }
 

--- a/lib/base/widgets/usb_audio_event_listener.dart
+++ b/lib/base/widgets/usb_audio_event_listener.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:sylvakru/base/audio_handler.dart';
+import 'package:sylvakru/base/services/usb_audio_service.dart';
+import 'package:sylvakru/base/widgets/audio_output_panel.dart';
+
+class UsbAudioEventListener extends StatefulWidget {
+  final Widget child;
+
+  const UsbAudioEventListener({super.key, required this.child});
+
+  @override
+  State<UsbAudioEventListener> createState() => _UsbAudioEventListenerState();
+}
+
+class _UsbAudioEventListenerState extends State<UsbAudioEventListener> {
+  UsbAudioDeviceEvent? _lastEvent;
+  int? _lastPromptedDeviceId;
+  bool _showingPrompt = false;
+
+  @override
+  void initState() {
+    super.initState();
+    usbAudioEventNotifier.addListener(_handleUsbAudioEvent);
+  }
+
+  @override
+  void dispose() {
+    usbAudioEventNotifier.removeListener(_handleUsbAudioEvent);
+    super.dispose();
+  }
+
+  void _handleUsbAudioEvent() {
+    final event = usbAudioEventNotifier.value;
+    if (event == null || identical(event, _lastEvent)) {
+      return;
+    }
+    _lastEvent = event;
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      switch (event.type) {
+        case UsbAudioDeviceEventType.added:
+          _showDetectedPrompt(event);
+          break;
+        case UsbAudioDeviceEventType.removed:
+          _showRemovedMessage();
+          break;
+      }
+    });
+  }
+
+  Future<void> _showDetectedPrompt(UsbAudioDeviceEvent event) async {
+    if (_showingPrompt || event.status.supported == false) {
+      return;
+    }
+    if (event.deviceId != null && event.deviceId == _lastPromptedDeviceId) {
+      return;
+    }
+
+    _showingPrompt = true;
+    _lastPromptedDeviceId = event.deviceId;
+    await showUsbAudioDetectedSheet(
+      context,
+      event.status,
+      currentSongNotifier.value,
+    );
+    _showingPrompt = false;
+  }
+
+  void _showRemovedMessage() {
+    _lastPromptedDeviceId = null;
+    ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+      const SnackBar(
+        content: Text('USB DAC 已断开，已恢复 Android 系统输出'),
+        behavior: SnackBarBehavior.floating,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+}

--- a/lib/base/widgets/usb_audio_event_listener.dart
+++ b/lib/base/widgets/usb_audio_event_listener.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:sylvakru/base/audio_handler.dart';
 import 'package:sylvakru/base/services/usb_audio_service.dart';
-import 'package:sylvakru/base/widgets/audio_output_panel.dart';
 
 class UsbAudioEventListener extends StatefulWidget {
   final Widget child;
@@ -14,8 +12,6 @@ class UsbAudioEventListener extends StatefulWidget {
 
 class _UsbAudioEventListenerState extends State<UsbAudioEventListener> {
   UsbAudioDeviceEvent? _lastEvent;
-  int? _lastPromptedDeviceId;
-  bool _showingPrompt = false;
 
   @override
   void initState() {
@@ -40,7 +36,6 @@ class _UsbAudioEventListenerState extends State<UsbAudioEventListener> {
       if (!mounted) return;
       switch (event.type) {
         case UsbAudioDeviceEventType.added:
-          _showDetectedPrompt(event);
           break;
         case UsbAudioDeviceEventType.removed:
           _showRemovedMessage();
@@ -49,26 +44,7 @@ class _UsbAudioEventListenerState extends State<UsbAudioEventListener> {
     });
   }
 
-  Future<void> _showDetectedPrompt(UsbAudioDeviceEvent event) async {
-    if (_showingPrompt || event.status.supported == false) {
-      return;
-    }
-    if (event.deviceId != null && event.deviceId == _lastPromptedDeviceId) {
-      return;
-    }
-
-    _showingPrompt = true;
-    _lastPromptedDeviceId = event.deviceId;
-    await showUsbAudioDetectedSheet(
-      context,
-      event.status,
-      currentSongNotifier.value,
-    );
-    _showingPrompt = false;
-  }
-
   void _showRemovedMessage() {
-    _lastPromptedDeviceId = null;
     ScaffoldMessenger.maybeOf(context)?.showSnackBar(
       const SnackBar(
         content: Text('USB DAC 已断开，已恢复 Android 系统输出'),

--- a/lib/landscape_view/landscape_view.dart
+++ b/lib/landscape_view/landscape_view.dart
@@ -8,6 +8,9 @@ import 'package:sylvakru/landscape_view/bottom_control.dart';
 import 'package:sylvakru/landscape_view/sidebar.dart';
 import 'package:sylvakru/layer/layers_manager.dart';
 
+const double _backgroundBlurSigma = 16;
+const int _backgroundCoverCacheWidth = 160;
+
 class LandscapeView extends StatelessWidget {
   const LandscapeView({super.key});
 
@@ -26,9 +29,19 @@ class LandscapeView extends StatelessWidget {
             return ValueListenableBuilder(
               valueListenable: layersManager.backgroundChangeNotifier,
               builder: (context, value, child) {
-                return CoverArtWidget(
-                  song: backgroundSong,
-                  color: colorManager.getSpecificBgBaseColor(),
+                return RepaintBoundary(
+                  child: ImageFiltered(
+                    imageFilter: ImageFilter.blur(
+                      sigmaX: _backgroundBlurSigma,
+                      sigmaY: _backgroundBlurSigma,
+                    ),
+                    child: CoverArtWidget(
+                      song: backgroundSong,
+                      color: colorManager.getSpecificBgBaseColor(),
+                      cacheWidth: _backgroundCoverCacheWidth,
+                      filterQuality: FilterQuality.low,
+                    ),
+                  ),
                 );
               },
             );
@@ -40,24 +53,16 @@ class LandscapeView extends StatelessWidget {
             if (value != .vivid) {
               return SizedBox.shrink();
             }
-            final pageWidth = MediaQuery.widthOf(context);
-            final pageHight = MediaQuery.heightOf(context);
 
-            return BackdropFilter(
-              filter: ImageFilter.blur(
-                sigmaX: pageWidth * 0.03,
-                sigmaY: pageHight * 0.03,
-              ),
-              child: ValueListenableBuilder(
-                valueListenable: layersManager.backgroundChangeNotifier,
-                builder: (context, value, child) {
-                  return AnimatedContainer(
-                    duration: Duration(milliseconds: 500),
-                    curve: Curves.easeInOutCubic,
-                    color: backgroundCoverArtColor.withAlpha(180),
-                  );
-                },
-              ),
+            return ValueListenableBuilder(
+              valueListenable: layersManager.backgroundChangeNotifier,
+              builder: (context, value, child) {
+                return AnimatedContainer(
+                  duration: Duration(milliseconds: 500),
+                  curve: Curves.easeInOutCubic,
+                  color: backgroundCoverArtColor.withAlpha(180),
+                );
+              },
             );
           },
         ),

--- a/lib/landscape_view/pages/landscape_lyrics_page.dart
+++ b/lib/landscape_view/pages/landscape_lyrics_page.dart
@@ -20,6 +20,9 @@ import 'package:sylvakru/base/widgets/seekbar.dart';
 import 'package:sylvakru/base/my_audio_metadata.dart';
 import 'package:sylvakru/base/utils/metadata_utils.dart';
 
+const double _backgroundBlurSigma = 16;
+const int _backgroundCoverCacheWidth = 160;
+
 class LandscapeLyricsPage extends StatefulWidget {
   const LandscapeLyricsPage({super.key});
 
@@ -80,20 +83,25 @@ class _LandscapeLyricsPageState extends State<LandscapeLyricsPage> {
             fit: StackFit.expand,
             children: [
               if (lyricsPageThemeNotifier.value == .vivid) ...[
-                CoverArtWidget(
-                  song: currentSong,
-                  color: colorManager.getSpecificLyricsPageCoverArtBaseColor(),
+                RepaintBoundary(
+                  child: ImageFiltered(
+                    imageFilter: ImageFilter.blur(
+                      sigmaX: _backgroundBlurSigma,
+                      sigmaY: _backgroundBlurSigma,
+                    ),
+                    child: CoverArtWidget(
+                      song: currentSong,
+                      color: colorManager
+                          .getSpecificLyricsPageCoverArtBaseColor(),
+                      cacheWidth: _backgroundCoverCacheWidth,
+                      filterQuality: FilterQuality.low,
+                    ),
+                  ),
                 ),
-                BackdropFilter(
-                  filter: ImageFilter.blur(
-                    sigmaX: pageWidth * 0.03,
-                    sigmaY: pageHight * 0.03,
-                  ),
-                  child: AnimatedContainer(
-                    duration: Duration(milliseconds: 300),
-                    curve: Curves.easeInOutCubic,
-                    color: currentCoverArtColor.withAlpha(180),
-                  ),
+                AnimatedContainer(
+                  duration: Duration(milliseconds: 300),
+                  curve: Curves.easeInOutCubic,
+                  color: currentCoverArtColor.withAlpha(180),
                 ),
               ],
 
@@ -272,7 +280,6 @@ class _LandscapeLyricsPageState extends State<LandscapeLyricsPage> {
               valueListenable: lyricsPageHighlightTextColor.valueNotifier,
               builder: (context, value, child) {
                 return MyAutoSizeText(
-                  key: UniqueKey(),
                   getTitle(currentSong),
                   maxLines: 1,
                   textStyle: TextStyle(
@@ -295,7 +302,6 @@ class _LandscapeLyricsPageState extends State<LandscapeLyricsPage> {
               valueListenable: lyricsPageForegroundColor.valueNotifier,
               builder: (context, value, child) {
                 return MyAutoSizeText(
-                  key: UniqueKey(),
                   '${getArtist(currentSong)} - ${getAlbum(currentSong)}',
                   maxLines: 1,
                   textStyle: TextStyle(fontSize: 14, color: value),

--- a/lib/layer/audio_output_settings_layer.dart
+++ b/lib/layer/audio_output_settings_layer.dart
@@ -1,12 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:sylvakru/base/app.dart';
 import 'package:sylvakru/base/data/setting.dart';
 import 'package:sylvakru/base/services/color_manager.dart';
 import 'package:sylvakru/base/services/usb_audio_preferences.dart';
 import 'package:sylvakru/base/services/usb_audio_service.dart';
+import 'package:sylvakru/base/utils/media_query.dart';
 import 'package:sylvakru/base/widgets/audio_output_panel.dart';
 import 'package:sylvakru/base/widgets/my_switch.dart';
-import 'package:sylvakru/base/utils/media_query.dart';
 import 'package:sylvakru/landscape_view/title_bar.dart';
 import 'package:sylvakru/layer/layers_manager.dart';
 import 'package:sylvakru/layer/settings_layer.dart';
@@ -30,6 +31,7 @@ class AudioOutputSettingsLayer extends StatefulWidget {
 class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
   UsbExclusiveProbeResult? _exclusiveProbeResult;
   bool _probingExclusive = false;
+  bool _refreshingStatus = false;
 
   @override
   Widget build(BuildContext context) {
@@ -102,243 +104,377 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
 
   Widget _overview() {
     final prefs = usbAudioPreferences;
-    return Column(
-      children: [
-        _exclusiveProbeCard(),
-        const SizedBox(height: 14),
-        _section(
+    return ValueListenableBuilder<UsbAudioStatus>(
+      valueListenable: usbAudioStatusNotifier,
+      builder: (context, status, _) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            _tile(
-              title: 'USB Audio 性能模式',
-              subtitle: '连接 DAC 后启用独占提示与高优先级输出策略',
-              info: true,
-              trailing: SizedBox(
-                width: 52,
-                child: MySwitch(
-                  valueNotifier: prefs.performanceModeNotifier,
-                  onToggleCallBack: setting.save,
-                ),
-              ),
-            ),
-            _navTile(
-              title: '固定采样率输出',
-              value: prefs.fixedSampleRateEnabledNotifier.value
-                  ? formatSampleRate(prefs.fixedSampleRateNotifier.value)
-                  : '关闭',
-              onTap: () {
-                layersManager.pushDetail('settings', 'usb_fixed_sample_rate');
-              },
-            ),
-            _navTile(
-              title: 'DSD 模式',
-              value: _dsdModeLabel(prefs.dsdModeNotifier.value),
-              onTap: () {
-                layersManager.pushDetail('settings', 'usb_dsd_mode');
-              },
-            ),
-            _choiceTile<UsbVolumeLockMode>(
-              title: 'USB Audio 音量锁定',
-              info: true,
-              notifier: prefs.volumeLockModeNotifier,
-              values: UsbVolumeLockMode.values,
-              label: _volumeLockLabel,
-            ),
-            _choiceTile<int>(
-              title: 'USB Audio DSD 增益补偿',
-              info: true,
-              notifier: prefs.dsdGainCompensationNotifier,
-              values: const [-12, -9, -6, -3, 0, 3, 6],
-              label: (value) => '${value}dB',
-            ),
-            _choiceTile<UsbBusSpeedMode>(
-              title: 'USB Audio 总线速度',
-              info: true,
-              notifier: prefs.busSpeedModeNotifier,
-              values: UsbBusSpeedMode.values,
-              label: _busSpeedLabel,
-            ),
-            _choiceTile<UsbBitDepthMode>(
-              title: 'USB Audio 位深',
-              info: true,
-              notifier: prefs.bitDepthModeNotifier,
-              values: UsbBitDepthMode.values,
-              label: _bitDepthModeLabel,
-            ),
-            _tile(
-              title: '播放后释放 USB 带宽',
-              subtitle: '停止播放后允许系统回收 USB 音频资源',
-              info: true,
-              trailing: SizedBox(
-                width: 52,
-                child: MySwitch(
-                  valueNotifier: prefs.releaseUsbBandwidthAfterPlaybackNotifier,
-                  onToggleCallBack: setting.save,
-                ),
-              ),
-            ),
-            _tile(
-              title: '保持后台活动',
-              subtitle: '减少后台播放时 USB 输出被系统中断的概率',
-              info: true,
-              trailing: SizedBox(
-                width: 52,
-                child: MySwitch(
-                  valueNotifier: prefs.keepAliveInBackgroundNotifier,
-                  onToggleCallBack: setting.save,
-                ),
-              ),
-            ),
-          ],
-        ),
-      ],
-    );
-  }
-
-  Widget _exclusiveProbeCard() {
-    final result = _exclusiveProbeResult;
-    final status = result == null
-        ? '未检测'
-        : result.interfaceClaimed
-        ? '可 claim'
-        : result.permissionGranted
-        ? '不可 claim'
-        : '待授权';
-    final accent = result?.interfaceClaimed == true
-        ? const Color(0xFF50D890)
-        : const Color(0xFFFFA33A);
-
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: menuColor.value,
-        borderRadius: BorderRadius.circular(18),
-        border: Border.all(color: accent.withAlpha(90)),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
+            _deviceStatusCard(status),
+            const SizedBox(height: 12),
+            _transportStatusCard(status),
+            const SizedBox(height: 18),
+            _sectionTitle('后台稳定性'),
+            _settingsCard(
               children: [
-                Icon(Icons.usb_rounded, color: accent),
-                const SizedBox(width: 10),
-                Expanded(
-                  child: Text(
-                    '真独占可行性探针',
-                    style: TextStyle(
-                      color: textColor.value,
-                      fontSize: 17,
-                      fontWeight: FontWeight.w800,
-                    ),
-                  ),
+                _noticeTile(
+                  icon: Icons.battery_alert_rounded,
+                  title: '建议关闭电池优化',
+                  subtitle: '否则后台播放或切到大型 App 时，USB 独占链路可能被系统暂停。',
+                  actionLabel: '打开设置',
+                  onTap: openAppSettings,
                 ),
-                Text(status, style: TextStyle(color: accent)),
+                _switchTile(
+                  title: 'USB 独占模式',
+                  subtitle: '连接 DAC 后启用独占提示与高优先级输出策略。',
+                  notifier: prefs.performanceModeNotifier,
+                ),
+                _switchTile(
+                  title: '保持后台活动',
+                  subtitle: '减少后台播放时 USB 输出被系统中断的概率。',
+                  notifier: prefs.keepAliveInBackgroundNotifier,
+                ),
               ],
             ),
-            const SizedBox(height: 10),
-            Text(
-              '验证 App 是否能获取 USB 权限、识别 USB Audio Class，并短暂 claim 接口。这里不会接管播放，也不会占用 DAC。',
-              style: TextStyle(color: textColor.value.withAlpha(160)),
+            const SizedBox(height: 18),
+            _sectionTitle('输出格式'),
+            _settingsCard(
+              children: [
+                _infoTile('源文件', '等待播放', '采样率未知 · 声道未知 · 位深未知'),
+                _infoTile(
+                  'DAC 端点',
+                  _dacEndpointLabel(status),
+                  '播放后显示真实 DAC 端点格式',
+                ),
+                _switchTile(
+                  title: '位深兼容',
+                  subtitle: '设备不支持源位深时自动回退。',
+                  notifier: prefs.bitDepthCompatNotifier,
+                ),
+                _switchTile(
+                  title: '采样率兼容',
+                  subtitle: '设备不支持源采样率时自动回退。',
+                  notifier: prefs.sampleRateCompatNotifier,
+                ),
+                _switchTile(
+                  title: '声道兼容',
+                  subtitle: '设备不支持源声道时自动回退到可用声道。',
+                  notifier: prefs.channelCompatNotifier,
+                ),
+                _switchTile(
+                  title: 'TPDF 抖动',
+                  subtitle: '高位深转 16-bit 时加入极低电平随机噪声，降低量化失真。',
+                  notifier: prefs.tpdfDitherNotifier,
+                ),
+                _navTile(
+                  title: '固定采样率输出',
+                  value: prefs.fixedSampleRateEnabledNotifier.value
+                      ? formatSampleRate(prefs.fixedSampleRateNotifier.value)
+                      : '关闭',
+                  onTap: () {
+                    layersManager.pushDetail(
+                      'settings',
+                      'usb_fixed_sample_rate',
+                    );
+                  },
+                ),
+                _navTile(
+                  title: 'DSD 模式',
+                  value: _dsdModeLabel(prefs.dsdModeNotifier.value),
+                  onTap: () {
+                    layersManager.pushDetail('settings', 'usb_dsd_mode');
+                  },
+                ),
+                _choiceTile<UsbBitDepthMode>(
+                  title: 'PCM 位深',
+                  notifier: prefs.bitDepthModeNotifier,
+                  values: UsbBitDepthMode.values,
+                  label: _bitDepthModeLabel,
+                ),
+              ],
             ),
-            if (result != null) ...[
-              const SizedBox(height: 12),
-              _probeLine('设备', result.deviceName ?? '未知'),
-              _probeLine('权限', result.permissionGranted ? '已授权' : '未授权'),
-              _probeLine('Audio Interface', '${result.audioInterfaceCount}'),
-              _probeLine('Claim 成功', '${result.claimedInterfaceCount}'),
-              _probeLine(
-                'Raw Descriptor',
-                '${result.rawDescriptorLength} bytes',
-              ),
-              if (result.message != null) _probeLine('结果', result.message!),
-            ],
-            const SizedBox(height: 14),
-            SizedBox(
-              width: double.infinity,
-              child: ElevatedButton.icon(
-                onPressed: _probingExclusive ? null : _runExclusiveProbe,
-                icon: _probingExclusive
-                    ? SizedBox(
-                        width: 16,
-                        height: 16,
-                        child: CircularProgressIndicator(
-                          strokeWidth: 2,
-                          color: textColor.value,
-                        ),
-                      )
-                    : const Icon(Icons.fact_check_rounded, size: 18),
-                label: Text(_probingExclusive ? '检测中' : '开始探针'),
-              ),
+            const SizedBox(height: 18),
+            _sectionTitle('传输缓冲'),
+            _settingsCard(
+              children: [
+                _bufferSlider(
+                  title: '前台缓冲区',
+                  notifier: prefs.foregroundBufferMsNotifier,
+                  min: 50,
+                  max: 1000,
+                  divisions: 19,
+                ),
+                _bufferSlider(
+                  title: '后台缓冲区',
+                  notifier: prefs.backgroundBufferMsNotifier,
+                  min: 500,
+                  max: 5000,
+                  divisions: 18,
+                ),
+                _hintTile('后台打开大型 App 出现卡顿时优先提高后台缓冲；数值越大越稳定，切歌与暂停响应可能稍慢。'),
+              ],
+            ),
+            const SizedBox(height: 18),
+            _sectionTitle('音量'),
+            _settingsCard(
+              children: [
+                _choiceTile<UsbVolumeLockMode>(
+                  title: '音量控制',
+                  notifier: prefs.volumeLockModeNotifier,
+                  values: UsbVolumeLockMode.values,
+                  label: _volumeLockLabel,
+                ),
+                _choiceTile<int>(
+                  title: 'DSD 增益补偿',
+                  notifier: prefs.dsdGainCompensationNotifier,
+                  values: const [-12, -9, -6, -3, 0, 3, 6],
+                  label: (value) => '${value} dB',
+                ),
+                _infoTile('当前媒体音量', '播放开始后检测', '硬件音量与 DAC 反馈可用后显示'),
+                _switchTile(
+                  title: '音量平滑交接',
+                  subtitle: '切换数字音量与 DAC 硬件音量时保持响度连续。',
+                  notifier: prefs.volumeSmoothHandoffNotifier,
+                ),
+              ],
+            ),
+            const SizedBox(height: 18),
+            _sectionTitle('兼容性'),
+            _settingsCard(
+              children: [
+                _switchTile(
+                  title: '延迟建立 USB 输出链路',
+                  subtitle: '播放开始时再建立独占会话，适合部分 DAC 卡死或控制界面异常的使用场景。',
+                  notifier: prefs.delayedUsbLinkNotifier,
+                ),
+                _choiceTile<UsbBusSpeedMode>(
+                  title: 'USB 总线速度',
+                  notifier: prefs.busSpeedModeNotifier,
+                  values: UsbBusSpeedMode.values,
+                  label: _busSpeedLabel,
+                ),
+                _switchTile(
+                  title: '播放后释放 USB 带宽',
+                  subtitle: '停止播放后允许系统回收 USB 音频资源。',
+                  notifier: prefs.releaseUsbBandwidthAfterPlaybackNotifier,
+                ),
+              ],
+            ),
+            const SizedBox(height: 18),
+            _sectionTitle('支持'),
+            _settingsCard(
+              children: [
+                _actionTile(
+                  icon: Icons.fact_check_rounded,
+                  title: 'USB 独占后台诊断',
+                  subtitle: _exclusiveProbeSummary(),
+                  actionLabel: _probingExclusive ? '检测中' : '开始检测',
+                  onTap: _probingExclusive ? null : _runExclusiveProbe,
+                ),
+                _actionTile(
+                  icon: Icons.feedback_rounded,
+                  title: 'USB 独占模式反馈',
+                  subtitle: '复制当前设备与输出链路信息，方便继续排查 DAC 兼容问题。',
+                  actionLabel: '查看状态',
+                  onTap: () => _showStatusSnack(status),
+                ),
+              ],
             ),
           ],
-        ),
-      ),
+        );
+      },
     );
   }
 
-  Widget _probeLine(String label, String value) {
-    return Padding(
-      padding: const EdgeInsets.only(top: 4),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          SizedBox(
-            width: 118,
-            child: Text(
-              label,
-              style: TextStyle(color: textColor.value.withAlpha(130)),
+  Widget _deviceStatusCard(UsbAudioStatus status) {
+    final device = _activeUsbDevice(status);
+    final supported = status.supported;
+    final exclusive = usbExclusivePlaybackStateNotifier.value;
+    final accent = supported ? highlightTextColor.value : textColor.value;
+    final title = supported ? device?.name ?? 'USB DAC' : '未识别 USB 设备';
+    final subtitle = supported
+        ? _exclusiveStatusLabel(status)
+        : '连接 DAC 后显示设备信息';
+    final id = device == null ? '等待连接' : '${device.type} · ${device.id}';
+
+    return _heroCard(
+      icon: Icons.usb_rounded,
+      accent: accent,
+      title: title,
+      subtitle: subtitle,
+      trailing: _refreshingStatus
+          ? const SizedBox(
+              width: 18,
+              height: 18,
+              child: CircularProgressIndicator(strokeWidth: 2),
+            )
+          : IconButton(
+              tooltip: '刷新 USB 状态',
+              onPressed: _refreshStatus,
+              icon: const Icon(Icons.refresh_rounded),
             ),
-          ),
-          Expanded(
-            child: Text(
-              value,
-              style: TextStyle(
-                color: textColor.value.withAlpha(220),
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-          ),
-        ],
-      ),
+      metrics: [
+        _Metric('输出链路', supported ? _outputPortLabel(status) : '未启用'),
+        _Metric('Format', _outputEncodingLabel(status)),
+        _Metric('Depth', _bitDepthLabel(status)),
+        _Metric('USB ID', id),
+      ],
+      footer: exclusive.active
+          ? '独占播放中 · ${formatSampleRate(exclusive.sampleRate)} · ${exclusive.bitDepth ?? '未知'} bits'
+          : '连接后可在这里确认 DAC 与独占链路状态',
     );
   }
 
-  Future<void> _runExclusiveProbe() async {
-    setState(() {
-      _probingExclusive = true;
-    });
+  Widget _transportStatusCard(UsbAudioStatus status) {
+    return ValueListenableBuilder<UsbExclusivePlaybackState>(
+      valueListenable: usbExclusivePlaybackStateNotifier,
+      builder: (context, exclusive, _) {
+        final active = exclusive.active;
+        final targetMs = usbAudioPreferences.foregroundBufferMsNotifier.value;
+        final levelMs = active ? exclusive.position.inMilliseconds : 0;
+        final clampedLevel = levelMs.clamp(0, targetMs);
+        final progress = targetMs <= 0 ? 0.0 : clampedLevel / targetMs;
+        final accent = active
+            ? const Color(0xFF50D890)
+            : highlightTextColor.value;
+        final foreground = textColor.value;
+        final background = Color.alphaBlend(
+          accent.withAlpha(mainPageThemeNotifier.value == .dark ? 36 : 24),
+          menuColor.value,
+        );
 
-    final result = await usbAudioService.probeExclusiveAccess();
-    if (!mounted) return;
-
-    setState(() {
-      _exclusiveProbeResult = result;
-      _probingExclusive = false;
-    });
+        return DecoratedBox(
+          decoration: BoxDecoration(
+            color: background,
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(color: accent.withAlpha(60)),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(16, 14, 16, 14),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        '传输状态',
+                        style: TextStyle(
+                          color: foreground,
+                          fontSize: 18,
+                          fontWeight: FontWeight.w800,
+                        ),
+                      ),
+                    ),
+                    Text(
+                      active ? (exclusive.playing ? '稳定' : '暂停') : '待机',
+                      style: TextStyle(
+                        color: active ? accent : foreground.withAlpha(170),
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 18),
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    Text(
+                      '$levelMs ms',
+                      style: TextStyle(
+                        color: foreground,
+                        fontSize: 34,
+                        height: 0.95,
+                        fontWeight: FontWeight.w900,
+                      ),
+                    ),
+                    const SizedBox(width: 10),
+                    Expanded(
+                      child: Padding(
+                        padding: const EdgeInsets.only(bottom: 3),
+                        child: Text(
+                          '缓冲区水位',
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: TextStyle(
+                            color: foreground.withAlpha(145),
+                            fontSize: 15,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                      ),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 3),
+                      child: Text(
+                        'ISO 0',
+                        style: TextStyle(
+                          color: foreground.withAlpha(175),
+                          fontSize: 16,
+                          fontWeight: FontWeight.w800,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(999),
+                  child: LinearProgressIndicator(
+                    value: progress,
+                    minHeight: 8,
+                    backgroundColor: foreground.withAlpha(28),
+                    valueColor: AlwaysStoppedAnimation<Color>(accent),
+                  ),
+                ),
+                const SizedBox(height: 10),
+                Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        active ? '目标 $targetMs ms' : '播放时建立目标水位',
+                        style: TextStyle(
+                          color: foreground.withAlpha(135),
+                          fontSize: 12,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+                    ),
+                    Text(
+                      active ? '最低 $levelMs ms' : '最低 --',
+                      style: TextStyle(
+                        color: foreground.withAlpha(135),
+                        fontSize: 12,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
   }
 
   Widget _fixedSampleRate() {
     final prefs = usbAudioPreferences;
     return Column(
       children: [
-        _section(
+        _settingsCard(
           children: [
-            _tile(
-              title: '启用',
-              trailing: SizedBox(
-                width: 52,
-                child: MySwitch(
-                  valueNotifier: prefs.fixedSampleRateEnabledNotifier,
-                  onToggleCallBack: setting.save,
-                ),
-              ),
+            _switchTile(
+              title: '启用固定采样率',
+              subtitle: '开启后 USB 输出优先使用下方选定采样率。',
+              notifier: prefs.fixedSampleRateEnabledNotifier,
             ),
             for (final rate in UsbAudioPreferences.sampleRates)
               ValueListenableBuilder<int?>(
                 valueListenable: prefs.fixedSampleRateNotifier,
                 builder: (context, selectedRate, _) {
                   return _radioTile<int>(
-                    title: rate.toString(),
+                    title: formatSampleRate(rate),
                     value: rate,
                     groupValue: selectedRate,
                     onTap: () {
@@ -357,8 +493,10 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
   Widget _dsdMode() {
     final prefs = usbAudioPreferences;
     return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        _section(
+        _sectionTitle('DSD 输出策略'),
+        _settingsCard(
           children: [
             for (final mode in UsbDsdMode.values)
               ValueListenableBuilder<UsbDsdMode>(
@@ -378,9 +516,9 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
               ),
           ],
         ),
-        const SizedBox(height: 14),
+        const SizedBox(height: 18),
         _sectionTitle('DSD to PCM'),
-        _section(
+        _settingsCard(
           children: [
             _dsdPcmRateTile('DSD64', prefs.dsd64PcmRateNotifier),
             _dsdPcmRateTile('DSD128', prefs.dsd128PcmRateNotifier),
@@ -401,42 +539,139 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
     );
   }
 
-  Widget _section({required List<Widget> children}) {
+  Widget _heroCard({
+    required IconData icon,
+    required Color accent,
+    required String title,
+    required String subtitle,
+    required List<_Metric> metrics,
+    required String footer,
+    Widget? trailing,
+    bool compact = false,
+  }) {
+    final foreground = textColor.value;
+    final background = Color.alphaBlend(
+      accent.withAlpha(mainPageThemeNotifier.value == .dark ? 38 : 24),
+      menuColor.value,
+    );
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: background,
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(color: accent.withAlpha(70)),
+      ),
+      child: Padding(
+        padding: EdgeInsets.all(compact ? 14 : 16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                _iconBox(icon, accent),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        title,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          color: foreground,
+                          fontSize: compact ? 17 : 20,
+                          fontWeight: FontWeight.w800,
+                        ),
+                      ),
+                      const SizedBox(height: 3),
+                      Text(
+                        subtitle,
+                        maxLines: 2,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          color: foreground.withAlpha(150),
+                          fontSize: 12,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                if (trailing != null) trailing,
+              ],
+            ),
+            const SizedBox(height: 14),
+            Wrap(
+              spacing: 10,
+              runSpacing: 10,
+              children: [
+                for (final metric in metrics)
+                  _metricPill(metric.label, metric.value, accent),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Text(
+              footer,
+              style: TextStyle(
+                color: foreground.withAlpha(120),
+                fontSize: 12,
+                height: 1.35,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _settingsCard({required List<Widget> children}) {
     return DecoratedBox(
       decoration: BoxDecoration(
         color: menuColor.value,
-        borderRadius: BorderRadius.circular(14),
+        borderRadius: BorderRadius.circular(16),
       ),
-      child: Column(children: children),
+      child: Column(
+        children: [
+          for (var index = 0; index < children.length; index++) ...[
+            children[index],
+            if (index != children.length - 1) _divider(),
+          ],
+        ],
+      ),
     );
   }
 
   Widget _sectionTitle(String title) {
     return Padding(
-      padding: const EdgeInsets.fromLTRB(8, 6, 8, 8),
+      padding: const EdgeInsets.fromLTRB(6, 0, 6, 8),
       child: Align(
         alignment: Alignment.centerLeft,
         child: Text(
           title,
           style: TextStyle(
-            color: textColor.value.withAlpha(180),
-            fontWeight: FontWeight.w700,
+            color: textColor.value.withAlpha(150),
+            fontSize: 13,
+            fontWeight: FontWeight.w800,
           ),
         ),
       ),
     );
   }
 
-  Widget _tile({
+  Widget _switchTile({
     required String title,
-    String? subtitle,
-    Widget? trailing,
-    bool info = false,
+    required String subtitle,
+    required ValueNotifier<bool> notifier,
   }) {
     return ListTile(
-      title: _titleWithInfo(title, info),
-      subtitle: subtitle == null ? null : Text(subtitle),
-      trailing: trailing,
+      title: Text(title),
+      subtitle: Text(subtitle),
+      trailing: SizedBox(
+        width: 52,
+        child: MySwitch(
+          valueNotifier: notifier,
+          onToggleCallBack: setting.save,
+        ),
+      ),
     );
   }
 
@@ -459,19 +694,114 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
     );
   }
 
-  Widget _titleWithInfo(String title, bool info) {
-    if (!info) return Text(title);
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Flexible(child: Text(title)),
-        const SizedBox(width: 6),
-        Icon(
-          Icons.info_outline_rounded,
-          size: 16,
-          color: textColor.value.withAlpha(90),
+  Widget _infoTile(String title, String value, String subtitle) {
+    return ListTile(
+      title: Text(title),
+      subtitle: Text(subtitle),
+      trailing: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 190),
+        child: Text(
+          value,
+          textAlign: TextAlign.right,
+          maxLines: 2,
+          overflow: TextOverflow.ellipsis,
+          style: TextStyle(
+            color: textColor.value.withAlpha(210),
+            fontWeight: FontWeight.w700,
+          ),
         ),
-      ],
+      ),
+    );
+  }
+
+  Widget _noticeTile({
+    required IconData icon,
+    required String title,
+    required String subtitle,
+    required String actionLabel,
+    required VoidCallback onTap,
+  }) {
+    return ListTile(
+      leading: _iconBox(icon, const Color(0xFFFF6868), compact: true),
+      title: Text(title),
+      subtitle: Text(subtitle),
+      trailing: TextButton(onPressed: onTap, child: Text(actionLabel)),
+    );
+  }
+
+  Widget _actionTile({
+    required IconData icon,
+    required String title,
+    required String subtitle,
+    required String actionLabel,
+    required VoidCallback? onTap,
+  }) {
+    return ListTile(
+      leading: _iconBox(icon, highlightTextColor.value, compact: true),
+      title: Text(title),
+      subtitle: Text(subtitle),
+      trailing: TextButton(onPressed: onTap, child: Text(actionLabel)),
+    );
+  }
+
+  Widget _hintTile(String text) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 14),
+      child: Text(
+        text,
+        style: TextStyle(color: textColor.value.withAlpha(130), fontSize: 12),
+      ),
+    );
+  }
+
+  Widget _bufferSlider({
+    required String title,
+    required ValueNotifier<int> notifier,
+    required double min,
+    required double max,
+    required int divisions,
+  }) {
+    return ValueListenableBuilder<int>(
+      valueListenable: notifier,
+      builder: (context, value, _) {
+        final sliderValue = value.toDouble().clamp(min, max);
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      title,
+                      style: const TextStyle(fontWeight: FontWeight.w700),
+                    ),
+                  ),
+                  Text(
+                    '${sliderValue.round()} ms',
+                    style: TextStyle(
+                      color: textColor.value.withAlpha(180),
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ],
+              ),
+              Slider(
+                value: sliderValue,
+                min: min,
+                max: max,
+                divisions: divisions,
+                label: '${sliderValue.round()} ms',
+                onChanged: (next) {
+                  notifier.value = next.round();
+                },
+                onChangeEnd: (_) => setting.save(),
+              ),
+            ],
+          ),
+        );
+      },
     );
   }
 
@@ -494,7 +824,6 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
 
   Widget _choiceTile<T>({
     required String title,
-    bool info = false,
     required ValueNotifier<T> notifier,
     required List<T> values,
     required String Function(T value) label,
@@ -503,7 +832,7 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
       valueListenable: notifier,
       builder: (context, value, _) {
         return ListTile(
-          title: _titleWithInfo(title, info),
+          title: Text(title),
           trailing: Row(
             mainAxisSize: MainAxisSize.min,
             children: [
@@ -579,6 +908,120 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
     );
   }
 
+  Widget _iconBox(IconData icon, Color color, {bool compact = false}) {
+    final size = compact ? 34.0 : 42.0;
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: color.withAlpha(30),
+        borderRadius: BorderRadius.circular(compact ? 10 : 13),
+        border: Border.all(color: color.withAlpha(90)),
+      ),
+      child: Icon(icon, color: color, size: compact ? 18 : 22),
+    );
+  }
+
+  Widget _metricPill(String label, String value, Color accent) {
+    return Container(
+      constraints: const BoxConstraints(minWidth: 110, maxWidth: 170),
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+      decoration: BoxDecoration(
+        color: textColor.value.withAlpha(16),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              color: textColor.value.withAlpha(115),
+              fontSize: 11,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const SizedBox(height: 3),
+          Text(
+            value,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: TextStyle(
+              color: textColor.value.withAlpha(220),
+              fontWeight: FontWeight.w800,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _divider() {
+    return Divider(
+      height: 1,
+      indent: 16,
+      endIndent: 16,
+      color: textColor.value.withAlpha(22),
+    );
+  }
+
+  Future<void> _refreshStatus() async {
+    setState(() {
+      _refreshingStatus = true;
+    });
+    await usbAudioService.refreshStatus();
+    if (!mounted) return;
+    setState(() {
+      _refreshingStatus = false;
+    });
+  }
+
+  Future<void> _runExclusiveProbe() async {
+    setState(() {
+      _probingExclusive = true;
+    });
+
+    final result = await usbAudioService.probeExclusiveAccess();
+    if (!mounted) return;
+
+    setState(() {
+      _exclusiveProbeResult = result;
+      _probingExclusive = false;
+    });
+  }
+
+  void _showStatusSnack(UsbAudioStatus status) {
+    final device = _activeUsbDevice(status);
+    final message = device == null
+        ? '当前未检测到 USB DAC。'
+        : 'USB DAC: ${device.name} · ${_supportedRatesLabel(status)} · ${_bitDepthLabel(status)}';
+    ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+      SnackBar(content: Text(message), behavior: SnackBarBehavior.floating),
+    );
+  }
+
+  String _exclusiveProbeSummary() {
+    final result = _exclusiveProbeResult;
+    if (result == null) return '检查 USB 权限、Audio Class 描述符与接口 claim 能力。';
+    if (!result.permissionGranted) return '等待 USB 授权。';
+    if (result.interfaceClaimed) {
+      return '可 claim · ${result.audioInterfaceCount} 个 Audio Interface';
+    }
+    return result.message ?? '未能 claim USB Audio Interface。';
+  }
+
+  String _dacEndpointLabel(UsbAudioStatus status) {
+    final exclusive = usbExclusivePlaybackStateNotifier.value;
+    if (exclusive.active) {
+      return '${formatSampleRate(exclusive.sampleRate)} / ${exclusive.bitDepth ?? '未知'} bits';
+    }
+    final device = _activeUsbDevice(status);
+    if (device == null) return '播放后显示';
+    return '${_supportedRatesLabel(status)} · ${_bitDepthLabel(status)}';
+  }
+
   String _dsdModeLabel(UsbDsdMode mode) {
     return switch (mode) {
       UsbDsdMode.pcm => 'PCM',
@@ -591,7 +1034,7 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
     return switch (mode) {
       UsbDsdMode.pcm => '将 DSD 转换为 PCM 输出',
       UsbDsdMode.dop => '以 PCM 帧封装 DSD，设备支持时使用',
-      UsbDsdMode.native => '保留 Native DSD 策略，需底层链路支持',
+      UsbDsdMode.native => '保留 Native DSD 策略，需要底层链路支持',
     };
   }
 
@@ -620,4 +1063,94 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
       UsbBitDepthMode.pcm32 => '32 bits',
     };
   }
+}
+
+class _Metric {
+  final String label;
+  final String value;
+
+  const _Metric(this.label, this.value);
+}
+
+UsbAudioDevice? _activeUsbDevice(UsbAudioStatus status) {
+  for (final device in status.devices) {
+    if (device.id == status.bestAvailableDeviceId) {
+      return device;
+    }
+  }
+  return null;
+}
+
+String _shortOutputName(UsbAudioStatus status) {
+  final exclusive = usbExclusivePlaybackStateNotifier.value;
+  if (exclusive.active) {
+    return 'USB 真独占';
+  }
+
+  if (!status.supported) {
+    return status.outputDeviceName ?? 'Android';
+  }
+  final device = _activeUsbDevice(status);
+  if (device != null) return device.name;
+  return status.outputDeviceName ?? 'USB DAC';
+}
+
+String _supportedRatesLabel(UsbAudioStatus status) {
+  final device = _activeUsbDevice(status);
+  final rates = device?.supportedMixerSampleRates.isNotEmpty == true
+      ? device!.supportedMixerSampleRates
+      : device?.sampleRates ?? const <int>[];
+  if (rates.isEmpty) return '未知';
+  return rates.map(formatSampleRate).join(' / ');
+}
+
+String _bitPerfectSupportLabel(UsbAudioStatus status) {
+  if (!status.supported) return '不可用';
+  if (status.androidSdk < 34) return '需要 Android 14+';
+  final device = _activeUsbDevice(status);
+  if (device?.supportsBitPerfectMixer == true) {
+    return status.preferredBitPerfect ? '已请求' : '可用';
+  }
+  return '设备未声明支持';
+}
+
+String _exclusiveStatusLabel(UsbAudioStatus status) {
+  if (!status.supported) return '未连接 USB 音频设备';
+  if (status.androidSdk < 34) return '当前系统不支持 USB 独占请求';
+  if (status.preferredBitPerfect && status.preferredSampleRate != null) {
+    return '已请求 USB 独占输出';
+  }
+  if (_activeUsbDevice(status)?.supportsBitPerfectMixer == true) {
+    return '可启用 USB 独占输出';
+  }
+  return '已连接 USB DAC，但未确认支持独占';
+}
+
+String _bitDepthLabel(UsbAudioStatus status) {
+  final exclusive = usbExclusivePlaybackStateNotifier.value;
+  if (exclusive.active && exclusive.bitDepth != null) {
+    return '${exclusive.bitDepth} bits';
+  }
+
+  final encoding = status.preferredEncoding ?? status.outputEncoding;
+  if (encoding == 'pcm_float') return '32 bits';
+  if (encoding == 'pcm_32bit') return '32 bits';
+  if (encoding == 'pcm_24bit_packed') return '24 bits';
+  if (encoding == 'pcm_16bit') return '16 bits';
+  return '未知';
+}
+
+String _outputEncodingLabel(UsbAudioStatus status) {
+  final encoding = status.preferredEncoding ?? status.outputEncoding;
+  if (encoding == null) return 'PCM / 系统默认';
+  final bitDepth = _bitDepthLabel(status);
+  return bitDepth == '未知' ? encoding : 'PCM / $bitDepth';
+}
+
+String _outputPortLabel(UsbAudioStatus status) {
+  if (!status.supported) {
+    return status.outputDeviceName ?? 'Android';
+  }
+  final name = _shortOutputName(status);
+  return status.preferredApplied ? '$name · 已应用偏好' : '$name · 系统输出';
 }

--- a/lib/layer/audio_output_settings_layer.dart
+++ b/lib/layer/audio_output_settings_layer.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:sylvakru/base/app.dart';
@@ -168,12 +170,7 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
             _sectionTitle('输出格式'),
             _settingsCard(
               children: [
-                _sourceFileTile(),
-                _infoTile(
-                  'DAC 端点',
-                  _dacEndpointLabel(status),
-                  '播放后显示真实 DAC 端点格式',
-                ),
+                _formatSummaryTile(status),
                 _switchTile(
                   title: '位深兼容',
                   subtitle: '设备不支持源位深时自动回退。',
@@ -254,6 +251,8 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
                   min: 50,
                   max: 1000,
                   divisions: 19,
+                  onChanged: (value) =>
+                      _applyExclusiveBufferIfActive(foregroundBufferMs: value),
                 ),
                 _bufferSlider(
                   title: '后台缓冲区',
@@ -261,6 +260,8 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
                   min: 500,
                   max: 5000,
                   divisions: 18,
+                  onChanged: (value) =>
+                      _applyExclusiveBufferIfActive(backgroundBufferMs: value),
                 ),
                 _hintTile('后台打开大型 App 出现卡顿时优先提高后台缓冲；数值越大越稳定，切歌与暂停响应可能稍慢。'),
               ],
@@ -281,7 +282,7 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
                   values: const [-12, -9, -6, -3, 0, 3, 6],
                   label: (value) => '$value dB',
                 ),
-                _infoTile('当前媒体音量', '播放开始后检测', '硬件音量与 DAC 反馈可用后显示'),
+                _mediaVolumeTile(),
                 _switchTile(
                   title: '音量平滑交接',
                   subtitle: '切换数字音量与 DAC 硬件音量时保持响度连续。',
@@ -350,9 +351,6 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
           menuColor.value,
         );
         final title = supported ? device?.name ?? 'USB DAC' : '未识别 USB 设备';
-        final subtitle = supported
-            ? _exclusiveStatusLabel(status)
-            : '连接 DAC 后显示设备信息';
         final statusLabel = supported ? '已连接' : '未连接';
         final linkLabel = supported
             ? (exclusive.active ? '独占播放' : '运行中')
@@ -429,17 +427,6 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
                     fontWeight: FontWeight.w900,
                   ),
                 ),
-                const SizedBox(height: 6),
-                Text(
-                  subtitle,
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                  style: TextStyle(
-                    color: foreground.withAlpha(150),
-                    fontSize: 14,
-                    fontWeight: FontWeight.w600,
-                  ),
-                ),
                 const SizedBox(height: 22),
                 Row(
                   children: [
@@ -494,157 +481,168 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
   }
 
   Widget _transportStatusCard(UsbAudioStatus status) {
-    return ValueListenableBuilder<UsbExclusivePlaybackState>(
-      valueListenable: usbExclusivePlaybackStateNotifier,
-      builder: (context, exclusive, _) {
-        return ValueListenableBuilder<UsbTransportTelemetry>(
-          valueListenable: usbTransportTelemetryNotifier,
-          builder: (context, telemetry, _) {
-            final active = exclusive.active || telemetry.active;
-            final targetMs =
-                telemetry.targetBuffer?.inMilliseconds ??
-                usbAudioPreferences.foregroundBufferMsNotifier.value;
-            final levelMs = telemetry.active
-                ? telemetry.bufferLevel.inMilliseconds
-                : 0;
-            final minimumMs = telemetry.minimumBufferLevel?.inMilliseconds;
-            final clampedLevel = levelMs.clamp(0, targetMs);
-            final progress = targetMs <= 0 ? 0.0 : clampedLevel / targetMs;
-            final health = _transportHealth(
-              active: active,
-              playing: exclusive.playing,
-              levelMs: levelMs,
-              minimumMs: minimumMs,
-              targetMs: targetMs,
-              underrunCount: telemetry.underrunCount,
-            );
-            final accent = _transportHealthAccent(health);
-            final foreground = textColor.value;
-            final background = Color.alphaBlend(
-              accent.withAlpha(mainPageThemeNotifier.value == .dark ? 36 : 24),
-              menuColor.value,
-            );
+    return ValueListenableBuilder<int>(
+      valueListenable: usbAudioPreferences.foregroundBufferMsNotifier,
+      builder: (context, foregroundTargetMs, _) {
+        return ValueListenableBuilder<UsbExclusivePlaybackState>(
+          valueListenable: usbExclusivePlaybackStateNotifier,
+          builder: (context, exclusive, _) {
+            return ValueListenableBuilder<UsbTransportTelemetry>(
+              valueListenable: usbTransportTelemetryNotifier,
+              builder: (context, telemetry, _) {
+                final active = exclusive.active || telemetry.active;
+                final targetMs = _currentExclusiveTargetBufferMs(
+                  foregroundTargetMs: foregroundTargetMs,
+                  backgroundTargetMs:
+                      usbAudioPreferences.backgroundBufferMsNotifier.value,
+                );
+                final levelMs = telemetry.active
+                    ? telemetry.bufferLevel.inMilliseconds
+                    : 0;
+                final minimumMs = telemetry.minimumBufferLevel?.inMilliseconds;
+                final clampedLevel = levelMs.clamp(0, targetMs);
+                final progress = targetMs <= 0 ? 0.0 : clampedLevel / targetMs;
+                final health = _transportHealth(
+                  active: active,
+                  playing: exclusive.playing,
+                  levelMs: levelMs,
+                  minimumMs: minimumMs,
+                  targetMs: targetMs,
+                  underrunCount: telemetry.underrunCount,
+                );
+                final accent = _transportHealthAccent(health);
+                final foreground = textColor.value;
+                final background = Color.alphaBlend(
+                  accent.withAlpha(
+                    mainPageThemeNotifier.value == .dark ? 36 : 24,
+                  ),
+                  menuColor.value,
+                );
 
-            return DecoratedBox(
-              decoration: BoxDecoration(
-                color: background,
-                borderRadius: BorderRadius.circular(16),
-                border: Border.all(color: accent.withAlpha(60)),
-              ),
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(16, 14, 16, 14),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.stretch,
-                  children: [
-                    Row(
+                return DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: background,
+                    borderRadius: BorderRadius.circular(16),
+                    border: Border.all(color: accent.withAlpha(60)),
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 14, 16, 14),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
                       children: [
-                        Expanded(
-                          child: Text(
-                            '传输状态',
-                            style: TextStyle(
-                              color: foreground,
-                              fontSize: 18,
-                              fontWeight: FontWeight.w800,
-                            ),
-                          ),
-                        ),
-                        Text(
-                          _transportHealthLabel(health),
-                          style: TextStyle(
-                            color: active ? accent : foreground.withAlpha(170),
-                            fontWeight: FontWeight.w800,
-                          ),
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: 18),
-                    Row(
-                      crossAxisAlignment: CrossAxisAlignment.end,
-                      children: [
-                        Flexible(
-                          flex: 4,
-                          child: FittedBox(
-                            fit: BoxFit.scaleDown,
-                            alignment: Alignment.bottomLeft,
-                            child: Text(
-                              '$levelMs ms',
-                              style: TextStyle(
-                                color: foreground,
-                                fontSize: 34,
-                                height: 0.95,
-                                fontWeight: FontWeight.w900,
+                        Row(
+                          children: [
+                            Expanded(
+                              child: Text(
+                                '传输状态',
+                                style: TextStyle(
+                                  color: foreground,
+                                  fontSize: 18,
+                                  fontWeight: FontWeight.w800,
+                                ),
                               ),
                             ),
+                            Text(
+                              _transportHealthLabel(health),
+                              style: TextStyle(
+                                color: active
+                                    ? accent
+                                    : foreground.withAlpha(170),
+                                fontWeight: FontWeight.w800,
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 18),
+                        Row(
+                          crossAxisAlignment: CrossAxisAlignment.end,
+                          children: [
+                            Flexible(
+                              flex: 4,
+                              child: FittedBox(
+                                fit: BoxFit.scaleDown,
+                                alignment: Alignment.bottomLeft,
+                                child: Text(
+                                  '$levelMs ms',
+                                  style: TextStyle(
+                                    color: foreground,
+                                    fontSize: 34,
+                                    height: 0.95,
+                                    fontWeight: FontWeight.w900,
+                                  ),
+                                ),
+                              ),
+                            ),
+                            const SizedBox(width: 10),
+                            Expanded(
+                              flex: 3,
+                              child: Padding(
+                                padding: const EdgeInsets.only(bottom: 3),
+                                child: Text(
+                                  '缓冲区水位',
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: TextStyle(
+                                    color: foreground.withAlpha(145),
+                                    fontSize: 15,
+                                    fontWeight: FontWeight.w700,
+                                  ),
+                                ),
+                              ),
+                            ),
+                            Padding(
+                              padding: const EdgeInsets.only(bottom: 3),
+                              child: Text(
+                                'ISO ${telemetry.active ? telemetry.isoPacketCount : 0}',
+                                style: TextStyle(
+                                  color: foreground.withAlpha(175),
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.w800,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 12),
+                        ClipRRect(
+                          borderRadius: BorderRadius.circular(999),
+                          child: LinearProgressIndicator(
+                            value: progress,
+                            minHeight: 8,
+                            backgroundColor: foreground.withAlpha(28),
+                            valueColor: AlwaysStoppedAnimation<Color>(accent),
                           ),
                         ),
-                        const SizedBox(width: 10),
-                        Expanded(
-                          flex: 3,
-                          child: Padding(
-                            padding: const EdgeInsets.only(bottom: 3),
-                            child: Text(
-                              '缓冲区水位',
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
+                        const SizedBox(height: 10),
+                        Row(
+                          children: [
+                            Expanded(
+                              child: Text(
+                                active ? '目标 $targetMs ms' : '播放时建立目标水位',
+                                style: TextStyle(
+                                  color: foreground.withAlpha(135),
+                                  fontSize: 12,
+                                  fontWeight: FontWeight.w700,
+                                ),
+                              ),
+                            ),
+                            Text(
+                              active && minimumMs != null
+                                  ? '最低 $minimumMs ms'
+                                  : '最低 --',
                               style: TextStyle(
-                                color: foreground.withAlpha(145),
-                                fontSize: 15,
+                                color: foreground.withAlpha(135),
+                                fontSize: 12,
                                 fontWeight: FontWeight.w700,
                               ),
                             ),
-                          ),
-                        ),
-                        Padding(
-                          padding: const EdgeInsets.only(bottom: 3),
-                          child: Text(
-                            'ISO ${telemetry.active ? telemetry.isoPacketCount : 0}',
-                            style: TextStyle(
-                              color: foreground.withAlpha(175),
-                              fontSize: 16,
-                              fontWeight: FontWeight.w800,
-                            ),
-                          ),
+                          ],
                         ),
                       ],
                     ),
-                    const SizedBox(height: 12),
-                    ClipRRect(
-                      borderRadius: BorderRadius.circular(999),
-                      child: LinearProgressIndicator(
-                        value: progress,
-                        minHeight: 8,
-                        backgroundColor: foreground.withAlpha(28),
-                        valueColor: AlwaysStoppedAnimation<Color>(accent),
-                      ),
-                    ),
-                    const SizedBox(height: 10),
-                    Row(
-                      children: [
-                        Expanded(
-                          child: Text(
-                            active ? '目标 $targetMs ms' : '播放时建立目标水位',
-                            style: TextStyle(
-                              color: foreground.withAlpha(135),
-                              fontSize: 12,
-                              fontWeight: FontWeight.w700,
-                            ),
-                          ),
-                        ),
-                        Text(
-                          active && minimumMs != null
-                              ? '最低 $minimumMs ms'
-                              : '最低 --',
-                          style: TextStyle(
-                            color: foreground.withAlpha(135),
-                            fontSize: 12,
-                            fontWeight: FontWeight.w700,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ],
-                ),
-              ),
+                  ),
+                );
+              },
             );
           },
         );
@@ -804,37 +802,126 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
     );
   }
 
-  Widget _infoTile(String title, String value, String subtitle) {
-    return ListTile(
-      title: Text(title),
-      subtitle: Text(subtitle),
-      trailing: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 190),
-        child: Text(
-          value,
-          textAlign: TextAlign.right,
-          maxLines: 2,
-          overflow: TextOverflow.ellipsis,
-          style: TextStyle(
-            color: textColor.value.withAlpha(210),
-            fontWeight: FontWeight.w700,
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _sourceFileTile() {
+  Widget _formatSummaryTile(UsbAudioStatus status) {
     return ValueListenableBuilder<MyAudioMetadata?>(
       valueListenable: currentSongNotifier,
       builder: (context, song, _) {
-        return _infoTile(
-          '源文件',
-          _sourceFileTitle(song),
-          _sourceFileSubtitle(song),
+        final channel = _channelCountLabel(status);
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 18),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _formatMetricRow('源文件', [
+                _sourceFormatLabel(song),
+                formatSampleRate(song?.samplerate),
+                channel,
+                _compactDepthLabel(status),
+              ]),
+              const SizedBox(height: 24),
+              _formatMetricRow('DAC 端点', [
+                'PCM',
+                formatOutputSampleRate(status),
+                channel,
+                _compactDepthLabel(status),
+              ]),
+            ],
+          ),
         );
       },
     );
+  }
+
+  Widget _formatMetricRow(String label, List<String> values) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: TextStyle(
+            color: textColor.value.withAlpha(145),
+            fontSize: 14,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Row(
+          children: [
+            for (var index = 0; index < values.length; index++) ...[
+              Expanded(
+                child: Text(
+                  values[index],
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: textColor.value.withAlpha(220),
+                    fontSize: 22,
+                    height: 1.05,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ),
+              if (index != values.length - 1) const SizedBox(width: 12),
+            ],
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _mediaVolumeTile() {
+    return ValueListenableBuilder<double>(
+      valueListenable: volumeNotifier,
+      builder: (context, volume, _) {
+        final percent = (volume.clamp(0.0, 1.0) * 100).round();
+        final sliderValue = volume.clamp(0.0, 1.0);
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      '当前媒体音量',
+                      style: const TextStyle(fontWeight: FontWeight.w700),
+                    ),
+                  ),
+                  Text(
+                    '$percent%',
+                    style: TextStyle(
+                      color: textColor.value.withAlpha(180),
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ],
+              ),
+              Slider(
+                value: sliderValue,
+                min: 0,
+                max: 1,
+                divisions: 100,
+                label: '$percent%',
+                onChanged: (next) {
+                  volumeNotifier.value = next;
+                  _setPlayerVolumeIfReady(next);
+                },
+                onChangeEnd: (_) => setting.save(),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  void _setPlayerVolumeIfReady(double volume) {
+    try {
+      audioHandler.setVolume(volume);
+    } on Error catch (error) {
+      if (!error.toString().contains('LateInitializationError')) rethrow;
+    }
   }
 
   Widget _noticeTile({
@@ -883,6 +970,7 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
     required double min,
     required double max,
     required int divisions,
+    ValueChanged<int>? onChanged,
   }) {
     return ValueListenableBuilder<int>(
       valueListenable: notifier,
@@ -917,7 +1005,9 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
                 divisions: divisions,
                 label: '${sliderValue.round()} ms',
                 onChanged: (next) {
-                  notifier.value = next.round();
+                  final rounded = next.round();
+                  notifier.value = rounded;
+                  onChanged?.call(rounded);
                 },
                 onChangeEnd: (_) => setting.save(),
               ),
@@ -1080,6 +1170,47 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
     );
   }
 
+  void _applyExclusiveBufferIfActive({
+    int? foregroundBufferMs,
+    int? backgroundBufferMs,
+  }) {
+    final exclusive = usbExclusivePlaybackStateNotifier.value;
+    if (!exclusive.active) return;
+
+    final targetBufferMs = _currentExclusiveTargetBufferMs(
+      foregroundTargetMs:
+          foregroundBufferMs ??
+          usbAudioPreferences.foregroundBufferMsNotifier.value,
+      backgroundTargetMs:
+          backgroundBufferMs ??
+          usbAudioPreferences.backgroundBufferMsNotifier.value,
+    );
+    unawaited(usbAudioService.setExclusiveTargetBufferMs(targetBufferMs));
+  }
+
+  int _currentExclusiveTargetBufferMs({
+    required int foregroundTargetMs,
+    required int backgroundTargetMs,
+  }) {
+    if (_usesBackgroundExclusiveBuffer()) {
+      return backgroundTargetMs;
+    }
+    return foregroundTargetMs;
+  }
+
+  bool _usesBackgroundExclusiveBuffer() {
+    if (!usbAudioPreferences.keepAliveInBackgroundNotifier.value) {
+      return false;
+    }
+    return switch (WidgetsBinding.instance.lifecycleState) {
+      AppLifecycleState.resumed || null => false,
+      AppLifecycleState.inactive ||
+      AppLifecycleState.hidden ||
+      AppLifecycleState.paused ||
+      AppLifecycleState.detached => true,
+    };
+  }
+
   Future<void> _refreshStatus() async {
     setState(() {
       _refreshingStatus = true;
@@ -1125,32 +1256,19 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
     return result.message ?? '未能 claim USB Audio Interface。';
   }
 
-  String _dacEndpointLabel(UsbAudioStatus status) {
-    final exclusive = usbExclusivePlaybackStateNotifier.value;
-    if (exclusive.active) {
-      return '${formatSampleRate(exclusive.sampleRate)} / ${exclusive.bitDepth ?? '未知'} bits';
-    }
+  String _sourceFormatLabel(MyAudioMetadata? song) {
+    final format = song?.format;
+    if (format == null || format.isEmpty) return '未知';
+    return format.toUpperCase();
+  }
+
+  String _channelCountLabel(UsbAudioStatus status) {
     final device = _activeUsbDevice(status);
-    if (device == null) return '播放后显示';
-    return '${_supportedRatesLabel(status)} · ${_bitDepthLabel(status)}';
-  }
-
-  String _sourceFileTitle(MyAudioMetadata? song) {
-    if (song == null) return '等待播放';
-    return formatSourceFileName(song.path ?? song.cachePath);
-  }
-
-  String _sourceFileSubtitle(MyAudioMetadata? song) {
-    if (song == null) return '采样率未知 · 格式未知 · 码率未知';
-    final parts = [
-      formatSampleRate(song.samplerate),
-      if (song.format?.isNotEmpty == true)
-        song.format!.toUpperCase()
-      else
-        '格式未知',
-      formatBitrate(song.bitrate),
-    ];
-    return parts.join(' · ');
+    final channels = device?.channelCounts.isNotEmpty == true
+        ? device!.channelCounts.first
+        : null;
+    if (channels == null || channels <= 0) return '未知';
+    return '$channels ch';
   }
 
   String _compactDepthLabel(UsbAudioStatus status) {
@@ -1223,18 +1341,6 @@ String _supportedRatesLabel(UsbAudioStatus status) {
       : device?.sampleRates ?? const <int>[];
   if (rates.isEmpty) return '未知';
   return rates.map(formatSampleRate).join(' / ');
-}
-
-String _exclusiveStatusLabel(UsbAudioStatus status) {
-  if (!status.supported) return '未连接 USB 音频设备';
-  if (status.androidSdk < 34) return '当前系统不支持 USB 独占请求';
-  if (status.preferredBitPerfect && status.preferredSampleRate != null) {
-    return '已请求 USB 独占输出';
-  }
-  if (_activeUsbDevice(status)?.supportsBitPerfectMixer == true) {
-    return '可启用 USB 独占输出';
-  }
-  return '已连接 USB DAC，但未确认支持独占';
 }
 
 String _bitDepthLabel(UsbAudioStatus status) {

--- a/lib/layer/audio_output_settings_layer.dart
+++ b/lib/layer/audio_output_settings_layer.dart
@@ -1,0 +1,494 @@
+import 'package:flutter/material.dart';
+import 'package:sylvakru/base/app.dart';
+import 'package:sylvakru/base/data/setting.dart';
+import 'package:sylvakru/base/services/color_manager.dart';
+import 'package:sylvakru/base/services/usb_audio_preferences.dart';
+import 'package:sylvakru/base/widgets/audio_output_panel.dart';
+import 'package:sylvakru/base/widgets/my_switch.dart';
+import 'package:sylvakru/base/utils/media_query.dart';
+import 'package:sylvakru/landscape_view/title_bar.dart';
+import 'package:sylvakru/layer/layers_manager.dart';
+import 'package:sylvakru/layer/settings_layer.dart';
+import 'package:sylvakru/portrait_view/custom_appbar_leading.dart';
+
+enum AudioOutputSettingsPageKind { overview, fixedSampleRate, dsdMode }
+
+class AudioOutputSettingsLayer extends StatefulWidget {
+  final AudioOutputSettingsPageKind pageKind;
+
+  const AudioOutputSettingsLayer({
+    super.key,
+    this.pageKind = AudioOutputSettingsPageKind.overview,
+  });
+
+  @override
+  State<AudioOutputSettingsLayer> createState() =>
+      _AudioOutputSettingsLayerState();
+}
+
+class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
+  @override
+  Widget build(BuildContext context) {
+    if (isTooNarrow(context)) {
+      return Scaffold(
+        backgroundColor: Colors.transparent,
+        appBar: AppBar(
+          automaticallyImplyLeading: false,
+          leading: customAppBarLeading(context, label: 'settings'),
+          backgroundColor: Colors.transparent,
+          systemOverlayStyle: mainPageThemeNotifier.value == .dark
+              ? .light
+              : .dark,
+          elevation: 0,
+          scrolledUnderElevation: 0,
+          title: Text(_title),
+          centerTitle: true,
+        ),
+        body: _content(),
+      );
+    }
+
+    return ValueListenableBuilder<bool>(
+      valueListenable: settingsVisibleNotifier,
+      builder: (context, visible, child) {
+        return Opacity(
+          opacity: visible ? 0 : 1,
+          child: Column(
+            children: [
+              TitleBar(backToRoot: () => layersManager.popDetail('settings')),
+              Expanded(child: _content()),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  String get _title {
+    return switch (widget.pageKind) {
+      AudioOutputSettingsPageKind.overview => 'USB 输出设置',
+      AudioOutputSettingsPageKind.fixedSampleRate => '固定采样率输出',
+      AudioOutputSettingsPageKind.dsdMode => 'DSD 模式',
+    };
+  }
+
+  Widget _content() {
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 620),
+        child: ValueListenableBuilder(
+          valueListenable: mainPageThemeNotifier,
+          builder: (context, value, child) {
+            return ListView(
+              padding: const EdgeInsets.fromLTRB(16, 8, 16, 120),
+              children: [
+                switch (widget.pageKind) {
+                  AudioOutputSettingsPageKind.overview => _overview(),
+                  AudioOutputSettingsPageKind.fixedSampleRate =>
+                    _fixedSampleRate(),
+                  AudioOutputSettingsPageKind.dsdMode => _dsdMode(),
+                },
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _overview() {
+    final prefs = usbAudioPreferences;
+    return Column(
+      children: [
+        _section(
+          children: [
+            _tile(
+              title: 'USB Audio 性能模式',
+              subtitle: '连接 DAC 后启用独占提示与高优先级输出策略',
+              info: true,
+              trailing: SizedBox(
+                width: 52,
+                child: MySwitch(
+                  valueNotifier: prefs.performanceModeNotifier,
+                  onToggleCallBack: setting.save,
+                ),
+              ),
+            ),
+            _navTile(
+              title: '固定采样率输出',
+              value: prefs.fixedSampleRateEnabledNotifier.value
+                  ? formatSampleRate(prefs.fixedSampleRateNotifier.value)
+                  : '关闭',
+              onTap: () {
+                layersManager.pushDetail('settings', 'usb_fixed_sample_rate');
+              },
+            ),
+            _navTile(
+              title: 'DSD 模式',
+              value: _dsdModeLabel(prefs.dsdModeNotifier.value),
+              onTap: () {
+                layersManager.pushDetail('settings', 'usb_dsd_mode');
+              },
+            ),
+            _choiceTile<UsbVolumeLockMode>(
+              title: 'USB Audio 音量锁定',
+              info: true,
+              notifier: prefs.volumeLockModeNotifier,
+              values: UsbVolumeLockMode.values,
+              label: _volumeLockLabel,
+            ),
+            _choiceTile<int>(
+              title: 'USB Audio DSD 增益补偿',
+              info: true,
+              notifier: prefs.dsdGainCompensationNotifier,
+              values: const [-12, -9, -6, -3, 0, 3, 6],
+              label: (value) => '${value}dB',
+            ),
+            _choiceTile<UsbBusSpeedMode>(
+              title: 'USB Audio 总线速度',
+              info: true,
+              notifier: prefs.busSpeedModeNotifier,
+              values: UsbBusSpeedMode.values,
+              label: _busSpeedLabel,
+            ),
+            _choiceTile<UsbBitDepthMode>(
+              title: 'USB Audio 位深',
+              info: true,
+              notifier: prefs.bitDepthModeNotifier,
+              values: UsbBitDepthMode.values,
+              label: _bitDepthModeLabel,
+            ),
+            _tile(
+              title: '播放后释放 USB 带宽',
+              subtitle: '停止播放后允许系统回收 USB 音频资源',
+              info: true,
+              trailing: SizedBox(
+                width: 52,
+                child: MySwitch(
+                  valueNotifier: prefs.releaseUsbBandwidthAfterPlaybackNotifier,
+                  onToggleCallBack: setting.save,
+                ),
+              ),
+            ),
+            _tile(
+              title: '保持后台活动',
+              subtitle: '减少后台播放时 USB 输出被系统中断的概率',
+              info: true,
+              trailing: SizedBox(
+                width: 52,
+                child: MySwitch(
+                  valueNotifier: prefs.keepAliveInBackgroundNotifier,
+                  onToggleCallBack: setting.save,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _fixedSampleRate() {
+    final prefs = usbAudioPreferences;
+    return Column(
+      children: [
+        _section(
+          children: [
+            _tile(
+              title: '启用',
+              trailing: SizedBox(
+                width: 52,
+                child: MySwitch(
+                  valueNotifier: prefs.fixedSampleRateEnabledNotifier,
+                  onToggleCallBack: setting.save,
+                ),
+              ),
+            ),
+            for (final rate in UsbAudioPreferences.sampleRates)
+              ValueListenableBuilder<int?>(
+                valueListenable: prefs.fixedSampleRateNotifier,
+                builder: (context, selectedRate, _) {
+                  return _radioTile<int>(
+                    title: rate.toString(),
+                    value: rate,
+                    groupValue: selectedRate,
+                    onTap: () {
+                      prefs.fixedSampleRateNotifier.value = rate;
+                      setting.save();
+                    },
+                  );
+                },
+              ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _dsdMode() {
+    final prefs = usbAudioPreferences;
+    return Column(
+      children: [
+        _section(
+          children: [
+            for (final mode in UsbDsdMode.values)
+              ValueListenableBuilder<UsbDsdMode>(
+                valueListenable: prefs.dsdModeNotifier,
+                builder: (context, selectedMode, _) {
+                  return _radioTile<UsbDsdMode>(
+                    title: _dsdModeLabel(mode),
+                    subtitle: _dsdModeHint(mode),
+                    value: mode,
+                    groupValue: selectedMode,
+                    onTap: () {
+                      prefs.dsdModeNotifier.value = mode;
+                      setting.save();
+                    },
+                  );
+                },
+              ),
+          ],
+        ),
+        const SizedBox(height: 14),
+        _sectionTitle('DSD to PCM'),
+        _section(
+          children: [
+            _dsdPcmRateTile('DSD64', prefs.dsd64PcmRateNotifier),
+            _dsdPcmRateTile('DSD128', prefs.dsd128PcmRateNotifier),
+            _dsdPcmRateTile('DSD256', prefs.dsd256PcmRateNotifier),
+            _dsdPcmRateTile('DSD512', prefs.dsd512PcmRateNotifier),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _dsdPcmRateTile(String title, ValueNotifier<int> notifier) {
+    return _choiceTile<int>(
+      title: title,
+      notifier: notifier,
+      values: UsbAudioPreferences.sampleRates,
+      label: (value) => '${formatSampleRate(value)} PCM',
+    );
+  }
+
+  Widget _section({required List<Widget> children}) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: menuColor.value,
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: Column(children: children),
+    );
+  }
+
+  Widget _sectionTitle(String title) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(8, 6, 8, 8),
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: Text(
+          title,
+          style: TextStyle(
+            color: textColor.value.withAlpha(180),
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _tile({
+    required String title,
+    String? subtitle,
+    Widget? trailing,
+    bool info = false,
+  }) {
+    return ListTile(
+      title: _titleWithInfo(title, info),
+      subtitle: subtitle == null ? null : Text(subtitle),
+      trailing: trailing,
+    );
+  }
+
+  Widget _navTile({
+    required String title,
+    required String value,
+    required VoidCallback onTap,
+  }) {
+    return ListTile(
+      title: Text(title),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(value, style: TextStyle(color: textColor.value.withAlpha(150))),
+          const SizedBox(width: 6),
+          const Icon(Icons.chevron_right_rounded),
+        ],
+      ),
+      onTap: onTap,
+    );
+  }
+
+  Widget _titleWithInfo(String title, bool info) {
+    if (!info) return Text(title);
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Flexible(child: Text(title)),
+        const SizedBox(width: 6),
+        Icon(
+          Icons.info_outline_rounded,
+          size: 16,
+          color: textColor.value.withAlpha(90),
+        ),
+      ],
+    );
+  }
+
+  Widget _radioTile<T>({
+    required String title,
+    String? subtitle,
+    required T value,
+    required T? groupValue,
+    required VoidCallback onTap,
+  }) {
+    return ListTile(
+      title: Text(title),
+      subtitle: subtitle == null ? null : Text(subtitle),
+      trailing: groupValue == value
+          ? Icon(Icons.check_rounded, color: highlightTextColor.value)
+          : Icon(Icons.circle_outlined, color: textColor.value.withAlpha(120)),
+      onTap: onTap,
+    );
+  }
+
+  Widget _choiceTile<T>({
+    required String title,
+    bool info = false,
+    required ValueNotifier<T> notifier,
+    required List<T> values,
+    required String Function(T value) label,
+  }) {
+    return ValueListenableBuilder<T>(
+      valueListenable: notifier,
+      builder: (context, value, _) {
+        return ListTile(
+          title: _titleWithInfo(title, info),
+          trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                label(value),
+                style: TextStyle(color: textColor.value.withAlpha(150)),
+              ),
+              const SizedBox(width: 6),
+              const Icon(Icons.chevron_right_rounded),
+            ],
+          ),
+          onTap: () => _showChoiceSheet<T>(
+            title: title,
+            notifier: notifier,
+            values: values,
+            label: label,
+          ),
+        );
+      },
+    );
+  }
+
+  void _showChoiceSheet<T>({
+    required String title,
+    required ValueNotifier<T> notifier,
+    required List<T> values,
+    required String Function(T value) label,
+  }) {
+    showModalBottomSheet<void>(
+      context: context,
+      backgroundColor: Colors.transparent,
+      builder: (context) {
+        return Material(
+          color: menuColor.value,
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
+          clipBehavior: Clip.antiAlias,
+          child: SafeArea(
+            child: ListView(
+              shrinkWrap: true,
+              padding: const EdgeInsets.fromLTRB(12, 10, 12, 18),
+              children: [
+                ListTile(
+                  title: Text(
+                    title,
+                    style: const TextStyle(fontWeight: FontWeight.w800),
+                  ),
+                ),
+                for (final value in values)
+                  ValueListenableBuilder<T>(
+                    valueListenable: notifier,
+                    builder: (context, currentValue, _) {
+                      return ListTile(
+                        title: Text(label(value)),
+                        trailing: currentValue == value
+                            ? Icon(
+                                Icons.check_rounded,
+                                color: highlightTextColor.value,
+                              )
+                            : null,
+                        onTap: () {
+                          notifier.value = value;
+                          setting.save();
+                          Navigator.pop(context);
+                        },
+                      );
+                    },
+                  ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  String _dsdModeLabel(UsbDsdMode mode) {
+    return switch (mode) {
+      UsbDsdMode.pcm => 'PCM',
+      UsbDsdMode.dop => 'DoP',
+      UsbDsdMode.native => 'Native',
+    };
+  }
+
+  String _dsdModeHint(UsbDsdMode mode) {
+    return switch (mode) {
+      UsbDsdMode.pcm => '将 DSD 转换为 PCM 输出',
+      UsbDsdMode.dop => '以 PCM 帧封装 DSD，设备支持时使用',
+      UsbDsdMode.native => '保留 Native DSD 策略，需底层链路支持',
+    };
+  }
+
+  String _volumeLockLabel(UsbVolumeLockMode mode) {
+    return switch (mode) {
+      UsbVolumeLockMode.off => '关闭',
+      UsbVolumeLockMode.dsdOnly => '只锁 DSD 音量',
+      UsbVolumeLockMode.always => '始终锁定',
+    };
+  }
+
+  String _busSpeedLabel(UsbBusSpeedMode mode) {
+    return switch (mode) {
+      UsbBusSpeedMode.auto => '自动',
+      UsbBusSpeedMode.full => 'Full',
+      UsbBusSpeedMode.high => 'High',
+      UsbBusSpeedMode.superSpeed => 'Super',
+    };
+  }
+
+  String _bitDepthModeLabel(UsbBitDepthMode mode) {
+    return switch (mode) {
+      UsbBitDepthMode.auto => '自动',
+      UsbBitDepthMode.pcm16 => '16 bits',
+      UsbBitDepthMode.pcm24 => '24 bits',
+      UsbBitDepthMode.pcm32 => '32 bits',
+    };
+  }
+}

--- a/lib/layer/audio_output_settings_layer.dart
+++ b/lib/layer/audio_output_settings_layer.dart
@@ -7,6 +7,7 @@ import 'package:sylvakru/base/services/usb_audio_preferences.dart';
 import 'package:sylvakru/base/services/usb_audio_service.dart';
 import 'package:sylvakru/base/utils/media_query.dart';
 import 'package:sylvakru/base/widgets/audio_output_panel.dart';
+import 'package:sylvakru/base/widgets/my_sheet.dart';
 import 'package:sylvakru/base/widgets/my_switch.dart';
 import 'package:sylvakru/landscape_view/title_bar.dart';
 import 'package:sylvakru/layer/layers_manager.dart';
@@ -863,45 +864,42 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
   }) {
     showModalBottomSheet<void>(
       context: context,
+      isScrollControlled: true,
+      useRootNavigator: true,
       backgroundColor: Colors.transparent,
       builder: (context) {
-        return Material(
-          color: menuColor.value,
-          borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
-          clipBehavior: Clip.antiAlias,
-          child: SafeArea(
-            child: ListView(
-              shrinkWrap: true,
-              padding: const EdgeInsets.fromLTRB(12, 10, 12, 18),
-              children: [
-                ListTile(
-                  title: Text(
-                    title,
-                    style: const TextStyle(fontWeight: FontWeight.w800),
-                  ),
+        return MySheet(
+          ListView(
+            shrinkWrap: true,
+            padding: const EdgeInsets.fromLTRB(12, 10, 12, 18),
+            children: [
+              ListTile(
+                title: Text(
+                  title,
+                  style: const TextStyle(fontWeight: FontWeight.w800),
                 ),
-                for (final value in values)
-                  ValueListenableBuilder<T>(
-                    valueListenable: notifier,
-                    builder: (context, currentValue, _) {
-                      return ListTile(
-                        title: Text(label(value)),
-                        trailing: currentValue == value
-                            ? Icon(
-                                Icons.check_rounded,
-                                color: highlightTextColor.value,
-                              )
-                            : null,
-                        onTap: () {
-                          notifier.value = value;
-                          setting.save();
-                          Navigator.pop(context);
-                        },
-                      );
-                    },
-                  ),
-              ],
-            ),
+              ),
+              for (final value in values)
+                ValueListenableBuilder<T>(
+                  valueListenable: notifier,
+                  builder: (context, currentValue, _) {
+                    return ListTile(
+                      title: Text(label(value)),
+                      trailing: currentValue == value
+                          ? Icon(
+                              Icons.check_rounded,
+                              color: highlightTextColor.value,
+                            )
+                          : null,
+                      onTap: () {
+                        notifier.value = value;
+                        setting.save();
+                        Navigator.pop(context);
+                      },
+                    );
+                  },
+                ),
+            ],
           ),
         );
       },
@@ -1084,11 +1082,11 @@ UsbAudioDevice? _activeUsbDevice(UsbAudioStatus status) {
 String _shortOutputName(UsbAudioStatus status) {
   final exclusive = usbExclusivePlaybackStateNotifier.value;
   if (exclusive.active) {
-    return 'USB 真独占';
+    return 'USB';
   }
 
   if (!status.supported) {
-    return status.outputDeviceName ?? 'Android';
+    return formatOutputDeviceName(status);
   }
   final device = _activeUsbDevice(status);
   if (device != null) return device.name;

--- a/lib/layer/audio_output_settings_layer.dart
+++ b/lib/layer/audio_output_settings_layer.dart
@@ -3,6 +3,7 @@ import 'package:sylvakru/base/app.dart';
 import 'package:sylvakru/base/data/setting.dart';
 import 'package:sylvakru/base/services/color_manager.dart';
 import 'package:sylvakru/base/services/usb_audio_preferences.dart';
+import 'package:sylvakru/base/services/usb_audio_service.dart';
 import 'package:sylvakru/base/widgets/audio_output_panel.dart';
 import 'package:sylvakru/base/widgets/my_switch.dart';
 import 'package:sylvakru/base/utils/media_query.dart';
@@ -27,6 +28,9 @@ class AudioOutputSettingsLayer extends StatefulWidget {
 }
 
 class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
+  UsbExclusiveProbeResult? _exclusiveProbeResult;
+  bool _probingExclusive = false;
+
   @override
   Widget build(BuildContext context) {
     if (isTooNarrow(context)) {
@@ -100,6 +104,8 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
     final prefs = usbAudioPreferences;
     return Column(
       children: [
+        _exclusiveProbeCard(),
+        const SizedBox(height: 14),
         _section(
           children: [
             _tile(
@@ -186,6 +192,129 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
         ),
       ],
     );
+  }
+
+  Widget _exclusiveProbeCard() {
+    final result = _exclusiveProbeResult;
+    final status = result == null
+        ? '未检测'
+        : result.interfaceClaimed
+        ? '可 claim'
+        : result.permissionGranted
+        ? '不可 claim'
+        : '待授权';
+    final accent = result?.interfaceClaimed == true
+        ? const Color(0xFF50D890)
+        : const Color(0xFFFFA33A);
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: menuColor.value,
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(color: accent.withAlpha(90)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.usb_rounded, color: accent),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Text(
+                    '真独占可行性探针',
+                    style: TextStyle(
+                      color: textColor.value,
+                      fontSize: 17,
+                      fontWeight: FontWeight.w800,
+                    ),
+                  ),
+                ),
+                Text(status, style: TextStyle(color: accent)),
+              ],
+            ),
+            const SizedBox(height: 10),
+            Text(
+              '验证 App 是否能获取 USB 权限、识别 USB Audio Class，并短暂 claim 接口。这里不会接管播放，也不会占用 DAC。',
+              style: TextStyle(color: textColor.value.withAlpha(160)),
+            ),
+            if (result != null) ...[
+              const SizedBox(height: 12),
+              _probeLine('设备', result.deviceName ?? '未知'),
+              _probeLine('权限', result.permissionGranted ? '已授权' : '未授权'),
+              _probeLine('Audio Interface', '${result.audioInterfaceCount}'),
+              _probeLine('Claim 成功', '${result.claimedInterfaceCount}'),
+              _probeLine(
+                'Raw Descriptor',
+                '${result.rawDescriptorLength} bytes',
+              ),
+              if (result.message != null) _probeLine('结果', result.message!),
+            ],
+            const SizedBox(height: 14),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton.icon(
+                onPressed: _probingExclusive ? null : _runExclusiveProbe,
+                icon: _probingExclusive
+                    ? SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          color: textColor.value,
+                        ),
+                      )
+                    : const Icon(Icons.fact_check_rounded, size: 18),
+                label: Text(_probingExclusive ? '检测中' : '开始探针'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _probeLine(String label, String value) {
+    return Padding(
+      padding: const EdgeInsets.only(top: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 118,
+            child: Text(
+              label,
+              style: TextStyle(color: textColor.value.withAlpha(130)),
+            ),
+          ),
+          Expanded(
+            child: Text(
+              value,
+              style: TextStyle(
+                color: textColor.value.withAlpha(220),
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _runExclusiveProbe() async {
+    setState(() {
+      _probingExclusive = true;
+    });
+
+    final result = await usbAudioService.probeExclusiveAccess();
+    if (!mounted) return;
+
+    setState(() {
+      _exclusiveProbeResult = result;
+      _probingExclusive = false;
+    });
   }
 
   Widget _fixedSampleRate() {

--- a/lib/layer/audio_output_settings_layer.dart
+++ b/lib/layer/audio_output_settings_layer.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:sylvakru/base/app.dart';
+import 'package:sylvakru/base/audio_handler.dart';
 import 'package:sylvakru/base/data/setting.dart';
+import 'package:sylvakru/base/my_audio_metadata.dart';
 import 'package:sylvakru/base/services/color_manager.dart';
 import 'package:sylvakru/base/services/usb_audio_preferences.dart';
 import 'package:sylvakru/base/services/usb_audio_service.dart';
@@ -15,6 +17,54 @@ import 'package:sylvakru/layer/settings_layer.dart';
 import 'package:sylvakru/portrait_view/custom_appbar_leading.dart';
 
 enum AudioOutputSettingsPageKind { overview, fixedSampleRate, dsdMode }
+
+enum _TransportHealth { idle, paused, stable, low, underrun }
+
+_TransportHealth _transportHealth({
+  required bool active,
+  required bool playing,
+  required int levelMs,
+  required int? minimumMs,
+  required int targetMs,
+  required int underrunCount,
+}) {
+  if (!active) {
+    return _TransportHealth.idle;
+  }
+  if (!playing) {
+    return _TransportHealth.paused;
+  }
+  if (underrunCount > 0) {
+    return _TransportHealth.underrun;
+  }
+
+  final lowWatermark = (targetMs * 0.35).round().clamp(20, 250);
+  if (levelMs < lowWatermark ||
+      (minimumMs != null && minimumMs < lowWatermark)) {
+    return _TransportHealth.low;
+  }
+  return _TransportHealth.stable;
+}
+
+String _transportHealthLabel(_TransportHealth health) {
+  return switch (health) {
+    _TransportHealth.idle => '待机',
+    _TransportHealth.paused => '暂停',
+    _TransportHealth.stable => '稳定',
+    _TransportHealth.low => '偏低',
+    _TransportHealth.underrun => '欠载',
+  };
+}
+
+Color _transportHealthAccent(_TransportHealth health) {
+  return switch (health) {
+    _TransportHealth.stable => const Color(0xFF50D890),
+    _TransportHealth.low => const Color(0xFFFFB454),
+    _TransportHealth.underrun => const Color(0xFFFF6B6B),
+    _TransportHealth.idle ||
+    _TransportHealth.paused => highlightTextColor.value,
+  };
+}
 
 class AudioOutputSettingsLayer extends StatefulWidget {
   final AudioOutputSettingsPageKind pageKind;
@@ -115,33 +165,10 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
             const SizedBox(height: 12),
             _transportStatusCard(status),
             const SizedBox(height: 18),
-            _sectionTitle('后台稳定性'),
-            _settingsCard(
-              children: [
-                _noticeTile(
-                  icon: Icons.battery_alert_rounded,
-                  title: '建议关闭电池优化',
-                  subtitle: '否则后台播放或切到大型 App 时，USB 独占链路可能被系统暂停。',
-                  actionLabel: '打开设置',
-                  onTap: openAppSettings,
-                ),
-                _switchTile(
-                  title: 'USB 独占模式',
-                  subtitle: '连接 DAC 后启用独占提示与高优先级输出策略。',
-                  notifier: prefs.performanceModeNotifier,
-                ),
-                _switchTile(
-                  title: '保持后台活动',
-                  subtitle: '减少后台播放时 USB 输出被系统中断的概率。',
-                  notifier: prefs.keepAliveInBackgroundNotifier,
-                ),
-              ],
-            ),
-            const SizedBox(height: 18),
             _sectionTitle('输出格式'),
             _settingsCard(
               children: [
-                _infoTile('源文件', '等待播放', '采样率未知 · 声道未知 · 位深未知'),
+                _sourceFileTile(),
                 _infoTile(
                   'DAC 端点',
                   _dacEndpointLabel(status),
@@ -195,6 +222,29 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
               ],
             ),
             const SizedBox(height: 18),
+            _sectionTitle('后台稳定性'),
+            _settingsCard(
+              children: [
+                _noticeTile(
+                  icon: Icons.battery_alert_rounded,
+                  title: '建议关闭电池优化',
+                  subtitle: '否则后台播放或切到大型 App 时，USB 独占链路可能被系统暂停。',
+                  actionLabel: '打开设置',
+                  onTap: openAppSettings,
+                ),
+                _switchTile(
+                  title: 'USB 独占模式',
+                  subtitle: '连接 DAC 后启用独占提示与高优先级输出策略。',
+                  notifier: prefs.performanceModeNotifier,
+                ),
+                _switchTile(
+                  title: '保持后台活动',
+                  subtitle: '减少后台播放时 USB 输出被系统中断的概率。',
+                  notifier: prefs.keepAliveInBackgroundNotifier,
+                ),
+              ],
+            ),
+            const SizedBox(height: 18),
             _sectionTitle('传输缓冲'),
             _settingsCard(
               children: [
@@ -229,7 +279,7 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
                   title: 'DSD 增益补偿',
                   notifier: prefs.dsdGainCompensationNotifier,
                   values: const [-12, -9, -6, -3, 0, 3, 6],
-                  label: (value) => '${value} dB',
+                  label: (value) => '$value dB',
                 ),
                 _infoTile('当前媒体音量', '播放开始后检测', '硬件音量与 DAC 反馈可用后显示'),
                 _switchTile(
@@ -288,41 +338,158 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
   }
 
   Widget _deviceStatusCard(UsbAudioStatus status) {
-    final device = _activeUsbDevice(status);
-    final supported = status.supported;
-    final exclusive = usbExclusivePlaybackStateNotifier.value;
-    final accent = supported ? highlightTextColor.value : textColor.value;
-    final title = supported ? device?.name ?? 'USB DAC' : '未识别 USB 设备';
-    final subtitle = supported
-        ? _exclusiveStatusLabel(status)
-        : '连接 DAC 后显示设备信息';
-    final id = device == null ? '等待连接' : '${device.type} · ${device.id}';
+    return ValueListenableBuilder<UsbExclusivePlaybackState>(
+      valueListenable: usbExclusivePlaybackStateNotifier,
+      builder: (context, exclusive, _) {
+        final device = _activeUsbDevice(status);
+        final supported = status.supported;
+        final accent = supported ? const Color(0xFF50D890) : textColor.value;
+        final foreground = textColor.value;
+        final background = Color.alphaBlend(
+          accent.withAlpha(mainPageThemeNotifier.value == .dark ? 34 : 20),
+          menuColor.value,
+        );
+        final title = supported ? device?.name ?? 'USB DAC' : '未识别 USB 设备';
+        final subtitle = supported
+            ? _exclusiveStatusLabel(status)
+            : '连接 DAC 后显示设备信息';
+        final statusLabel = supported ? '已连接' : '未连接';
+        final linkLabel = supported
+            ? (exclusive.active ? '独占播放' : '运行中')
+            : '待连接';
+        final formatLabel = 'PCM ${formatOutputSampleRate(status)}'.replaceAll(
+          '未知',
+          '系统默认',
+        );
 
-    return _heroCard(
-      icon: Icons.usb_rounded,
-      accent: accent,
-      title: title,
-      subtitle: subtitle,
-      trailing: _refreshingStatus
-          ? const SizedBox(
-              width: 18,
-              height: 18,
-              child: CircularProgressIndicator(strokeWidth: 2),
-            )
-          : IconButton(
-              tooltip: '刷新 USB 状态',
-              onPressed: _refreshStatus,
-              icon: const Icon(Icons.refresh_rounded),
+        return DecoratedBox(
+          decoration: BoxDecoration(
+            color: background,
+            borderRadius: BorderRadius.circular(18),
+            border: Border.all(color: accent.withAlpha(70)),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 18),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Icon(Icons.usb_rounded, color: foreground.withAlpha(170)),
+                    const SizedBox(width: 10),
+                    Text(
+                      'USB EXCLUSIVE',
+                      style: TextStyle(
+                        color: foreground.withAlpha(150),
+                        fontSize: 13,
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                    const Spacer(),
+                    Container(
+                      width: 8,
+                      height: 8,
+                      decoration: BoxDecoration(
+                        color: supported ? accent : foreground.withAlpha(100),
+                        shape: BoxShape.circle,
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Text(
+                      statusLabel,
+                      style: TextStyle(
+                        color: foreground.withAlpha(165),
+                        fontSize: 13,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                    const SizedBox(width: 4),
+                    _refreshingStatus
+                        ? const SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : IconButton(
+                            tooltip: '刷新 USB 状态',
+                            onPressed: _refreshStatus,
+                            icon: const Icon(Icons.refresh_rounded),
+                          ),
+                  ],
+                ),
+                const SizedBox(height: 18),
+                Text(
+                  title,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: foreground,
+                    fontSize: 24,
+                    height: 1.05,
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  subtitle,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: foreground.withAlpha(150),
+                    fontSize: 14,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 22),
+                Row(
+                  children: [
+                    Container(
+                      width: 8,
+                      height: 8,
+                      decoration: BoxDecoration(
+                        color: supported ? accent : foreground.withAlpha(100),
+                        shape: BoxShape.circle,
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Text(
+                      'OUTPUT LINK',
+                      style: TextStyle(
+                        color: foreground.withAlpha(135),
+                        fontSize: 12,
+                        fontWeight: FontWeight.w900,
+                      ),
+                    ),
+                    const SizedBox(width: 14),
+                    Text(
+                      linkLabel,
+                      style: TextStyle(
+                        color: foreground.withAlpha(190),
+                        fontSize: 14,
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 22),
+                Row(
+                  children: [
+                    Expanded(child: _metricColumn('FORMAT', formatLabel)),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: _metricColumn('DEPTH', _compactDepthLabel(status)),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: _metricColumn('USB ID', _usbIdLabel(device)),
+                    ),
+                  ],
+                ),
+              ],
             ),
-      metrics: [
-        _Metric('输出链路', supported ? _outputPortLabel(status) : '未启用'),
-        _Metric('Format', _outputEncodingLabel(status)),
-        _Metric('Depth', _bitDepthLabel(status)),
-        _Metric('USB ID', id),
-      ],
-      footer: exclusive.active
-          ? '独占播放中 · ${formatSampleRate(exclusive.sampleRate)} · ${exclusive.bitDepth ?? '未知'} bits'
-          : '连接后可在这里确认 DAC 与独占链路状态',
+          ),
+        );
+      },
     );
   }
 
@@ -330,130 +497,156 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
     return ValueListenableBuilder<UsbExclusivePlaybackState>(
       valueListenable: usbExclusivePlaybackStateNotifier,
       builder: (context, exclusive, _) {
-        final active = exclusive.active;
-        final targetMs = usbAudioPreferences.foregroundBufferMsNotifier.value;
-        final levelMs = active ? exclusive.position.inMilliseconds : 0;
-        final clampedLevel = levelMs.clamp(0, targetMs);
-        final progress = targetMs <= 0 ? 0.0 : clampedLevel / targetMs;
-        final accent = active
-            ? const Color(0xFF50D890)
-            : highlightTextColor.value;
-        final foreground = textColor.value;
-        final background = Color.alphaBlend(
-          accent.withAlpha(mainPageThemeNotifier.value == .dark ? 36 : 24),
-          menuColor.value,
-        );
+        return ValueListenableBuilder<UsbTransportTelemetry>(
+          valueListenable: usbTransportTelemetryNotifier,
+          builder: (context, telemetry, _) {
+            final active = exclusive.active || telemetry.active;
+            final targetMs =
+                telemetry.targetBuffer?.inMilliseconds ??
+                usbAudioPreferences.foregroundBufferMsNotifier.value;
+            final levelMs = telemetry.active
+                ? telemetry.bufferLevel.inMilliseconds
+                : 0;
+            final minimumMs = telemetry.minimumBufferLevel?.inMilliseconds;
+            final clampedLevel = levelMs.clamp(0, targetMs);
+            final progress = targetMs <= 0 ? 0.0 : clampedLevel / targetMs;
+            final health = _transportHealth(
+              active: active,
+              playing: exclusive.playing,
+              levelMs: levelMs,
+              minimumMs: minimumMs,
+              targetMs: targetMs,
+              underrunCount: telemetry.underrunCount,
+            );
+            final accent = _transportHealthAccent(health);
+            final foreground = textColor.value;
+            final background = Color.alphaBlend(
+              accent.withAlpha(mainPageThemeNotifier.value == .dark ? 36 : 24),
+              menuColor.value,
+            );
 
-        return DecoratedBox(
-          decoration: BoxDecoration(
-            color: background,
-            borderRadius: BorderRadius.circular(16),
-            border: Border.all(color: accent.withAlpha(60)),
-          ),
-          child: Padding(
-            padding: const EdgeInsets.fromLTRB(16, 14, 16, 14),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                Row(
+            return DecoratedBox(
+              decoration: BoxDecoration(
+                color: background,
+                borderRadius: BorderRadius.circular(16),
+                border: Border.all(color: accent.withAlpha(60)),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(16, 14, 16, 14),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
                   children: [
-                    Expanded(
-                      child: Text(
-                        '传输状态',
-                        style: TextStyle(
-                          color: foreground,
-                          fontSize: 18,
-                          fontWeight: FontWeight.w800,
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            '传输状态',
+                            style: TextStyle(
+                              color: foreground,
+                              fontSize: 18,
+                              fontWeight: FontWeight.w800,
+                            ),
+                          ),
                         ),
-                      ),
-                    ),
-                    Text(
-                      active ? (exclusive.playing ? '稳定' : '暂停') : '待机',
-                      style: TextStyle(
-                        color: active ? accent : foreground.withAlpha(170),
-                        fontWeight: FontWeight.w800,
-                      ),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 18),
-                Row(
-                  crossAxisAlignment: CrossAxisAlignment.end,
-                  children: [
-                    Text(
-                      '$levelMs ms',
-                      style: TextStyle(
-                        color: foreground,
-                        fontSize: 34,
-                        height: 0.95,
-                        fontWeight: FontWeight.w900,
-                      ),
-                    ),
-                    const SizedBox(width: 10),
-                    Expanded(
-                      child: Padding(
-                        padding: const EdgeInsets.only(bottom: 3),
-                        child: Text(
-                          '缓冲区水位',
-                          maxLines: 1,
-                          overflow: TextOverflow.ellipsis,
+                        Text(
+                          _transportHealthLabel(health),
                           style: TextStyle(
-                            color: foreground.withAlpha(145),
-                            fontSize: 15,
+                            color: active ? accent : foreground.withAlpha(170),
+                            fontWeight: FontWeight.w800,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 18),
+                    Row(
+                      crossAxisAlignment: CrossAxisAlignment.end,
+                      children: [
+                        Flexible(
+                          flex: 4,
+                          child: FittedBox(
+                            fit: BoxFit.scaleDown,
+                            alignment: Alignment.bottomLeft,
+                            child: Text(
+                              '$levelMs ms',
+                              style: TextStyle(
+                                color: foreground,
+                                fontSize: 34,
+                                height: 0.95,
+                                fontWeight: FontWeight.w900,
+                              ),
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 10),
+                        Expanded(
+                          flex: 3,
+                          child: Padding(
+                            padding: const EdgeInsets.only(bottom: 3),
+                            child: Text(
+                              '缓冲区水位',
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: TextStyle(
+                                color: foreground.withAlpha(145),
+                                fontSize: 15,
+                                fontWeight: FontWeight.w700,
+                              ),
+                            ),
+                          ),
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.only(bottom: 3),
+                          child: Text(
+                            'ISO ${telemetry.active ? telemetry.isoPacketCount : 0}',
+                            style: TextStyle(
+                              color: foreground.withAlpha(175),
+                              fontSize: 16,
+                              fontWeight: FontWeight.w800,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 12),
+                    ClipRRect(
+                      borderRadius: BorderRadius.circular(999),
+                      child: LinearProgressIndicator(
+                        value: progress,
+                        minHeight: 8,
+                        backgroundColor: foreground.withAlpha(28),
+                        valueColor: AlwaysStoppedAnimation<Color>(accent),
+                      ),
+                    ),
+                    const SizedBox(height: 10),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            active ? '目标 $targetMs ms' : '播放时建立目标水位',
+                            style: TextStyle(
+                              color: foreground.withAlpha(135),
+                              fontSize: 12,
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                        ),
+                        Text(
+                          active && minimumMs != null
+                              ? '最低 $minimumMs ms'
+                              : '最低 --',
+                          style: TextStyle(
+                            color: foreground.withAlpha(135),
+                            fontSize: 12,
                             fontWeight: FontWeight.w700,
                           ),
                         ),
-                      ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.only(bottom: 3),
-                      child: Text(
-                        'ISO 0',
-                        style: TextStyle(
-                          color: foreground.withAlpha(175),
-                          fontSize: 16,
-                          fontWeight: FontWeight.w800,
-                        ),
-                      ),
+                      ],
                     ),
                   ],
                 ),
-                const SizedBox(height: 12),
-                ClipRRect(
-                  borderRadius: BorderRadius.circular(999),
-                  child: LinearProgressIndicator(
-                    value: progress,
-                    minHeight: 8,
-                    backgroundColor: foreground.withAlpha(28),
-                    valueColor: AlwaysStoppedAnimation<Color>(accent),
-                  ),
-                ),
-                const SizedBox(height: 10),
-                Row(
-                  children: [
-                    Expanded(
-                      child: Text(
-                        active ? '目标 $targetMs ms' : '播放时建立目标水位',
-                        style: TextStyle(
-                          color: foreground.withAlpha(135),
-                          fontSize: 12,
-                          fontWeight: FontWeight.w700,
-                        ),
-                      ),
-                    ),
-                    Text(
-                      active ? '最低 $levelMs ms' : '最低 --',
-                      style: TextStyle(
-                        color: foreground.withAlpha(135),
-                        fontSize: 12,
-                        fontWeight: FontWeight.w700,
-                      ),
-                    ),
-                  ],
-                ),
-              ],
-            ),
-          ),
+              ),
+            );
+          },
         );
       },
     );
@@ -537,90 +730,6 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
       notifier: notifier,
       values: UsbAudioPreferences.sampleRates,
       label: (value) => '${formatSampleRate(value)} PCM',
-    );
-  }
-
-  Widget _heroCard({
-    required IconData icon,
-    required Color accent,
-    required String title,
-    required String subtitle,
-    required List<_Metric> metrics,
-    required String footer,
-    Widget? trailing,
-    bool compact = false,
-  }) {
-    final foreground = textColor.value;
-    final background = Color.alphaBlend(
-      accent.withAlpha(mainPageThemeNotifier.value == .dark ? 38 : 24),
-      menuColor.value,
-    );
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: background,
-        borderRadius: BorderRadius.circular(18),
-        border: Border.all(color: accent.withAlpha(70)),
-      ),
-      child: Padding(
-        padding: EdgeInsets.all(compact ? 14 : 16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              children: [
-                _iconBox(icon, accent),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        title,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: TextStyle(
-                          color: foreground,
-                          fontSize: compact ? 17 : 20,
-                          fontWeight: FontWeight.w800,
-                        ),
-                      ),
-                      const SizedBox(height: 3),
-                      Text(
-                        subtitle,
-                        maxLines: 2,
-                        overflow: TextOverflow.ellipsis,
-                        style: TextStyle(
-                          color: foreground.withAlpha(150),
-                          fontSize: 12,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-                if (trailing != null) trailing,
-              ],
-            ),
-            const SizedBox(height: 14),
-            Wrap(
-              spacing: 10,
-              runSpacing: 10,
-              children: [
-                for (final metric in metrics)
-                  _metricPill(metric.label, metric.value, accent),
-              ],
-            ),
-            const SizedBox(height: 12),
-            Text(
-              footer,
-              style: TextStyle(
-                color: foreground.withAlpha(120),
-                fontSize: 12,
-                height: 1.35,
-              ),
-            ),
-          ],
-        ),
-      ),
     );
   }
 
@@ -712,6 +821,19 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
           ),
         ),
       ),
+    );
+  }
+
+  Widget _sourceFileTile() {
+    return ValueListenableBuilder<MyAudioMetadata?>(
+      valueListenable: currentSongNotifier,
+      builder: (context, song, _) {
+        return _infoTile(
+          '源文件',
+          _sourceFileTitle(song),
+          _sourceFileSubtitle(song),
+        );
+      },
     );
   }
 
@@ -920,39 +1042,32 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
     );
   }
 
-  Widget _metricPill(String label, String value, Color accent) {
-    return Container(
-      constraints: const BoxConstraints(minWidth: 110, maxWidth: 170),
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
-      decoration: BoxDecoration(
-        color: textColor.value.withAlpha(16),
-        borderRadius: BorderRadius.circular(12),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            label,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: TextStyle(
-              color: textColor.value.withAlpha(115),
-              fontSize: 11,
-              fontWeight: FontWeight.w700,
-            ),
+  Widget _metricColumn(String label, String value) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: TextStyle(
+            color: textColor.value.withAlpha(125),
+            fontSize: 11,
+            fontWeight: FontWeight.w900,
           ),
-          const SizedBox(height: 3),
-          Text(
-            value,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: TextStyle(
-              color: textColor.value.withAlpha(220),
-              fontWeight: FontWeight.w800,
-            ),
+        ),
+        const SizedBox(height: 6),
+        Text(
+          value,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: TextStyle(
+            color: textColor.value.withAlpha(215),
+            fontSize: 15,
+            fontWeight: FontWeight.w800,
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 
@@ -1020,6 +1135,35 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
     return '${_supportedRatesLabel(status)} · ${_bitDepthLabel(status)}';
   }
 
+  String _sourceFileTitle(MyAudioMetadata? song) {
+    if (song == null) return '等待播放';
+    return formatSourceFileName(song.path ?? song.cachePath);
+  }
+
+  String _sourceFileSubtitle(MyAudioMetadata? song) {
+    if (song == null) return '采样率未知 · 格式未知 · 码率未知';
+    final parts = [
+      formatSampleRate(song.samplerate),
+      if (song.format?.isNotEmpty == true)
+        song.format!.toUpperCase()
+      else
+        '格式未知',
+      formatBitrate(song.bitrate),
+    ];
+    return parts.join(' · ');
+  }
+
+  String _compactDepthLabel(UsbAudioStatus status) {
+    return _bitDepthLabel(status).replaceAll(' bits', '-bit');
+  }
+
+  String _usbIdLabel(UsbAudioDevice? device) {
+    if (device == null) return '等待连接';
+    final address = device.address;
+    if (address != null && address.isNotEmpty) return '$address · ${device.id}';
+    return '${device.type} · ${device.id}';
+  }
+
   String _dsdModeLabel(UsbDsdMode mode) {
     return switch (mode) {
       UsbDsdMode.pcm => 'PCM',
@@ -1063,13 +1207,6 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
   }
 }
 
-class _Metric {
-  final String label;
-  final String value;
-
-  const _Metric(this.label, this.value);
-}
-
 UsbAudioDevice? _activeUsbDevice(UsbAudioStatus status) {
   for (final device in status.devices) {
     if (device.id == status.bestAvailableDeviceId) {
@@ -1079,20 +1216,6 @@ UsbAudioDevice? _activeUsbDevice(UsbAudioStatus status) {
   return null;
 }
 
-String _shortOutputName(UsbAudioStatus status) {
-  final exclusive = usbExclusivePlaybackStateNotifier.value;
-  if (exclusive.active) {
-    return 'USB';
-  }
-
-  if (!status.supported) {
-    return formatOutputDeviceName(status);
-  }
-  final device = _activeUsbDevice(status);
-  if (device != null) return device.name;
-  return status.outputDeviceName ?? 'USB DAC';
-}
-
 String _supportedRatesLabel(UsbAudioStatus status) {
   final device = _activeUsbDevice(status);
   final rates = device?.supportedMixerSampleRates.isNotEmpty == true
@@ -1100,16 +1223,6 @@ String _supportedRatesLabel(UsbAudioStatus status) {
       : device?.sampleRates ?? const <int>[];
   if (rates.isEmpty) return '未知';
   return rates.map(formatSampleRate).join(' / ');
-}
-
-String _bitPerfectSupportLabel(UsbAudioStatus status) {
-  if (!status.supported) return '不可用';
-  if (status.androidSdk < 34) return '需要 Android 14+';
-  final device = _activeUsbDevice(status);
-  if (device?.supportsBitPerfectMixer == true) {
-    return status.preferredBitPerfect ? '已请求' : '可用';
-  }
-  return '设备未声明支持';
 }
 
 String _exclusiveStatusLabel(UsbAudioStatus status) {
@@ -1136,19 +1249,4 @@ String _bitDepthLabel(UsbAudioStatus status) {
   if (encoding == 'pcm_24bit_packed') return '24 bits';
   if (encoding == 'pcm_16bit') return '16 bits';
   return '未知';
-}
-
-String _outputEncodingLabel(UsbAudioStatus status) {
-  final encoding = status.preferredEncoding ?? status.outputEncoding;
-  if (encoding == null) return 'PCM / 系统默认';
-  final bitDepth = _bitDepthLabel(status);
-  return bitDepth == '未知' ? encoding : 'PCM / $bitDepth';
-}
-
-String _outputPortLabel(UsbAudioStatus status) {
-  if (!status.supported) {
-    return status.outputDeviceName ?? 'Android';
-  }
-  final name = _shortOutputName(status);
-  return status.preferredApplied ? '$name · 已应用偏好' : '$name · 系统输出';
 }

--- a/lib/layer/audio_output_settings_layer.dart
+++ b/lib/layer/audio_output_settings_layer.dart
@@ -1,6 +1,10 @@
 import 'dart:async';
+import 'dart:io';
 
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:path/path.dart' as p;
 import 'package:permission_handler/permission_handler.dart';
 import 'package:sylvakru/base/app.dart';
 import 'package:sylvakru/base/audio_handler.dart';
@@ -85,6 +89,7 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
   UsbExclusiveProbeResult? _exclusiveProbeResult;
   bool _probingExclusive = false;
   bool _refreshingStatus = false;
+  bool _generatingReport = false;
 
   @override
   Widget build(BuildContext context) {
@@ -324,11 +329,11 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
                   onTap: _probingExclusive ? null : _runExclusiveProbe,
                 ),
                 _actionTile(
-                  icon: Icons.feedback_rounded,
-                  title: 'USB 独占模式反馈',
-                  subtitle: '复制当前设备与输出链路信息，方便继续排查 DAC 兼容问题。',
-                  actionLabel: '查看状态',
-                  onTap: () => _showStatusSnack(status),
+                  icon: Icons.assignment_rounded,
+                  title: '生成诊断报告',
+                  subtitle: '汇总设备描述符、解析结果与最近日志，一键复制或导出发给开发者排查 DAC 兼容问题。',
+                  actionLabel: _generatingReport ? '生成中' : '生成报告',
+                  onTap: _generatingReport ? null : _generateDiagnosticsReport,
                 ),
               ],
             ),
@@ -1236,13 +1241,140 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
     });
   }
 
-  void _showStatusSnack(UsbAudioStatus status) {
-    final device = _activeUsbDevice(status);
-    final message = device == null
-        ? '当前未检测到 USB DAC。'
-        : 'USB DAC: ${device.name} · ${_supportedRatesLabel(status)} · ${_bitDepthLabel(status)}';
+  Future<void> _generateDiagnosticsReport() async {
+    setState(() {
+      _generatingReport = true;
+    });
+
+    String report;
+    try {
+      report = await usbAudioService.getDiagnosticsReport();
+    } catch (error) {
+      report = 'Sylvakru USB 诊断报告 v1\n\n生成失败: $error';
+    }
+
+    if (!mounted) return;
+    setState(() {
+      _generatingReport = false;
+    });
+    _showDiagnosticsReportSheet(report);
+  }
+
+  void _showDiagnosticsReportSheet(String report) {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      useRootNavigator: true,
+      builder: (sheetContext) {
+        return MySheet(
+          height: MediaQuery.heightOf(sheetContext) * 0.85,
+          Column(
+            children: [
+              const Padding(
+                padding: EdgeInsets.fromLTRB(16, 16, 16, 6),
+                child: Text(
+                  'USB 诊断报告',
+                  style: TextStyle(fontSize: 16, fontWeight: FontWeight.w700),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Text(
+                  '包含设备名称与 USB 描述符，不包含任何音乐文件内容；序列号已脱敏。',
+                  style: TextStyle(
+                    color: textColor.value.withAlpha(150),
+                    fontSize: 12,
+                  ),
+                ),
+              ),
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 12),
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      color: textColor.value.withAlpha(12),
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: SingleChildScrollView(
+                      padding: const EdgeInsets.all(12),
+                      child: SelectableText(
+                        report,
+                        style: const TextStyle(
+                          fontFamily: 'monospace',
+                          fontSize: 11,
+                          height: 1.4,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 0, 16, 20),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: OutlinedButton.icon(
+                        onPressed: () => _copyReport(report),
+                        icon: const Icon(Icons.copy_rounded, size: 18),
+                        label: const Text('复制到剪贴板'),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: FilledButton.icon(
+                        onPressed: () => _exportReport(report),
+                        icon: const Icon(Icons.save_alt_rounded, size: 18),
+                        label: const Text('导出为文件'),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Future<void> _copyReport(String report) async {
+    await Clipboard.setData(ClipboardData(text: report));
+    if (!mounted) return;
     ScaffoldMessenger.maybeOf(context)?.showSnackBar(
-      SnackBar(content: Text(message), behavior: SnackBarBehavior.floating),
+      const SnackBar(
+        content: Text('已复制，可直接粘贴反馈'),
+        behavior: SnackBarBehavior.floating,
+      ),
+    );
+  }
+
+  Future<void> _exportReport(String report) async {
+    String two(int n) => n.toString().padLeft(2, '0');
+    final now = DateTime.now();
+    final timestamp =
+        '${now.year}${two(now.month)}${two(now.day)}_'
+        '${two(now.hour)}${two(now.minute)}${two(now.second)}';
+    final fileName = 'usb_diag_$timestamp.txt';
+
+    String directory;
+    if (Platform.isAndroid) {
+      final picked = await FilePicker.getDirectoryPath();
+      if (picked == null) return;
+      directory = picked;
+    } else {
+      directory = '${appDocsDir.path}/logs';
+      Directory(directory).createSync(recursive: true);
+    }
+
+    final file = File(p.join(directory, fileName));
+    file.writeAsStringSync(report);
+    if (!mounted) return;
+    ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+      SnackBar(
+        content: Text('已导出到 ${file.path}'),
+        behavior: SnackBarBehavior.floating,
+      ),
     );
   }
 
@@ -1332,15 +1464,6 @@ UsbAudioDevice? _activeUsbDevice(UsbAudioStatus status) {
     }
   }
   return null;
-}
-
-String _supportedRatesLabel(UsbAudioStatus status) {
-  final device = _activeUsbDevice(status);
-  final rates = device?.supportedMixerSampleRates.isNotEmpty == true
-      ? device!.supportedMixerSampleRates
-      : device?.sampleRates ?? const <int>[];
-  if (rates.isEmpty) return '未知';
-  return rates.map(formatSampleRate).join(' / ');
 }
 
 String _bitDepthLabel(UsbAudioStatus status) {

--- a/lib/layer/layers_manager.dart
+++ b/lib/layer/layers_manager.dart
@@ -340,6 +340,7 @@ class LayersManager {
 
     final detailLayer = detailWidgetMap.remove(rootLayer);
     final parentLayer = parentWidgetMap.remove(detailLayer);
+    var revealVisibleNotifier = true;
 
     late GlobalKey<NavigatorState> rootKey;
     late ValueNotifier<bool> visibleNotifier;
@@ -358,17 +359,22 @@ class LayersManager {
     } else {
       rootKey = settingsKey;
       visibleNotifier = settingsVisibleNotifier;
-      if (detailLayer is LicenseLayer) {
+      if (parentLayer != null && parentLayer != rootLayer) {
         detailWidgetMap[rootLayer] = parentLayer;
+        revealVisibleNotifier = false;
+      }
+      if (detailLayer is LicenseLayer) {
         visibleNotifier = aboutVisibleNotifier;
+        revealVisibleNotifier = true;
       }
     }
 
-    await layersManager.updateBackground();
-
     rootKey.currentState?.pop();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      visibleNotifier.value = true;
+      if (revealVisibleNotifier) {
+        visibleNotifier.value = true;
+      }
+      updateBackground();
     });
 
     return true;

--- a/lib/layer/layers_manager.dart
+++ b/lib/layer/layers_manager.dart
@@ -38,6 +38,9 @@ import 'package:sylvakru/portrait_view/portrait_view.dart';
 final layersManager = LayersManager();
 MyAudioMetadata? backgroundSong;
 
+const double _backgroundBlurSigma = 16;
+const int _backgroundCoverCacheWidth = 160;
+
 class LayerInfo {
   MyAudioMetadata? backgroundSong;
   Color backgroundCoverArtColor;
@@ -84,9 +87,19 @@ class LayersManager {
             return ValueListenableBuilder(
               valueListenable: layerInfo.changeNotifier,
               builder: (context, value, child) {
-                return CoverArtWidget(
-                  song: layerInfo.backgroundSong,
-                  color: layerInfo.backgroundCoverArtColor,
+                return RepaintBoundary(
+                  child: ImageFiltered(
+                    imageFilter: ImageFilter.blur(
+                      sigmaX: _backgroundBlurSigma,
+                      sigmaY: _backgroundBlurSigma,
+                    ),
+                    child: CoverArtWidget(
+                      song: layerInfo.backgroundSong,
+                      color: layerInfo.backgroundCoverArtColor,
+                      cacheWidth: _backgroundCoverCacheWidth,
+                      filterQuality: FilterQuality.low,
+                    ),
+                  ),
                 );
               },
             );
@@ -99,19 +112,13 @@ class LayersManager {
               return SizedBox.shrink();
             }
 
-            // ClipRect is important
-            return ClipRect(
-              child: BackdropFilter(
-                filter: ImageFilter.blur(sigmaX: 30, sigmaY: 30),
-                child: ValueListenableBuilder(
-                  valueListenable: layerInfo.changeNotifier,
-                  builder: (context, value, child) {
-                    return Container(
-                      color: layerInfo.backgroundCoverArtColor.withAlpha(180),
-                    );
-                  },
-                ),
-              ),
+            return ValueListenableBuilder(
+              valueListenable: layerInfo.changeNotifier,
+              builder: (context, value, child) {
+                return Container(
+                  color: layerInfo.backgroundCoverArtColor.withAlpha(180),
+                );
+              },
             );
           },
         ),

--- a/lib/layer/layers_manager.dart
+++ b/lib/layer/layers_manager.dart
@@ -14,6 +14,7 @@ import 'package:sylvakru/base/widgets/cover_art_widget.dart';
 import 'package:sylvakru/base/data/history.dart';
 import 'package:sylvakru/landscape_view/sidebar.dart';
 import 'package:sylvakru/layer/about_layer.dart';
+import 'package:sylvakru/layer/audio_output_settings_layer.dart';
 import 'package:sylvakru/layer/albums_layer.dart';
 import 'package:sylvakru/layer/artists_layer.dart';
 import 'package:sylvakru/layer/folders_layer.dart';
@@ -245,6 +246,16 @@ class LayersManager {
       visibleNotifier = settingsVisibleNotifier;
       if (detail == 'about') {
         detailLayer = AboutLayer();
+      } else if (detail == 'audio_output') {
+        detailLayer = AudioOutputSettingsLayer();
+      } else if (detail == 'usb_fixed_sample_rate') {
+        detailLayer = AudioOutputSettingsLayer(
+          pageKind: AudioOutputSettingsPageKind.fixedSampleRate,
+        );
+      } else if (detail == 'usb_dsd_mode') {
+        detailLayer = AudioOutputSettingsLayer(
+          pageKind: AudioOutputSettingsPageKind.dsdMode,
+        );
       } else if (detail == 'license') {
         visibleNotifier = aboutVisibleNotifier;
         detailLayer = LicenseLayer();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:sylvakru/base/services/keyboard.dart';
 import 'package:sylvakru/base/services/my_tray_listener.dart';
 import 'package:sylvakru/base/services/my_window_listener.dart';
 import 'package:sylvakru/base/services/single_instance.dart';
+import 'package:sylvakru/base/widgets/usb_audio_event_listener.dart';
 import 'package:sylvakru/l10n/generated/app_localizations.dart';
 import 'package:sylvakru/l10n/generated/app_localizations_en.dart';
 import 'package:sylvakru/base/data/loader.dart';
@@ -137,11 +138,13 @@ Future<void> main() async {
       },
       child: Builder(
         builder: (context) {
-          return MediaQuery.removePadding(
-            context: context,
-            removeLeft: true, // for mobile
-            removeRight: true,
-            child: ViewEntry(),
+          return UsbAudioEventListener(
+            child: MediaQuery.removePadding(
+              context: context,
+              removeLeft: true, // for mobile
+              removeRight: true,
+              child: ViewEntry(),
+            ),
           );
         },
       ),

--- a/lib/portrait_view/pages/portrait_lyrics_page.dart
+++ b/lib/portrait_view/pages/portrait_lyrics_page.dart
@@ -7,6 +7,7 @@ import 'package:sylvakru/base/services/color_manager.dart';
 import 'package:sylvakru/base/app.dart';
 import 'package:sylvakru/base/asset_images.dart';
 import 'package:sylvakru/base/services/interaction.dart';
+import 'package:sylvakru/base/widgets/audio_output_panel.dart';
 import 'package:sylvakru/base/widgets/buttons.dart';
 import 'package:sylvakru/base/widgets/cover_art_widget.dart';
 import 'package:sylvakru/base/widgets/my_auto_size_text.dart';
@@ -23,6 +24,9 @@ import 'package:sylvakru/base/data/playlist.dart';
 import 'package:sylvakru/base/widgets/seekbar.dart';
 import 'package:sylvakru/base/utils/metadata_utils.dart';
 import 'package:smooth_corner/smooth_corner.dart';
+
+const double _backgroundBlurSigma = 16;
+const int _backgroundCoverCacheWidth = 160;
 
 class PortraitLyricsPage extends StatefulWidget {
   const PortraitLyricsPage({super.key});
@@ -88,27 +92,37 @@ class _PortraitLyricsPageState extends State<PortraitLyricsPage> {
                 dragOffset > 0 ? screenRadius?.topLeft ?? 0 : 0,
               ),
             ),
-            clipBehavior: .antiAliasWithSaveLayer,
+            clipBehavior: .antiAlias,
             child: Stack(
               fit: StackFit.expand,
               children: [
                 if (lyricsPageThemeNotifier.value == .vivid) ...[
-                  CoverArtWidget(
-                    song: currentSong,
-                    color: colorManager
-                        .getSpecificLyricsPageCoverArtBaseColor(),
-                  ),
-                  BackdropFilter(
-                    filter: ImageFilter.blur(sigmaX: 30, sigmaY: 30),
-                    child: AnimatedContainer(
-                      duration: Duration(milliseconds: 300),
-                      curve: Curves.easeInOutCubic,
-                      color: currentCoverArtColor.withAlpha(180),
+                  RepaintBoundary(
+                    child: ImageFiltered(
+                      imageFilter: ImageFilter.blur(
+                        sigmaX: _backgroundBlurSigma,
+                        sigmaY: _backgroundBlurSigma,
+                      ),
+                      child: CoverArtWidget(
+                        song: currentSong,
+                        color: colorManager
+                            .getSpecificLyricsPageCoverArtBaseColor(),
+                        cacheWidth: _backgroundCoverCacheWidth,
+                        filterQuality: FilterQuality.low,
+                      ),
                     ),
                   ),
+                  AnimatedContainer(
+                    duration: Duration(milliseconds: 300),
+                    curve: Curves.easeInOutCubic,
+                    color: currentCoverArtColor.withAlpha(180),
+                  ),
                 ],
-                Container(
-                  color: lyricsPageBackgroundColor.value,
+                ValueListenableBuilder(
+                  valueListenable: lyricsPageBackgroundColor.valueNotifier,
+                  builder: (context, value, child) {
+                    return Container(color: value, child: child);
+                  },
                   child: Column(
                     children: [
                       SizedBox(height: 50),
@@ -121,31 +135,40 @@ class _PortraitLyricsPageState extends State<PortraitLyricsPage> {
                                 SizedBox(
                                   height: 36,
                                   child: Center(
-                                    child: MyAutoSizeText(
-                                      key: UniqueKey(),
-                                      getTitle(currentSong),
-                                      maxLines: 1,
-                                      textStyle: TextStyle(
-                                        fontWeight: FontWeight.bold,
-                                        fontSize: 20,
-                                        color:
-                                            lyricsPageHighlightTextColor.value,
-                                      ),
+                                    child: ValueListenableBuilder(
+                                      valueListenable:
+                                          lyricsPageHighlightTextColor
+                                              .valueNotifier,
+                                      builder: (context, value, child) {
+                                        return MyAutoSizeText(
+                                          getTitle(currentSong),
+                                          maxLines: 1,
+                                          textStyle: TextStyle(
+                                            fontWeight: FontWeight.bold,
+                                            fontSize: 20,
+                                            color: value,
+                                          ),
+                                        );
+                                      },
                                     ),
                                   ),
                                 ),
-
                                 SizedBox(
                                   height: 28,
                                   child: Center(
-                                    child: MyAutoSizeText(
-                                      key: UniqueKey(),
-                                      '${getArtist(currentSong)} - ${getAlbum(currentSong)}',
-                                      maxLines: 1,
-                                      textStyle: TextStyle(
-                                        fontSize: 14,
-                                        color: lyricsPageForegroundColor.value,
-                                      ),
+                                    child: ValueListenableBuilder(
+                                      valueListenable: lyricsPageForegroundColor
+                                          .valueNotifier,
+                                      builder: (context, value, child) {
+                                        return MyAutoSizeText(
+                                          '${getArtist(currentSong)} - ${getAlbum(currentSong)}',
+                                          maxLines: 1,
+                                          textStyle: TextStyle(
+                                            fontSize: 14,
+                                            color: value,
+                                          ),
+                                        );
+                                      },
                                     ),
                                   ),
                                 ),
@@ -156,7 +179,6 @@ class _PortraitLyricsPageState extends State<PortraitLyricsPage> {
                         ],
                       ),
                       SizedBox(height: 10),
-
                       Expanded(
                         child: PageView(
                           children: [
@@ -223,6 +245,16 @@ class _PortraitLyricsPageState extends State<PortraitLyricsPage> {
                       isKaraoke: currentSong.parsedLyrics!.isKaraoke,
                     ),
             ),
+          ),
+        ),
+
+        Padding(
+          padding: const EdgeInsets.fromLTRB(34, 0, 34, 12),
+          child: ValueListenableBuilder(
+            valueListenable: lyricsPageForegroundColor.valueNotifier,
+            builder: (context, value, child) {
+              return AudioOutputChip(song: currentSong, color: value);
+            },
           ),
         ),
 

--- a/sylvakru_performance_optimization.md
+++ b/sylvakru_performance_optimization.md
@@ -1,0 +1,459 @@
+# Sylvakru v3.1.1 页面切换掉帧 / GPU 占用过高优化建议
+
+## 1. 问题概述
+
+在 Android 高刷新率设备上，例如骁龙 8 至尊平台，Sylvakru v3.1.1 在页面切换、进入播放页、切换详情页时出现明显掉帧。录屏观察中，静止首页可以接近 120 FPS，但页面切换期间帧率会明显下降，同时 GPU 占用接近打满。
+
+初步判断：这不是 CPU 性能不足，也不是单纯 Flutter 无法胜任，而是当前 UI 实现中存在多处高 GPU 成本操作叠加：
+
+- 全屏 `BackdropFilter + ImageFilter.blur(sigmaX: 30, sigmaY: 30)`
+- 全屏或大面积透明层合成
+- `Clip.antiAliasWithSaveLayer`
+- 页面切换时非 opaque route 叠加
+- Hero 封面动画、阴影、圆角裁剪同时参与合成
+- vivid 主题下背景封面与模糊层在多个页面重复存在
+
+这些组合在 60Hz 下可能只是轻微卡顿，但在 120Hz 下每帧预算只有约 8.33ms，非常容易让 Raster/GPU 线程超时。
+
+---
+
+## 2. 重点风险点
+
+### 2.1 播放页使用全屏 BackdropFilter
+
+`lib/portrait_view/pages/portrait_lyrics_page.dart`
+
+当前结构大致为：
+
+```dart
+if (lyricsPageThemeNotifier.value == .vivid) ...[
+  CoverArtWidget(
+    song: currentSong,
+    color: colorManager.getSpecificLyricsPageCoverArtBaseColor(),
+  ),
+  BackdropFilter(
+    filter: ImageFilter.blur(sigmaX: 30, sigmaY: 30),
+    child: AnimatedContainer(
+      duration: Duration(milliseconds: 300),
+      curve: Curves.easeInOutCubic,
+      color: currentCoverArtColor.withAlpha(180),
+    ),
+  ),
+],
+```
+
+问题：
+
+- `BackdropFilter` 会对其后方已经绘制的内容进行滤镜处理。
+- `sigma 30` 对移动端全屏实时模糊来说非常重。
+- 页面切换过程中，背景、裁剪区域、透明层、Hero 动画都在变化，难以有效缓存。
+- 如果这个页面还叠加在非 opaque route 上，GPU 需要同时处理上下层页面。
+
+### 2.2 首页 / layer 页面也使用全屏 BackdropFilter
+
+`lib/layer/layers_manager.dart`
+
+当前结构大致为：
+
+```dart
+CoverArtWidget(
+  song: layerInfo.backgroundSong,
+  color: layerInfo.backgroundCoverArtColor,
+);
+
+ClipRect(
+  child: BackdropFilter(
+    filter: ImageFilter.blur(sigmaX: 30, sigmaY: 30),
+    child: Container(
+      color: layerInfo.backgroundCoverArtColor.withAlpha(180),
+    ),
+  ),
+);
+```
+
+问题：
+
+- 首页和播放页都使用类似的全屏封面模糊背景。
+- 页面切换时，旧页面和新页面可能同时存在，从而出现双层甚至多层全屏 blur。
+- vivid 主题下该问题尤其明显。
+
+### 2.3 播放页根节点使用 antiAliasWithSaveLayer
+
+`lib/portrait_view/pages/portrait_lyrics_page.dart`
+
+当前结构中存在：
+
+```dart
+Material(
+  color: Colors.transparent,
+  shape: SmoothRectangleBorder(...),
+  clipBehavior: .antiAliasWithSaveLayer,
+  child: Stack(...),
+)
+```
+
+问题：
+
+- `antiAliasWithSaveLayer` 会触发离屏缓冲区。
+- 离屏缓冲区再叠加 `BackdropFilter`、透明色、阴影、圆角裁剪，会显著增加 GPU 压力。
+- 如果只是为了圆角裁剪，大多数情况下不应使用 `saveLayer`。
+
+### 2.4 图片没有针对背景模糊做降采样
+
+`CoverArtWidget` 当前主要通过 `Image.file` 显示原图：
+
+```dart
+Image.file(
+  File(path),
+  width: size,
+  height: size,
+  fit: BoxFit.cover,
+)
+```
+
+如果用于背景模糊，原图清晰度并不重要。使用原图进行全屏模糊属于浪费。背景只需要低频色块和氛围感，应当使用低分辨率版本。
+
+---
+
+## 3. 优化目标
+
+建议优化目标：
+
+1. 页面切换期间尽量稳定 120 FPS。
+2. vivid 主题开启时 GPU 占用明显下降。
+3. 静态页面不牺牲主要视觉效果。
+4. 播放页进入 / 返回 / 详情页切换不再出现明显掉帧。
+5. 尽量减少全屏 `saveLayer`、全屏 `BackdropFilter` 和重复背景合成。
+
+---
+
+## 4. 优先级最高的修改
+
+### 4.1 将全屏 BackdropFilter 改为 ImageFiltered
+
+如果只是想“把封面图做成模糊背景”，不需要 `BackdropFilter`。  
+`BackdropFilter` 适合毛玻璃，也就是模糊背后已经绘制好的内容；但这里更像是模糊某一张封面图。
+
+建议改成：
+
+```dart
+if (lyricsPageThemeNotifier.value == .vivid) ...[
+  ImageFiltered(
+    imageFilter: ImageFilter.blur(sigmaX: 16, sigmaY: 16),
+    child: CoverArtWidget(
+      song: currentSong,
+      color: colorManager.getSpecificLyricsPageCoverArtBaseColor(),
+    ),
+  ),
+  AnimatedContainer(
+    duration: const Duration(milliseconds: 300),
+    curve: Curves.easeInOutCubic,
+    color: currentCoverArtColor.withAlpha(180),
+  ),
+],
+```
+
+优点：
+
+- 只模糊封面图本身，不需要读取和处理整个后方场景。
+- 合成成本明显低于 `BackdropFilter`。
+- 对当前视觉效果影响较小。
+- 更容易被 Flutter 缓存和复用。
+
+首页 / layer 页面同理：
+
+```dart
+ImageFiltered(
+  imageFilter: ImageFilter.blur(sigmaX: 16, sigmaY: 16),
+  child: CoverArtWidget(
+    song: layerInfo.backgroundSong,
+    color: layerInfo.backgroundCoverArtColor,
+  ),
+),
+Container(
+  color: layerInfo.backgroundCoverArtColor.withAlpha(180),
+),
+```
+
+### 4.2 降低 blur sigma
+
+当前 `sigmaX: 30, sigmaY: 30` 偏高。建议先测试以下档位：
+
+```dart
+sigmaX: 12,
+sigmaY: 12,
+```
+
+或：
+
+```dart
+sigmaX: 16,
+sigmaY: 16,
+```
+
+如果配合半透明遮罩，视觉上依然能保持足够的氛围感，但 GPU 成本会明显下降。
+
+推荐默认：
+
+```dart
+const double backgroundBlurSigma = 16;
+```
+
+并在设置里加入低 / 中 / 高三档：
+
+```dart
+enum BackgroundBlurQuality {
+  off,
+  low,    // sigma 8
+  medium, // sigma 16
+  high,   // sigma 24
+}
+```
+
+不建议默认使用 sigma 30。
+
+### 4.3 去掉 antiAliasWithSaveLayer
+
+把播放页根节点的：
+
+```dart
+clipBehavior: Clip.antiAliasWithSaveLayer,
+```
+
+改为：
+
+```dart
+clipBehavior: Clip.antiAlias,
+```
+
+如果视觉没有明显问题，应保留该修改。
+
+如果某些地方确实需要 `saveLayer`，建议缩小裁剪范围，只包裹真正需要特殊裁剪的局部组件，而不是整页。
+
+### 4.4 页面切换期间禁用或冻结背景模糊
+
+进入播放页 / 详情页动画期间，可以先显示静态背景或低成本背景，动画结束后再启用高质量模糊。
+
+示例：
+
+```dart
+final bool enableExpensiveEffects = !isPageTransitioning;
+
+ImageFiltered(
+  enabled: enableExpensiveEffects,
+  imageFilter: ImageFilter.blur(sigmaX: 16, sigmaY: 16),
+  child: CoverArtWidget(...),
+)
+```
+
+如果仍然卡顿，可以进一步处理：
+
+- 页面切换时只显示纯色动态取色背景。
+- 页面稳定后再淡入模糊封面。
+- 或提前生成一张静态模糊背景图，切换期间直接显示图片。
+
+---
+
+## 5. 中优先级优化
+
+### 5.1 为背景封面生成低分辨率缓存
+
+背景模糊不需要原图清晰度。可以生成一个低分辨率背景缓存，例如：
+
+- 64px / 96px / 128px 宽度
+- 根据封面路径和修改时间缓存
+- 切歌时异步生成
+- UI 层只显示缓存图并放大
+
+示例方向：
+
+```dart
+Image.file(
+  File(blurredBackgroundPath),
+  fit: BoxFit.cover,
+  filterQuality: FilterQuality.low,
+)
+```
+
+或者在 `Image.file` 中根据背景用途传入 `cacheWidth`：
+
+```dart
+Image.file(
+  File(path),
+  fit: BoxFit.cover,
+  cacheWidth: 160,
+  filterQuality: FilterQuality.low,
+)
+```
+
+注意：封面展示本体仍然可以使用高清图；只有背景图需要降采样。
+
+### 5.2 给背景层加 RepaintBoundary
+
+背景封面、遮罩层、歌词列表、播放控制区建议分离 repaint 边界，避免一个小控件变化导致整页重绘。
+
+示例：
+
+```dart
+RepaintBoundary(
+  child: _BlurredBackground(...),
+)
+```
+
+尤其是：
+
+- 背景层
+- 歌词列表
+- 播放控制按钮区域
+- 进度条区域
+
+这些区域的刷新频率不同，不应该互相拖累。
+
+### 5.3 避免不必要的 UniqueKey
+
+播放页标题和副标题中有：
+
+```dart
+MyAutoSizeText(
+  key: UniqueKey(),
+  ...
+)
+```
+
+`UniqueKey()` 会让 Flutter 每次 build 都认为这是一个全新的 widget，导致状态和布局缓存无法复用。建议改成稳定 key 或直接去掉 key。
+
+例如：
+
+```dart
+MyAutoSizeText(
+  getTitle(currentSong),
+  maxLines: 1,
+  ...
+)
+```
+
+或者：
+
+```dart
+key: ValueKey(currentSong?.id ?? currentSong?.path),
+```
+
+### 5.4 减少 ValueListenableBuilder 嵌套重建范围
+
+当前页面中多个 `ValueListenableBuilder` 直接包裹较大的 UI 结构。建议拆分成更小组件，让颜色变化、播放状态变化、歌词变化分别只刷新必要区域。
+
+例如播放按钮只监听播放状态，不应该带动整行控制区重建。
+
+---
+
+## 6. 推荐修改方案
+
+### 方案 A：低风险快速优化
+
+适合快速验证性能问题来源。
+
+修改点：
+
+1. 所有全屏 `BackdropFilter sigma 30` 改为 `ImageFiltered sigma 16`。
+2. `Clip.antiAliasWithSaveLayer` 改为 `Clip.antiAlias`。
+3. 背景封面图使用 `cacheWidth: 160` 或低分辨率缓存。
+4. 去掉标题和副标题的 `UniqueKey()`。
+
+预期效果：
+
+- 页面切换掉帧明显改善。
+- GPU 占用下降。
+- 视觉变化较小。
+- 改动范围较可控。
+
+### 方案 B：中等改造，体验更稳
+
+在方案 A 基础上增加：
+
+1. 页面切换期间禁用高成本 blur。
+2. 动画结束后再淡入模糊背景。
+3. 背景层、歌词层、控制层分离 `RepaintBoundary`。
+4. vivid 主题增加“性能模式”。
+
+预期效果：
+
+- 高刷新率设备上更容易稳定 120 FPS。
+- 中端设备也能获得明显收益。
+- 适合发布为正式性能优化版本。
+
+### 方案 C：彻底优化
+
+在方案 B 基础上增加：
+
+1. 异步预生成模糊背景图。
+2. 切歌时缓存背景图。
+3. 页面切换期间完全使用静态位图。
+4. 只在封面变化时重新生成背景，不在每帧实时滤镜。
+5. 根据设备性能自动选择 blur 档位。
+
+预期效果：
+
+- GPU 压力最低。
+- 页面切换最稳定。
+- 实现成本较高，但最适合音乐播放器长期维护。
+
+---
+
+## 7. 建议验证方式
+
+### 7.1 使用 Flutter Performance Overlay
+
+运行：
+
+```bash
+flutter run --profile --trace-skia
+```
+
+或至少使用 profile 包测试，不要用 debug 包判断性能。
+
+重点观察：
+
+- UI thread 是否稳定
+- Raster thread 是否超时
+- 页面切换期间 Raster 是否明显高于 8.33ms
+- vivid 主题开启 / 关闭的差异
+
+### 7.2 对比测试项
+
+建议分别测试以下组合：
+
+| 测试项 | 目的 |
+|---|---|
+| 关闭 vivid 主题 | 验证是否为背景模糊导致 |
+| 注释 BackdropFilter | 验证 blur 成本 |
+| sigma 30 改 16 | 验证 blur 强度影响 |
+| BackdropFilter 改 ImageFiltered | 验证滤镜类型影响 |
+| antiAliasWithSaveLayer 改 antiAlias | 验证 saveLayer 成本 |
+| 关闭 Hero / elevation | 验证动画合成成本 |
+| 背景图 cacheWidth 降采样 | 验证图片采样成本 |
+
+### 7.3 目标数据
+
+以 120Hz 设备为目标：
+
+- 页面静止：Raster 平均 < 4ms
+- 页面切换：Raster 尽量 < 8ms
+- 最差帧：尽量不要频繁超过 16ms
+- GPU 占用：页面切换时不应长期接近 100%
+
+---
+
+## 8. 结论
+
+当前掉帧的核心原因不是设备性能不足，而是 vivid 主题下 UI 合成成本过高。  
+尤其是全屏 `BackdropFilter sigma 30`、`antiAliasWithSaveLayer`、透明层、Hero 动画和页面切换叠加，导致 GPU/Raster 线程压力过大。
+
+最建议优先处理：
+
+1. `BackdropFilter` 改为 `ImageFiltered`
+2. `sigma 30` 降到 `12~16`
+3. 去掉整页 `antiAliasWithSaveLayer`
+4. 背景图降采样
+5. 页面切换期间冻结或降低背景特效
+
+这几项改完后，骁龙 8 至尊这类设备理论上不应该再出现明显页面切换掉帧。

--- a/test/audio_output_panel_test.dart
+++ b/test/audio_output_panel_test.dart
@@ -36,6 +36,25 @@ void main() {
     expect(formatOutputSampleRate(status), '48 kHz');
   });
 
+  test('formatOutputDeviceName shows speaker for system speaker output', () {
+    const status = UsbAudioStatus(
+      supported: false,
+      androidSdk: 35,
+      activeDeviceId: null,
+      preferredApplied: false,
+      preferredSampleRate: null,
+      preferredEncoding: null,
+      preferredBitPerfect: false,
+      outputDeviceName: '内置扬声器',
+      outputSampleRate: 48000,
+      outputEncoding: 'pcm_16bit',
+      message: null,
+      devices: [],
+    );
+
+    expect(formatOutputDeviceName(status), '扬声器');
+  });
+
   test('formatOutputDeviceName prefers connected USB device name', () {
     const status = UsbAudioStatus(
       supported: true,
@@ -67,9 +86,61 @@ void main() {
     expect(formatOutputDeviceName(status), 'iBasso Macaron');
   });
 
-  test('formatBitrate marks tiny metadata bitrate clearly', () {
-    expect(formatBitrate(3000), '约 3 kbps（源文件元数据）');
+  test('formatBitrate displays concrete value without source metadata note', () {
+    expect(formatBitrate(3000), '3 kbps');
     expect(formatBitrate(null), '未知');
+  });
+
+  test('formatSourceFileName strips directory and keeps only file name', () {
+    expect(
+      formatSourceFileName('/storage/emulated/0/Music/TOMOO - LUCKY.flac'),
+      'TOMOO - LUCKY.flac',
+    );
+    expect(formatSourceFileName(r'D:\Music\demo.wav'), 'demo.wav');
+    expect(formatSourceFileName(null), '未知');
+  });
+
+  test('formatOutputPortLabel removes true exclusive wording', () {
+    usbExclusivePlaybackStateNotifier.value = const UsbExclusivePlaybackState(
+      active: true,
+      playing: true,
+      position: Duration.zero,
+      duration: null,
+      sampleRate: 48000,
+      bitDepth: 24,
+      format: 'flac',
+      message: null,
+    );
+
+    const status = UsbAudioStatus(
+      supported: true,
+      androidSdk: 35,
+      activeDeviceId: 7,
+      preferredApplied: false,
+      preferredSampleRate: null,
+      preferredEncoding: null,
+      preferredBitPerfect: false,
+      outputDeviceName: 'USB-Audio - Macaron',
+      outputSampleRate: 48000,
+      outputEncoding: 'pcm_24bit_packed',
+      message: null,
+      devices: [
+        UsbAudioDevice(
+          id: 7,
+          name: 'USB-Audio - Macaron',
+          type: 'usb_device',
+          address: 'dac',
+          sampleRates: [48000],
+          encodings: ['pcm_24bit_packed'],
+          channelCounts: [2],
+          supportedMixerSampleRates: [48000],
+          supportsBitPerfectMixer: true,
+        ),
+      ],
+    );
+
+    expect(formatOutputPortLabel(status), 'USB · 系统输出');
+    expect(formatOutputPortLabel(status), isNot(contains('真独占')));
   });
 
   test('buildSampleRateOptions prefers USB supported mixer rates', () {

--- a/test/audio_output_panel_test.dart
+++ b/test/audio_output_panel_test.dart
@@ -6,6 +6,9 @@ import 'package:sylvakru/base/widgets/audio_output_panel.dart';
 void main() {
   tearDown(() {
     usbAudioPreferences.resetForTest();
+    usbAudioStatusNotifier.value = UsbAudioStatus.unavailable();
+    usbExclusivePlaybackStateNotifier.value =
+        UsbExclusivePlaybackState.inactive();
   });
 
   test('formatSampleRate displays source rate as kHz', () {
@@ -31,6 +34,42 @@ void main() {
     );
 
     expect(formatOutputSampleRate(status), '48 kHz');
+  });
+
+  test('formatOutputDeviceName prefers connected USB device name', () {
+    const status = UsbAudioStatus(
+      supported: true,
+      androidSdk: 35,
+      activeDeviceId: 7,
+      preferredApplied: true,
+      preferredSampleRate: 96000,
+      preferredEncoding: 'pcm_24bit_packed',
+      preferredBitPerfect: true,
+      outputDeviceName: 'Android USB output',
+      outputSampleRate: 96000,
+      outputEncoding: 'pcm_24bit_packed',
+      message: 'USB audio device detected.',
+      devices: [
+        UsbAudioDevice(
+          id: 7,
+          name: 'iBasso Macaron',
+          type: 'usb_device',
+          address: 'dac',
+          sampleRates: [44100, 48000, 96000],
+          encodings: ['pcm_16bit', 'pcm_24bit_packed'],
+          channelCounts: [2],
+          supportedMixerSampleRates: [48000, 96000],
+          supportsBitPerfectMixer: true,
+        ),
+      ],
+    );
+
+    expect(formatOutputDeviceName(status), 'iBasso Macaron');
+  });
+
+  test('formatBitrate marks tiny metadata bitrate clearly', () {
+    expect(formatBitrate(3000), '约 3 kbps（源文件元数据）');
+    expect(formatBitrate(null), '未知');
   });
 
   test('buildSampleRateOptions prefers USB supported mixer rates', () {

--- a/test/audio_output_panel_test.dart
+++ b/test/audio_output_panel_test.dart
@@ -1,12 +1,36 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:sylvakru/base/services/usb_audio_preferences.dart';
 import 'package:sylvakru/base/services/usb_audio_service.dart';
 import 'package:sylvakru/base/widgets/audio_output_panel.dart';
 
 void main() {
+  tearDown(() {
+    usbAudioPreferences.resetForTest();
+  });
+
   test('formatSampleRate displays source rate as kHz', () {
     expect(formatSampleRate(44100), '44.1 kHz');
     expect(formatSampleRate(96000), '96 kHz');
     expect(formatSampleRate(null), '未知');
+  });
+
+  test('formatOutputSampleRate falls back to Android system output rate', () {
+    const status = UsbAudioStatus(
+      supported: false,
+      androidSdk: 35,
+      activeDeviceId: null,
+      preferredApplied: false,
+      preferredSampleRate: null,
+      preferredEncoding: null,
+      preferredBitPerfect: false,
+      outputDeviceName: '内置扬声器',
+      outputSampleRate: 48000,
+      outputEncoding: 'pcm_16bit',
+      message: null,
+      devices: [],
+    );
+
+    expect(formatOutputSampleRate(status), '48 kHz');
   });
 
   test('buildSampleRateOptions prefers USB supported mixer rates', () {
@@ -18,6 +42,9 @@ void main() {
       preferredSampleRate: 96000,
       preferredEncoding: 'pcm_24bit_packed',
       preferredBitPerfect: true,
+      outputDeviceName: 'USB DAC',
+      outputSampleRate: 96000,
+      outputEncoding: 'pcm_24bit_packed',
       message: null,
       devices: [
         UsbAudioDevice(
@@ -41,5 +68,73 @@ void main() {
       192000,
       44100,
     ]);
+  });
+
+  test('exclusive sample rate prefers current song rate when supported', () {
+    const status = UsbAudioStatus(
+      supported: true,
+      androidSdk: 35,
+      activeDeviceId: 7,
+      preferredApplied: false,
+      preferredSampleRate: null,
+      preferredEncoding: null,
+      preferredBitPerfect: false,
+      outputDeviceName: 'USB DAC',
+      outputSampleRate: 48000,
+      outputEncoding: 'pcm_16bit',
+      message: null,
+      devices: [
+        UsbAudioDevice(
+          id: 7,
+          name: 'USB DAC',
+          type: 'usb_device',
+          address: 'dac',
+          sampleRates: [48000, 96000],
+          encodings: ['pcm_16bit'],
+          channelCounts: [2],
+          supportedMixerSampleRates: [44100, 48000, 96000],
+          supportsBitPerfectMixer: true,
+        ),
+      ],
+    );
+
+    expect(preferredExclusiveSampleRate(status, 44100), 44100);
+    expect(preferredExclusiveSampleRate(status, 88200), 96000);
+  });
+
+  test('exclusive sample rate prefers configured fixed rate', () {
+    usbAudioPreferences.load({
+      'usbFixedSampleRateEnabled': true,
+      'usbFixedSampleRate': 192000,
+    });
+
+    const status = UsbAudioStatus(
+      supported: true,
+      androidSdk: 35,
+      activeDeviceId: 7,
+      preferredApplied: false,
+      preferredSampleRate: null,
+      preferredEncoding: null,
+      preferredBitPerfect: false,
+      outputDeviceName: 'USB DAC',
+      outputSampleRate: 48000,
+      outputEncoding: 'pcm_16bit',
+      message: null,
+      devices: [
+        UsbAudioDevice(
+          id: 7,
+          name: 'USB DAC',
+          type: 'usb_device',
+          address: 'dac',
+          sampleRates: [44100, 48000, 96000],
+          encodings: ['pcm_16bit'],
+          channelCounts: [2],
+          supportedMixerSampleRates: [44100, 48000, 96000, 192000],
+          supportsBitPerfectMixer: true,
+        ),
+      ],
+    );
+
+    expect(preferredExclusiveSampleRate(status, 44100), 192000);
   });
 }

--- a/test/audio_output_panel_test.dart
+++ b/test/audio_output_panel_test.dart
@@ -86,10 +86,14 @@ void main() {
     expect(formatOutputDeviceName(status), 'iBasso Macaron');
   });
 
-  test('formatBitrate displays concrete value without source metadata note', () {
-    expect(formatBitrate(3000), '3 kbps');
-    expect(formatBitrate(null), '未知');
-  });
+  test(
+    'formatBitrate displays concrete value without source metadata note',
+    () {
+      expect(formatBitrate(3489), '3489 kbps');
+      expect(formatBitrate(822000), '822 kbps');
+      expect(formatBitrate(null), '未知');
+    },
+  );
 
   test('formatSourceFileName strips directory and keeps only file name', () {
     expect(
@@ -139,8 +143,9 @@ void main() {
       ],
     );
 
-    expect(formatOutputPortLabel(status), 'USB · 系统输出');
+    expect(formatOutputPortLabel(status), 'USB 独占');
     expect(formatOutputPortLabel(status), isNot(contains('真独占')));
+    expect(formatOutputPortLabel(status), isNot(contains('系统输出')));
   });
 
   test('buildSampleRateOptions prefers USB supported mixer rates', () {

--- a/test/audio_output_panel_test.dart
+++ b/test/audio_output_panel_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sylvakru/base/services/usb_audio_service.dart';
+import 'package:sylvakru/base/widgets/audio_output_panel.dart';
+
+void main() {
+  test('formatSampleRate displays source rate as kHz', () {
+    expect(formatSampleRate(44100), '44.1 kHz');
+    expect(formatSampleRate(96000), '96 kHz');
+    expect(formatSampleRate(null), '未知');
+  });
+
+  test('buildSampleRateOptions prefers USB supported mixer rates', () {
+    const status = UsbAudioStatus(
+      supported: true,
+      androidSdk: 35,
+      activeDeviceId: 7,
+      preferredApplied: true,
+      preferredSampleRate: 96000,
+      preferredEncoding: 'pcm_24bit_packed',
+      preferredBitPerfect: true,
+      message: null,
+      devices: [
+        UsbAudioDevice(
+          id: 7,
+          name: 'USB DAC',
+          type: 'usb_device',
+          address: 'dac',
+          sampleRates: [44100, 48000],
+          encodings: ['pcm_16bit'],
+          channelCounts: [2],
+          supportedMixerSampleRates: [48000, 96000, 192000],
+          supportsBitPerfectMixer: true,
+        ),
+      ],
+    );
+
+    expect(buildSampleRateOptions(status, 44100), [
+      null,
+      48000,
+      96000,
+      192000,
+      44100,
+    ]);
+  });
+}

--- a/test/audio_output_settings_layer_test.dart
+++ b/test/audio_output_settings_layer_test.dart
@@ -234,6 +234,42 @@ void main() {
     });
 
     usbAudioPreferences.load(const {});
+    usbAudioStatusNotifier.value = const UsbAudioStatus(
+      supported: true,
+      androidSdk: 35,
+      activeDeviceId: 7,
+      preferredApplied: false,
+      preferredSampleRate: null,
+      preferredEncoding: 'pcm_24bit_packed',
+      preferredBitPerfect: false,
+      outputDeviceName: 'USB-Audio - Macaron',
+      outputSampleRate: 44100,
+      outputEncoding: 'pcm_24bit_packed',
+      message: null,
+      devices: [
+        UsbAudioDevice(
+          id: 7,
+          name: 'USB-Audio - Macaron',
+          type: 'usb_headset',
+          address: 'usb_headset',
+          sampleRates: [44100, 48000],
+          encodings: ['pcm_16bit', 'pcm_24bit_packed'],
+          channelCounts: [2],
+          supportedMixerSampleRates: [44100, 48000],
+          supportsBitPerfectMixer: false,
+        ),
+      ],
+    );
+    usbExclusivePlaybackStateNotifier.value = const UsbExclusivePlaybackState(
+      active: true,
+      playing: true,
+      position: Duration.zero,
+      duration: Duration(minutes: 3),
+      sampleRate: 44100,
+      bitDepth: 24,
+      format: 'FLAC',
+      message: null,
+    );
     currentSongNotifier.value = MyAudioMetadata(
       AudioMetadata(
         format: 'FLAC',
@@ -250,8 +286,13 @@ void main() {
     );
 
     expect(find.text('源文件'), findsOneWidget);
-    expect(find.text('TOMOO - LUCKY.flac'), findsOneWidget);
-    expect(find.text('44.1 kHz · FLAC · 822 kbps'), findsOneWidget);
+    expect(find.text('TOMOO - LUCKY.flac'), findsNothing);
+    expect(find.text('FLAC'), findsOneWidget);
+    expect(find.text('44.1 kHz'), findsWidgets);
+    expect(find.text('2 ch'), findsWidgets);
+    expect(find.text('24-bit'), findsWidgets);
+    expect(find.text('PCM'), findsOneWidget);
+    expect(find.text('44.1 kHz · FLAC · 822 kbps'), findsNothing);
     expect(find.text('等待播放'), findsNothing);
   });
 
@@ -302,6 +343,7 @@ void main() {
     expect(find.text('FORMAT'), findsOneWidget);
     expect(find.text('DEPTH'), findsOneWidget);
     expect(find.text('USB ID'), findsOneWidget);
+    expect(find.text('已连接 USB DAC，但未确认支持独占'), findsNothing);
   });
 
   testWidgets('后台稳定性移动到输出格式之后', (tester) async {
@@ -322,5 +364,56 @@ void main() {
     final stabilityTop = tester.getTopLeft(find.text('后台稳定性')).dy;
 
     expect(stabilityTop, greaterThan(outputTop));
+  });
+
+  testWidgets('媒体音量显示真实播放器音量', (tester) async {
+    tester.view.physicalSize = const Size(390, 1200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    usbAudioPreferences.load(const {});
+    volumeNotifier.value = 0.42;
+
+    await tester.pumpWidget(
+      const MaterialApp(home: AudioOutputSettingsLayer()),
+    );
+
+    expect(find.text('42%'), findsOneWidget);
+    expect(find.text('播放开始后检测'), findsNothing);
+  });
+
+  testWidgets('调整前台缓冲区后传输目标实时刷新', (tester) async {
+    tester.view.physicalSize = const Size(390, 1200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    usbAudioPreferences.load(const {});
+    usbExclusivePlaybackStateNotifier.value = const UsbExclusivePlaybackState(
+      active: true,
+      playing: true,
+      position: Duration.zero,
+      duration: Duration(minutes: 3),
+      sampleRate: 96000,
+      bitDepth: 24,
+      format: 'PCM',
+      message: null,
+    );
+    usbTransportTelemetryNotifier.value = UsbTransportTelemetry.inactive();
+
+    await tester.pumpWidget(
+      const MaterialApp(home: AudioOutputSettingsLayer()),
+    );
+
+    usbAudioPreferences.foregroundBufferMsNotifier.value = 350;
+    await tester.pump();
+
+    expect(find.text('350 ms'), findsWidgets);
+    expect(find.text('目标 350 ms'), findsOneWidget);
   });
 }

--- a/test/audio_output_settings_layer_test.dart
+++ b/test/audio_output_settings_layer_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sylvakru/base/services/usb_audio_preferences.dart';
+import 'package:sylvakru/base/services/usb_audio_service.dart';
+import 'package:sylvakru/layer/audio_output_settings_layer.dart';
+
+void main() {
+  tearDown(() {
+    usbAudioPreferences.resetForTest();
+    usbAudioStatusNotifier.value = UsbAudioStatus.unavailable();
+    usbExclusivePlaybackStateNotifier.value =
+        UsbExclusivePlaybackState.inactive();
+  });
+
+  testWidgets('传输状态卡使用水位表达且隐藏采样率和缓冲设置值', (tester) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    usbAudioPreferences.load(const {});
+    usbAudioStatusNotifier.value = const UsbAudioStatus(
+      supported: true,
+      androidSdk: 35,
+      activeDeviceId: 7,
+      preferredApplied: true,
+      preferredSampleRate: 96000,
+      preferredEncoding: 'pcm_24bit_packed',
+      preferredBitPerfect: true,
+      outputDeviceName: 'Macaron',
+      outputSampleRate: 96000,
+      outputEncoding: 'pcm_24bit_packed',
+      message: null,
+      devices: [
+        UsbAudioDevice(
+          id: 7,
+          name: 'Macaron',
+          type: 'usb_headset',
+          address: '/dev/bus/usb/001/002',
+          sampleRates: [48000, 96000],
+          encodings: ['pcm_16bit', 'pcm_24bit_packed'],
+          channelCounts: [2],
+          supportedMixerSampleRates: [48000, 96000],
+          supportsBitPerfectMixer: true,
+        ),
+      ],
+    );
+    usbExclusivePlaybackStateNotifier.value = const UsbExclusivePlaybackState(
+      active: true,
+      playing: true,
+      position: Duration(milliseconds: 195),
+      duration: Duration(minutes: 3),
+      sampleRate: 96000,
+      bitDepth: 24,
+      format: 'PCM',
+      message: null,
+    );
+
+    await tester.pumpWidget(
+      const MaterialApp(home: AudioOutputSettingsLayer()),
+    );
+
+    expect(find.text('传输状态'), findsOneWidget);
+    expect(find.text('195 ms'), findsOneWidget);
+    expect(find.text('缓冲区水位'), findsOneWidget);
+    expect(find.text('ISO 0'), findsOneWidget);
+    expect(find.text('目标 200 ms'), findsOneWidget);
+    expect(find.text('最低 195 ms'), findsOneWidget);
+    expect(find.text('采样率'), findsNothing);
+    expect(find.text('缓冲'), findsNothing);
+  });
+}

--- a/test/audio_output_settings_layer_test.dart
+++ b/test/audio_output_settings_layer_test.dart
@@ -1,18 +1,32 @@
+import 'dart:io';
+
+import 'package:audio_tags_lofty/audio_tags_lofty.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:sylvakru/base/app.dart' as app;
+import 'package:sylvakru/base/audio_handler.dart';
+import 'package:sylvakru/base/my_audio_metadata.dart';
 import 'package:sylvakru/base/services/usb_audio_preferences.dart';
 import 'package:sylvakru/base/services/usb_audio_service.dart';
 import 'package:sylvakru/layer/audio_output_settings_layer.dart';
 
 void main() {
+  setUpAll(() {
+    app.appSupportDir = Directory.systemTemp.createTempSync(
+      'sylvakru_audio_settings_test_',
+    );
+  });
+
   tearDown(() {
     usbAudioPreferences.resetForTest();
     usbAudioStatusNotifier.value = UsbAudioStatus.unavailable();
     usbExclusivePlaybackStateNotifier.value =
         UsbExclusivePlaybackState.inactive();
+    usbTransportTelemetryNotifier.value = UsbTransportTelemetry.inactive();
+    currentSongNotifier.value = null;
   });
 
-  testWidgets('传输状态卡使用水位表达且隐藏采样率和缓冲设置值', (tester) async {
+  testWidgets('传输状态卡使用 telemetry 水位而不是播放进度', (tester) async {
     tester.view.physicalSize = const Size(390, 844);
     tester.view.devicePixelRatio = 1;
     addTearDown(() {
@@ -50,12 +64,22 @@ void main() {
     usbExclusivePlaybackStateNotifier.value = const UsbExclusivePlaybackState(
       active: true,
       playing: true,
-      position: Duration(milliseconds: 195),
+      position: Duration(milliseconds: 248424),
       duration: Duration(minutes: 3),
       sampleRate: 96000,
       bitDepth: 24,
       format: 'PCM',
       message: null,
+    );
+    usbTransportTelemetryNotifier.value = const UsbTransportTelemetry(
+      active: true,
+      bufferLevel: Duration(milliseconds: 184),
+      minimumBufferLevel: Duration(milliseconds: 120),
+      targetBuffer: Duration(milliseconds: 200),
+      isoPacketCount: 4096,
+      pendingUrbs: 7,
+      underrunCount: 0,
+      updatedAtMs: 123456,
     );
 
     await tester.pumpWidget(
@@ -63,12 +87,240 @@ void main() {
     );
 
     expect(find.text('传输状态'), findsOneWidget);
-    expect(find.text('195 ms'), findsOneWidget);
+    expect(find.text('184 ms'), findsOneWidget);
+    expect(find.text('248424 ms'), findsNothing);
     expect(find.text('缓冲区水位'), findsOneWidget);
-    expect(find.text('ISO 0'), findsOneWidget);
+    expect(find.text('ISO 4096'), findsOneWidget);
     expect(find.text('目标 200 ms'), findsOneWidget);
-    expect(find.text('最低 195 ms'), findsOneWidget);
+    expect(find.text('最低 120 ms'), findsOneWidget);
     expect(find.text('采样率'), findsNothing);
     expect(find.text('缓冲'), findsNothing);
+  });
+
+  testWidgets('传输状态卡低水位时不显示稳定', (tester) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    usbAudioPreferences.load(const {});
+    usbAudioStatusNotifier.value = const UsbAudioStatus(
+      supported: true,
+      androidSdk: 35,
+      activeDeviceId: 7,
+      preferredApplied: true,
+      preferredSampleRate: 96000,
+      preferredEncoding: 'pcm_24bit_packed',
+      preferredBitPerfect: true,
+      outputDeviceName: 'Macaron',
+      outputSampleRate: 96000,
+      outputEncoding: 'pcm_24bit_packed',
+      message: null,
+      devices: [
+        UsbAudioDevice(
+          id: 7,
+          name: 'Macaron',
+          type: 'usb_headset',
+          address: '/dev/bus/usb/001/002',
+          sampleRates: [48000, 96000],
+          encodings: ['pcm_16bit', 'pcm_24bit_packed'],
+          channelCounts: [2],
+          supportedMixerSampleRates: [48000, 96000],
+          supportsBitPerfectMixer: true,
+        ),
+      ],
+    );
+    usbExclusivePlaybackStateNotifier.value = const UsbExclusivePlaybackState(
+      active: true,
+      playing: true,
+      position: Duration(milliseconds: 1000),
+      duration: Duration(minutes: 3),
+      sampleRate: 96000,
+      bitDepth: 24,
+      format: 'PCM',
+      message: null,
+    );
+    usbTransportTelemetryNotifier.value = const UsbTransportTelemetry(
+      active: true,
+      bufferLevel: Duration(milliseconds: 52),
+      minimumBufferLevel: Duration(milliseconds: 2),
+      targetBuffer: Duration(milliseconds: 300),
+      isoPacketCount: 4096,
+      pendingUrbs: 2,
+      underrunCount: 0,
+      updatedAtMs: 123456,
+    );
+
+    await tester.pumpWidget(
+      const MaterialApp(home: AudioOutputSettingsLayer()),
+    );
+
+    expect(find.text('偏低'), findsOneWidget);
+    expect(find.text('稳定'), findsNothing);
+  });
+
+  testWidgets('传输状态卡出现欠载时显示欠载', (tester) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    usbAudioPreferences.load(const {});
+    usbAudioStatusNotifier.value = const UsbAudioStatus(
+      supported: true,
+      androidSdk: 35,
+      activeDeviceId: 7,
+      preferredApplied: true,
+      preferredSampleRate: 96000,
+      preferredEncoding: 'pcm_24bit_packed',
+      preferredBitPerfect: true,
+      outputDeviceName: 'Macaron',
+      outputSampleRate: 96000,
+      outputEncoding: 'pcm_24bit_packed',
+      message: null,
+      devices: [
+        UsbAudioDevice(
+          id: 7,
+          name: 'Macaron',
+          type: 'usb_headset',
+          address: '/dev/bus/usb/001/002',
+          sampleRates: [48000, 96000],
+          encodings: ['pcm_16bit', 'pcm_24bit_packed'],
+          channelCounts: [2],
+          supportedMixerSampleRates: [48000, 96000],
+          supportsBitPerfectMixer: true,
+        ),
+      ],
+    );
+    usbExclusivePlaybackStateNotifier.value = const UsbExclusivePlaybackState(
+      active: true,
+      playing: true,
+      position: Duration(milliseconds: 1000),
+      duration: Duration(minutes: 3),
+      sampleRate: 96000,
+      bitDepth: 24,
+      format: 'PCM',
+      message: null,
+    );
+    usbTransportTelemetryNotifier.value = const UsbTransportTelemetry(
+      active: true,
+      bufferLevel: Duration(milliseconds: 320),
+      minimumBufferLevel: Duration(milliseconds: 280),
+      targetBuffer: Duration(milliseconds: 300),
+      isoPacketCount: 4096,
+      pendingUrbs: 12,
+      underrunCount: 1,
+      updatedAtMs: 123456,
+    );
+
+    await tester.pumpWidget(
+      const MaterialApp(home: AudioOutputSettingsLayer()),
+    );
+
+    expect(find.text('欠载'), findsOneWidget);
+    expect(find.text('稳定'), findsNothing);
+  });
+
+  testWidgets('输出格式显示当前歌曲源文件信息', (tester) async {
+    tester.view.physicalSize = const Size(390, 1200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    usbAudioPreferences.load(const {});
+    currentSongNotifier.value = MyAudioMetadata(
+      AudioMetadata(
+        format: 'FLAC',
+        title: 'LUCKY',
+        bitrate: 822000,
+        samplerate: 44100,
+      ),
+      id: 'lucky',
+      path: '/storage/emulated/0/Music/TOMOO - LUCKY.flac',
+    );
+
+    await tester.pumpWidget(
+      const MaterialApp(home: AudioOutputSettingsLayer()),
+    );
+
+    expect(find.text('源文件'), findsOneWidget);
+    expect(find.text('TOMOO - LUCKY.flac'), findsOneWidget);
+    expect(find.text('44.1 kHz · FLAC · 822 kbps'), findsOneWidget);
+    expect(find.text('等待播放'), findsNothing);
+  });
+
+  testWidgets('设备状态卡使用样板式状态字段', (tester) async {
+    tester.view.physicalSize = const Size(390, 1200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    usbAudioPreferences.load(const {});
+    usbAudioStatusNotifier.value = const UsbAudioStatus(
+      supported: true,
+      androidSdk: 35,
+      activeDeviceId: 7,
+      preferredApplied: false,
+      preferredSampleRate: null,
+      preferredEncoding: 'pcm_24bit_packed',
+      preferredBitPerfect: false,
+      outputDeviceName: 'USB-Audio - Macaron',
+      outputSampleRate: 44100,
+      outputEncoding: 'pcm_24bit_packed',
+      message: null,
+      devices: [
+        UsbAudioDevice(
+          id: 7,
+          name: 'USB-Audio - Macaron',
+          type: 'usb_headset',
+          address: 'usb_headset',
+          sampleRates: [44100, 48000],
+          encodings: ['pcm_16bit', 'pcm_24bit_packed'],
+          channelCounts: [2],
+          supportedMixerSampleRates: [44100, 48000],
+          supportsBitPerfectMixer: false,
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      const MaterialApp(home: AudioOutputSettingsLayer()),
+    );
+
+    expect(find.text('USB EXCLUSIVE'), findsOneWidget);
+    expect(find.text('已连接'), findsOneWidget);
+    expect(find.text('OUTPUT LINK'), findsOneWidget);
+    expect(find.text('运行中'), findsOneWidget);
+    expect(find.text('FORMAT'), findsOneWidget);
+    expect(find.text('DEPTH'), findsOneWidget);
+    expect(find.text('USB ID'), findsOneWidget);
+  });
+
+  testWidgets('后台稳定性移动到输出格式之后', (tester) async {
+    tester.view.physicalSize = const Size(390, 1600);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    usbAudioPreferences.load(const {});
+
+    await tester.pumpWidget(
+      const MaterialApp(home: AudioOutputSettingsLayer()),
+    );
+
+    final outputTop = tester.getTopLeft(find.text('输出格式')).dy;
+    final stabilityTop = tester.getTopLeft(find.text('后台稳定性')).dy;
+
+    expect(stabilityTop, greaterThan(outputTop));
   });
 }

--- a/test/cover_art_widget_test.dart
+++ b/test/cover_art_widget_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sylvakru/base/widgets/cover_art_widget.dart';
+
+void main() {
+  test('CoverArtWidget uses requested cache width for image decoding', () {
+    final coverArt = CoverArtWidget(
+      picturePath: 'F:\\Symusic\\cover.png',
+      cacheWidth: 160,
+      filterQuality: FilterQuality.low,
+    );
+
+    final image = coverArt.imageWidget('F:\\Symusic\\cover.png') as Image;
+
+    final imageProvider = image.image;
+
+    expect(imageProvider, isA<ResizeImage>());
+    expect((imageProvider as ResizeImage).width, 160);
+    expect(image.filterQuality, FilterQuality.low);
+  });
+}

--- a/test/path_utils_test.dart
+++ b/test/path_utils_test.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sylvakru/base/utils/path.dart';
+
+void main() {
+  test('convertToRealPathIfNeed ignores Android local file paths', () async {
+    final result = await convertToRealPathIfNeed(
+      '/storage/emulated/0/TRIM/Download/01.%20test.flac',
+    );
+
+    expect(result, isNull);
+  });
+}

--- a/test/playback_position_bridge_test.dart
+++ b/test/playback_position_bridge_test.dart
@@ -1,0 +1,52 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sylvakru/base/services/playback_position_bridge.dart';
+import 'package:sylvakru/base/services/usb_audio_service.dart';
+
+void main() {
+  test('USB 真独占 active 时位置流使用独占播放位置', () async {
+    final playerPositions = StreamController<Duration>.broadcast();
+    var playerPosition = Duration.zero;
+    final exclusiveState = ValueNotifier(UsbExclusivePlaybackState.inactive());
+    final bridge = PlaybackPositionBridge(
+      playerPositionStream: playerPositions.stream,
+      playerPosition: () => playerPosition,
+      exclusiveStateListenable: exclusiveState,
+    );
+
+    addTearDown(() async {
+      bridge.dispose();
+      exclusiveState.dispose();
+      await playerPositions.close();
+    });
+
+    final emitted = <Duration>[];
+    final subscription = bridge.stream.listen(emitted.add);
+    addTearDown(subscription.cancel);
+
+    playerPosition = const Duration(seconds: 2);
+    playerPositions.add(playerPosition);
+    await pumpEventQueue();
+
+    exclusiveState.value = const UsbExclusivePlaybackState(
+      active: true,
+      playing: true,
+      position: Duration(seconds: 42),
+      duration: Duration(minutes: 3),
+      sampleRate: 96000,
+      bitDepth: 24,
+      format: 'flac',
+      message: 'Playing.',
+    );
+    await pumpEventQueue();
+
+    playerPosition = const Duration(seconds: 3);
+    playerPositions.add(playerPosition);
+    await pumpEventQueue();
+
+    expect(emitted, [const Duration(seconds: 2), const Duration(seconds: 42)]);
+    expect(bridge.position, const Duration(seconds: 42));
+  });
+}

--- a/test/super_lyric_bridge_test.dart
+++ b/test/super_lyric_bridge_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:sylvakru/base/services/lyric.dart';
 import 'package:sylvakru/base/services/super_lyric_bridge.dart';
 
 void main() {
@@ -31,6 +32,43 @@ void main() {
     expect(calls[0].method, 'sendLyric');
     expect(calls[0].arguments, {'lyric': 'first line'});
     expect(calls[1].arguments, {'lyric': 'second line'});
+  });
+
+  test('sendLyricLine sends line timing and word timing tokens', () async {
+    final calls = <MethodCall>[];
+    SuperLyricBridge.configureForTest(channel: channel, isAndroid: true);
+
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      calls.add(call);
+      return null;
+    });
+
+    await SuperLyricBridge.sendLyricLine(
+      LyricLine(const Duration(seconds: 10), 'hello world', [
+        LyricToken(
+          const Duration(seconds: 10),
+          'hello ',
+          const Duration(milliseconds: 10400),
+        ),
+        LyricToken(
+          const Duration(milliseconds: 10400),
+          'world',
+          const Duration(seconds: 11),
+        ),
+      ]),
+    );
+
+    expect(calls, hasLength(1));
+    expect(calls.single.method, 'sendLyric');
+    expect(calls.single.arguments, {
+      'lyric': 'hello world',
+      'startTime': 10000,
+      'endTime': 11000,
+      'tokens': [
+        {'text': 'hello ', 'startTime': 10000, 'endTime': 10400},
+        {'text': 'world', 'startTime': 10400, 'endTime': 11000},
+      ],
+    });
   });
 
   test('sendLyric sends stop for blank or placeholder lyrics', () async {

--- a/test/super_lyric_bridge_test.dart
+++ b/test/super_lyric_bridge_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sylvakru/base/services/super_lyric_bridge.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('com.afalphy.sylvakru/super_lyric');
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  tearDown(() {
+    messenger.setMockMethodCallHandler(channel, null);
+    SuperLyricBridge.resetForTest();
+  });
+
+  test('sendLyric sends non-empty lyric and skips duplicates', () async {
+    final calls = <MethodCall>[];
+    SuperLyricBridge.configureForTest(channel: channel, isAndroid: true);
+
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      calls.add(call);
+      return null;
+    });
+
+    await SuperLyricBridge.sendLyric('first line');
+    await SuperLyricBridge.sendLyric('first line');
+    await SuperLyricBridge.sendLyric('second line');
+
+    expect(calls, hasLength(2));
+    expect(calls[0].method, 'sendLyric');
+    expect(calls[0].arguments, {'lyric': 'first line'});
+    expect(calls[1].arguments, {'lyric': 'second line'});
+  });
+
+  test('sendLyric sends stop for blank or placeholder lyrics', () async {
+    final calls = <MethodCall>[];
+    SuperLyricBridge.configureForTest(channel: channel, isAndroid: true);
+
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      calls.add(call);
+      return null;
+    });
+
+    await SuperLyricBridge.sendLyric('   ');
+    await SuperLyricBridge.sendLyric('There are no lyrics');
+    await SuperLyricBridge.sendLyric('Lyrics parsing failed');
+
+    expect(calls.map((call) => call.method), ['sendStop']);
+  });
+
+  test('sendStop clears last sent lyric and skips duplicate stop', () async {
+    final calls = <MethodCall>[];
+    SuperLyricBridge.configureForTest(channel: channel, isAndroid: true);
+
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      calls.add(call);
+      return null;
+    });
+
+    await SuperLyricBridge.sendLyric('one line');
+    await SuperLyricBridge.sendStop();
+    await SuperLyricBridge.sendStop();
+    await SuperLyricBridge.sendLyric('one line');
+
+    expect(calls.map((call) => call.method), [
+      'sendLyric',
+      'sendStop',
+      'sendLyric',
+    ]);
+  });
+}

--- a/test/super_lyric_position_publisher_test.dart
+++ b/test/super_lyric_position_publisher_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sylvakru/base/services/lyric.dart';
+import 'package:sylvakru/base/services/super_lyric_position_publisher.dart';
+
+void main() {
+  test('publishes lyric lines as playback position advances', () async {
+    final events = <String>[];
+    final publisher = SuperLyricPositionPublisher(
+      sendLyricLine: (line) async => events.add('lyric:${line.text}'),
+      sendStop: () async => events.add('stop'),
+    );
+
+    publisher.updateLines([
+      LyricLine(const Duration(seconds: 1), 'first', const []),
+      LyricLine(const Duration(seconds: 3), 'second', const []),
+    ]);
+
+    await publisher.publishAt(const Duration(milliseconds: 500));
+    await publisher.publishAt(const Duration(seconds: 1));
+    await publisher.publishAt(const Duration(seconds: 2));
+    await publisher.publishAt(const Duration(seconds: 3));
+
+    expect(events, ['stop', 'lyric:first', 'lyric:second']);
+  });
+
+  test(
+    'reset makes the current lyric publish again after a song change',
+    () async {
+      final events = <String>[];
+      final publisher = SuperLyricPositionPublisher(
+        sendLyricLine: (line) async => events.add(line.text),
+        sendStop: () async {},
+      );
+
+      publisher.updateLines([
+        LyricLine(Duration.zero, 'same visible text', const []),
+      ]);
+      await publisher.publishAt(Duration.zero);
+
+      publisher.updateLines([
+        LyricLine(Duration.zero, 'same visible text', const []),
+      ]);
+      await publisher.publishAt(Duration.zero);
+
+      expect(events, ['same visible text', 'same visible text']);
+    },
+  );
+
+  test(
+    'reset makes the current lyric publish again after pause stop',
+    () async {
+      final events = <String>[];
+      final publisher = SuperLyricPositionPublisher(
+        sendLyricLine: (line) async => events.add(line.text),
+        sendStop: () async {},
+      );
+
+      publisher.updateLines([
+        LyricLine(Duration.zero, 'current line', const []),
+      ]);
+      await publisher.publishAt(Duration.zero);
+
+      publisher.reset();
+      await publisher.publishAt(Duration.zero);
+
+      expect(events, ['current line', 'current line']);
+    },
+  );
+}

--- a/test/usb_audio_preferences_test.dart
+++ b/test/usb_audio_preferences_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sylvakru/base/services/usb_audio_preferences.dart';
+
+void main() {
+  tearDown(() {
+    usbAudioPreferences.resetForTest();
+  });
+
+  test('loads and serializes USB audio preferences', () {
+    usbAudioPreferences.load({
+      'usbFixedSampleRateEnabled': true,
+      'usbFixedSampleRate': 96000,
+      'usbDsdMode': 'native',
+      'usbDsd64PcmRate': 176400,
+      'usbPerformanceMode': false,
+      'usbVolumeLockMode': 'always',
+      'usbDsdGainCompensation': -6,
+      'usbBusSpeedMode': 'high',
+      'usbBitDepthMode': 'pcm32',
+      'usbReleaseBandwidthAfterPlayback': true,
+      'usbKeepAliveInBackground': false,
+    });
+
+    expect(usbAudioPreferences.preferredFixedSampleRate(), 96000);
+    expect(usbAudioPreferences.dsdModeNotifier.value, UsbDsdMode.native);
+    expect(usbAudioPreferences.dsd64PcmRateNotifier.value, 176400);
+    expect(usbAudioPreferences.performanceModeNotifier.value, isFalse);
+    expect(
+      usbAudioPreferences.volumeLockModeNotifier.value,
+      UsbVolumeLockMode.always,
+    );
+    expect(usbAudioPreferences.dsdGainCompensationNotifier.value, -6);
+    expect(
+      usbAudioPreferences.busSpeedModeNotifier.value,
+      UsbBusSpeedMode.high,
+    );
+    expect(usbAudioPreferences.preferredEncoding(), 'pcm_32bit');
+    expect(
+      usbAudioPreferences.releaseUsbBandwidthAfterPlaybackNotifier.value,
+      isTrue,
+    );
+    expect(usbAudioPreferences.keepAliveInBackgroundNotifier.value, isFalse);
+    expect(usbAudioPreferences.toMap()['usbDsdMode'], 'native');
+  });
+
+  test('ignores unsupported fixed sample rate', () {
+    usbAudioPreferences.load({
+      'usbFixedSampleRateEnabled': true,
+      'usbFixedSampleRate': 12345,
+    });
+
+    expect(usbAudioPreferences.preferredFixedSampleRate(), isNull);
+  });
+}

--- a/test/usb_audio_preferences_test.dart
+++ b/test/usb_audio_preferences_test.dart
@@ -89,6 +89,20 @@ void main() {
     expect(preferredUsbExclusiveTargetBufferMs(background: true), 320);
   });
 
+  test('selects exclusive PCM bit depth from user preference', () {
+    usbAudioPreferences.bitDepthModeNotifier.value = UsbBitDepthMode.auto;
+    expect(preferredUsbExclusiveBitDepth(), isNull);
+
+    usbAudioPreferences.bitDepthModeNotifier.value = UsbBitDepthMode.pcm16;
+    expect(preferredUsbExclusiveBitDepth(), 16);
+
+    usbAudioPreferences.bitDepthModeNotifier.value = UsbBitDepthMode.pcm24;
+    expect(preferredUsbExclusiveBitDepth(), 24);
+
+    usbAudioPreferences.bitDepthModeNotifier.value = UsbBitDepthMode.pcm32;
+    expect(preferredUsbExclusiveBitDepth(), 32);
+  });
+
   test('ignores unsupported fixed sample rate', () {
     usbAudioPreferences.load({
       'usbFixedSampleRateEnabled': true,

--- a/test/usb_audio_preferences_test.dart
+++ b/test/usb_audio_preferences_test.dart
@@ -75,6 +75,20 @@ void main() {
     expect(usbAudioPreferences.delayedUsbLinkNotifier.value, isFalse);
   });
 
+  test('selects exclusive target buffer for foreground and background', () {
+    usbAudioPreferences.load({
+      'usbForegroundBufferMs': 320,
+      'usbBackgroundBufferMs': 2400,
+      'usbKeepAliveInBackground': true,
+    });
+
+    expect(preferredUsbExclusiveTargetBufferMs(background: false), 320);
+    expect(preferredUsbExclusiveTargetBufferMs(background: true), 2400);
+
+    usbAudioPreferences.keepAliveInBackgroundNotifier.value = false;
+    expect(preferredUsbExclusiveTargetBufferMs(background: true), 320);
+  });
+
   test('ignores unsupported fixed sample rate', () {
     usbAudioPreferences.load({
       'usbFixedSampleRateEnabled': true,

--- a/test/usb_audio_preferences_test.dart
+++ b/test/usb_audio_preferences_test.dart
@@ -19,6 +19,14 @@ void main() {
       'usbBitDepthMode': 'pcm32',
       'usbReleaseBandwidthAfterPlayback': true,
       'usbKeepAliveInBackground': false,
+      'usbBitDepthCompat': false,
+      'usbSampleRateCompat': false,
+      'usbChannelCompat': false,
+      'usbTpdfDither': true,
+      'usbForegroundBufferMs': 320,
+      'usbBackgroundBufferMs': 2400,
+      'usbVolumeSmoothHandoff': false,
+      'usbDelayedUsbLink': true,
     });
 
     expect(usbAudioPreferences.preferredFixedSampleRate(), 96000);
@@ -40,7 +48,31 @@ void main() {
       isTrue,
     );
     expect(usbAudioPreferences.keepAliveInBackgroundNotifier.value, isFalse);
+    expect(usbAudioPreferences.bitDepthCompatNotifier.value, isFalse);
+    expect(usbAudioPreferences.sampleRateCompatNotifier.value, isFalse);
+    expect(usbAudioPreferences.channelCompatNotifier.value, isFalse);
+    expect(usbAudioPreferences.tpdfDitherNotifier.value, isTrue);
+    expect(usbAudioPreferences.foregroundBufferMsNotifier.value, 320);
+    expect(usbAudioPreferences.backgroundBufferMsNotifier.value, 2400);
+    expect(usbAudioPreferences.volumeSmoothHandoffNotifier.value, isFalse);
+    expect(usbAudioPreferences.delayedUsbLinkNotifier.value, isTrue);
     expect(usbAudioPreferences.toMap()['usbDsdMode'], 'native');
+    expect(usbAudioPreferences.toMap()['usbBitDepthCompat'], isFalse);
+    expect(usbAudioPreferences.toMap()['usbTpdfDither'], isTrue);
+    expect(usbAudioPreferences.toMap()['usbForegroundBufferMs'], 320);
+  });
+
+  test('uses practical defaults for USB compatibility options', () {
+    usbAudioPreferences.load(const {});
+
+    expect(usbAudioPreferences.bitDepthCompatNotifier.value, isTrue);
+    expect(usbAudioPreferences.sampleRateCompatNotifier.value, isTrue);
+    expect(usbAudioPreferences.channelCompatNotifier.value, isTrue);
+    expect(usbAudioPreferences.tpdfDitherNotifier.value, isFalse);
+    expect(usbAudioPreferences.foregroundBufferMsNotifier.value, 200);
+    expect(usbAudioPreferences.backgroundBufferMsNotifier.value, 1500);
+    expect(usbAudioPreferences.volumeSmoothHandoffNotifier.value, isTrue);
+    expect(usbAudioPreferences.delayedUsbLinkNotifier.value, isFalse);
   });
 
   test('ignores unsupported fixed sample rate', () {

--- a/test/usb_audio_service_test.dart
+++ b/test/usb_audio_service_test.dart
@@ -189,91 +189,99 @@ void main() {
     expect(result.rawDescriptorLength, 257);
   });
 
-  test('getExclusiveCapabilities maps native exclusive USB capabilities', () async {
-    final service = UsbAudioService(channel: channel, isAndroid: true);
+  test(
+    'getExclusiveCapabilities maps native exclusive USB capabilities',
+    () async {
+      final service = UsbAudioService(channel: channel, isAndroid: true);
 
-    messenger.setMockMethodCallHandler(channel, (call) async {
-      if (call.method == 'getExclusiveCapabilities') {
-        return {
-          'available': true,
-          'permissionGranted': true,
-          'deviceName': 'iBasso Macaron',
-          'deviceId': 31,
-          'interfaceNumber': 1,
-          'alternateSetting': 1,
-          'endpointAddress': 1,
-          'maxPacketSize': 196,
-          'sampleRates': [44100, 48000, 96000],
-          'bitDepths': [16, 24, 32],
-          'channelCounts': [2],
-          'message': 'USB exclusive endpoint is available.',
-        };
-      }
-      throw PlatformException(code: 'unexpected_method');
-    });
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        if (call.method == 'getExclusiveCapabilities') {
+          return {
+            'available': true,
+            'permissionGranted': true,
+            'deviceName': 'iBasso Macaron',
+            'deviceId': 31,
+            'interfaceNumber': 1,
+            'alternateSetting': 1,
+            'endpointAddress': 1,
+            'maxPacketSize': 196,
+            'sampleRates': [44100, 48000, 96000],
+            'bitDepths': [16, 24, 32],
+            'channelCounts': [2],
+            'message': 'USB exclusive endpoint is available.',
+          };
+        }
+        throw PlatformException(code: 'unexpected_method');
+      });
 
-    final capability = await service.getExclusiveCapabilities();
+      final capability = await service.getExclusiveCapabilities();
 
-    expect(capability.available, isTrue);
-    expect(capability.permissionGranted, isTrue);
-    expect(capability.deviceName, 'iBasso Macaron');
-    expect(capability.deviceId, 31);
-    expect(capability.interfaceNumber, 1);
-    expect(capability.alternateSetting, 1);
-    expect(capability.endpointAddress, 1);
-    expect(capability.maxPacketSize, 196);
-    expect(capability.sampleRates, [44100, 48000, 96000]);
-    expect(capability.bitDepths, [16, 24, 32]);
-    expect(capability.channelCounts, [2]);
-  });
+      expect(capability.available, isTrue);
+      expect(capability.permissionGranted, isTrue);
+      expect(capability.deviceName, 'iBasso Macaron');
+      expect(capability.deviceId, 31);
+      expect(capability.interfaceNumber, 1);
+      expect(capability.alternateSetting, 1);
+      expect(capability.endpointAddress, 1);
+      expect(capability.maxPacketSize, 196);
+      expect(capability.sampleRates, [44100, 48000, 96000]);
+      expect(capability.bitDepths, [16, 24, 32]);
+      expect(capability.channelCounts, [2]);
+    },
+  );
 
-  test('startExclusivePlayback sends playback request to native layer', () async {
-    final service = UsbAudioService(channel: channel, isAndroid: true);
-    Object? receivedArguments;
+  test(
+    'startExclusivePlayback sends playback request to native layer',
+    () async {
+      final service = UsbAudioService(channel: channel, isAndroid: true);
+      Object? receivedArguments;
 
-    messenger.setMockMethodCallHandler(channel, (call) async {
-      if (call.method == 'startExclusivePlayback') {
-        receivedArguments = call.arguments;
-        return {
-          'active': true,
-          'playing': true,
-          'positionMs': 0,
-          'durationMs': 180000,
-          'sampleRate': 44100,
-          'bitDepth': 24,
-          'format': 'flac',
-          'message': 'USB exclusive playback started.',
-        };
-      }
-      throw PlatformException(code: 'unexpected_method');
-    });
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        if (call.method == 'startExclusivePlayback') {
+          receivedArguments = call.arguments;
+          return {
+            'active': true,
+            'playing': true,
+            'positionMs': 0,
+            'durationMs': 180000,
+            'sampleRate': 44100,
+            'bitDepth': 24,
+            'format': 'flac',
+            'message': 'USB exclusive playback started.',
+          };
+        }
+        throw PlatformException(code: 'unexpected_method');
+      });
 
-    final state = await service.startExclusivePlayback(
-      const UsbExclusivePlaybackRequest(
-        filePath: '/music/test.flac',
-        title: 'Test',
-        sampleRate: 44100,
-        bitDepth: 24,
-        startPaused: false,
-      ),
-    );
+      final state = await service.startExclusivePlayback(
+        const UsbExclusivePlaybackRequest(
+          filePath: '/music/test.flac',
+          title: 'Test',
+          sourceFormat: 'flac',
+          sampleRate: 44100,
+          bitDepth: 24,
+          startPaused: false,
+        ),
+      );
 
-    expect(receivedArguments, {
-      'filePath': '/music/test.flac',
-      'title': 'Test',
-      'sampleRate': 44100,
-      'bitDepth': 24,
-      'startPaused': false,
-    });
-    expect(state.active, isTrue);
-    expect(state.playing, isTrue);
-    expect(state.position, Duration.zero);
-    expect(state.duration, const Duration(minutes: 3));
-    expect(state.sampleRate, 44100);
-    expect(state.bitDepth, 24);
-    expect(state.format, 'flac');
-    expect(usbExclusivePlaybackStateNotifier.value, state);
-  });
+      expect(receivedArguments, {
+        'filePath': '/music/test.flac',
+        'title': 'Test',
+        'sourceFormat': 'flac',
+        'sampleRate': 44100,
+        'bitDepth': 24,
+        'startPaused': false,
+      });
+      expect(state.active, isTrue);
+      expect(state.playing, isTrue);
+      expect(state.position, Duration.zero);
+      expect(state.duration, const Duration(minutes: 3));
+      expect(state.sampleRate, 44100);
+      expect(state.bitDepth, 24);
+      expect(state.format, 'flac');
+      expect(usbExclusivePlaybackStateNotifier.value, state);
+    },
+  );
 
   test('native exclusive state event updates playback notifier', () async {
     UsbAudioService(channel: channel, isAndroid: true);

--- a/test/usb_audio_service_test.dart
+++ b/test/usb_audio_service_test.dart
@@ -362,4 +362,71 @@ void main() {
     expect(telemetry.underrunCount, 1);
     expect(telemetry.updatedAtMs, 123456);
   });
+
+  test('getDiagnosticsReport assembles native data into a text report', () async {
+    final service = UsbAudioService(channel: channel, isAndroid: true);
+
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      if (call.method == 'getUsbDiagnosticsReport') {
+        return {
+          'generatedAtMs': 1751414400000,
+          'androidSdk': 34,
+          'androidRelease': '14',
+          'manufacturer': 'Pixel',
+          'model': 'Test',
+          'permissionGranted': true,
+          'device': {
+            'vendorIdHex': '0x2972',
+            'productIdHex': '0x0047',
+            'manufacturerName': 'FiiO',
+            'productName': 'FiiO KA13',
+            'deviceClass': 0,
+            'deviceSubclass': 0,
+            'interfaceCount': 4,
+            'audioInterfaceCount': 2,
+            'serialTail': '****9F2A',
+          },
+          'diagnostics': {
+            'available': true,
+            'rawDescriptorLength': 32,
+            'rawDescriptorsHex': '0000: 12 01 00 02',
+            'streamingFormats': ['StreamingFormatInfo(alt=1)'],
+            'outputCandidates': ['alt=1/max=294/bits=32'],
+            'clockSourceId': 41,
+          },
+          'lastProbe': {'message': 'ok'},
+          'systemStatus': {
+            'devices': [
+              {'id': 10, 'name': 'FiiO KA13'},
+            ],
+          },
+          'nativeLogcat': ['01-01 00:00:00.000 I native line'],
+          'logs': ['00:00:00.000 I/UsbExclusiveAudioEngine: open ok'],
+        };
+      }
+      throw PlatformException(code: 'unexpected_method');
+    });
+
+    final report = await service.getDiagnosticsReport();
+
+    expect(report, startsWith('Sylvakru USB 诊断报告 v1'));
+    expect(report, contains('App 版本'));
+    expect(report, contains('0x2972 / 0x0047'));
+    expect(report, contains('****9F2A'));
+    expect(report, contains('## 原始描述符 (hex dump)'));
+    expect(report, contains('0000: 12 01 00 02'));
+    expect(report, contains('alt=1/max=294/bits=32'));
+    expect(report, contains('UAC2 时钟源 id: 41'));
+    expect(report, contains('## 偏好快照'));
+    expect(report, contains('open ok'));
+    expect(report, contains('native line'));
+  });
+
+  test('buildUsbDiagnosticsReport handles missing device data', () {
+    final report = buildUsbDiagnosticsReport(const {}, platformSupported: true);
+
+    expect(report, startsWith('Sylvakru USB 诊断报告 v1'));
+    expect(report, contains('未检测到 USB 音频设备。'));
+    expect(report, contains('描述符不可用。'));
+  });
 }

--- a/test/usb_audio_service_test.dart
+++ b/test/usb_audio_service_test.dart
@@ -11,6 +11,7 @@ void main() {
 
   tearDown(() {
     messenger.setMockMethodCallHandler(channel, null);
+    usbTransportTelemetryNotifier.value = UsbTransportTelemetry.inactive();
   });
 
   test(
@@ -260,6 +261,7 @@ void main() {
           sourceFormat: 'flac',
           sampleRate: 44100,
           bitDepth: 24,
+          targetBufferMs: 320,
           startPaused: false,
         ),
       );
@@ -270,6 +272,7 @@ void main() {
         'sourceFormat': 'flac',
         'sampleRate': 44100,
         'bitDepth': 24,
+        'targetBufferMs': 320,
         'startPaused': false,
       });
       expect(state.active, isTrue);
@@ -282,6 +285,23 @@ void main() {
       expect(usbExclusivePlaybackStateNotifier.value, state);
     },
   );
+
+  test('setExclusiveTargetBufferMs updates native exclusive buffer', () async {
+    final service = UsbAudioService(channel: channel, isAndroid: true);
+    Object? receivedArguments;
+
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      if (call.method == 'setExclusiveTargetBufferMs') {
+        receivedArguments = call.arguments;
+        return null;
+      }
+      throw PlatformException(code: 'unexpected_method');
+    });
+
+    await service.setExclusiveTargetBufferMs(2400);
+
+    expect(receivedArguments, {'targetBufferMs': 2400});
+  });
 
   test('native exclusive state event updates playback notifier', () async {
     UsbAudioService(channel: channel, isAndroid: true);
@@ -310,5 +330,36 @@ void main() {
     expect(state.duration, const Duration(minutes: 4));
     expect(state.sampleRate, 48000);
     expect(state.bitDepth, 24);
+  });
+
+  test('native transport telemetry event updates transport notifier', () async {
+    UsbAudioService(channel: channel, isAndroid: true);
+
+    await messenger.handlePlatformMessage(
+      channel.name,
+      const StandardMethodCodec().encodeMethodCall(
+        MethodCall('onUsbTransportTelemetryChanged', {
+          'active': true,
+          'bufferLevelMs': 184,
+          'minimumBufferLevelMs': 120,
+          'targetBufferMs': 200,
+          'isoPacketCount': 4096,
+          'pendingUrbs': 7,
+          'underrunCount': 1,
+          'updatedAtMs': 123456,
+        }),
+      ),
+      (_) {},
+    );
+
+    final telemetry = usbTransportTelemetryNotifier.value;
+    expect(telemetry.active, isTrue);
+    expect(telemetry.bufferLevel, const Duration(milliseconds: 184));
+    expect(telemetry.minimumBufferLevel, const Duration(milliseconds: 120));
+    expect(telemetry.targetBuffer, const Duration(milliseconds: 200));
+    expect(telemetry.isoPacketCount, 4096);
+    expect(telemetry.pendingUrbs, 7);
+    expect(telemetry.underrunCount, 1);
+    expect(telemetry.updatedAtMs, 123456);
   });
 }

--- a/test/usb_audio_service_test.dart
+++ b/test/usb_audio_service_test.dart
@@ -28,6 +28,9 @@ void main() {
             'preferredSampleRate': 96000,
             'preferredEncoding': 'pcm_24bit_packed',
             'preferredBitPerfect': true,
+            'outputDeviceName': 'USB DAC',
+            'outputSampleRate': 96000,
+            'outputEncoding': 'pcm_24bit_packed',
             'message': 'USB audio device detected',
             'devices': [
               {
@@ -55,6 +58,9 @@ void main() {
       expect(status.preferredSampleRate, 96000);
       expect(status.preferredEncoding, 'pcm_24bit_packed');
       expect(status.preferredBitPerfect, isTrue);
+      expect(status.outputDeviceName, 'USB DAC');
+      expect(status.outputSampleRate, 96000);
+      expect(status.outputEncoding, 'pcm_24bit_packed');
       expect(status.devices, hasLength(1));
       expect(status.devices.single.name, 'USB DAC');
       expect(status.devices.single.sampleRates, [44100, 48000, 96000]);
@@ -77,6 +83,7 @@ void main() {
             'androidSdk': 35,
             'activeDeviceId': 10,
             'preferredApplied': true,
+            'outputSampleRate': 96000,
             'message': 'Applied preferred USB mixer attributes',
             'devices': const [],
           };
@@ -99,4 +106,55 @@ void main() {
       expect(status.message, 'Applied preferred USB mixer attributes');
     },
   );
+
+  test('native USB added event updates status and event notifier', () async {
+    UsbAudioService(channel: channel, isAndroid: true);
+
+    final eventStatus = {
+      'supported': true,
+      'androidSdk': 35,
+      'activeDeviceId': 18,
+      'preferredApplied': false,
+      'preferredSampleRate': null,
+      'preferredEncoding': null,
+      'preferredBitPerfect': false,
+      'outputDeviceName': 'USB DAC',
+      'outputSampleRate': 48000,
+      'outputEncoding': 'pcm_16bit',
+      'message': 'USB audio device detected.',
+      'devices': [
+        {
+          'id': 18,
+          'name': 'USB DAC',
+          'type': 'usb_device',
+          'address': 'dac-18',
+          'sampleRates': [44100, 48000, 96000],
+          'encodings': ['pcm_16bit', 'pcm_24bit_packed'],
+          'channelCounts': [2],
+          'supportedMixerSampleRates': [44100, 48000, 96000],
+          'supportsBitPerfectMixer': true,
+        },
+      ],
+    };
+
+    await messenger.handlePlatformMessage(
+      channel.name,
+      const StandardMethodCodec().encodeMethodCall(
+        MethodCall('onUsbAudioDeviceEvent', {
+          'type': 'added',
+          'deviceId': 18,
+          'status': eventStatus,
+        }),
+      ),
+      (_) {},
+    );
+
+    final event = usbAudioEventNotifier.value;
+    expect(event, isNotNull);
+    expect(event!.type, UsbAudioDeviceEventType.added);
+    expect(event.deviceId, 18);
+    expect(event.status.supported, isTrue);
+    expect(event.status.devices.single.name, 'USB DAC');
+    expect(usbAudioStatusNotifier.value.activeDeviceId, 18);
+  });
 }

--- a/test/usb_audio_service_test.dart
+++ b/test/usb_audio_service_test.dart
@@ -157,4 +157,35 @@ void main() {
     expect(event.status.devices.single.name, 'USB DAC');
     expect(usbAudioStatusNotifier.value.activeDeviceId, 18);
   });
+
+  test('probeExclusiveAccess maps native USB claim result', () async {
+    final service = UsbAudioService(channel: channel, isAndroid: true);
+
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      if (call.method == 'probeExclusiveAccess') {
+        return {
+          'supported': true,
+          'permissionGranted': true,
+          'deviceName': 'USB DAC',
+          'deviceId': 21,
+          'audioInterfaceCount': 2,
+          'claimedInterfaceCount': 1,
+          'rawDescriptorLength': 257,
+          'message': 'USB Audio interface can be claimed.',
+        };
+      }
+      throw PlatformException(code: 'unexpected_method');
+    });
+
+    final result = await service.probeExclusiveAccess();
+
+    expect(result.supported, isTrue);
+    expect(result.permissionGranted, isTrue);
+    expect(result.deviceName, 'USB DAC');
+    expect(result.deviceId, 21);
+    expect(result.audioInterfaceCount, 2);
+    expect(result.claimedInterfaceCount, 1);
+    expect(result.interfaceClaimed, isTrue);
+    expect(result.rawDescriptorLength, 257);
+  });
 }

--- a/test/usb_audio_service_test.dart
+++ b/test/usb_audio_service_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sylvakru/base/services/usb_audio_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('com.afalphy.sylvakru/usb_audio');
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  tearDown(() {
+    messenger.setMockMethodCallHandler(channel, null);
+  });
+
+  test(
+    'refreshStatus maps USB device capabilities from platform channel',
+    () async {
+      final service = UsbAudioService(channel: channel, isAndroid: true);
+
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        if (call.method == 'getStatus') {
+          return {
+            'supported': true,
+            'androidSdk': 35,
+            'activeDeviceId': 10,
+            'preferredApplied': false,
+            'preferredSampleRate': 96000,
+            'preferredEncoding': 'pcm_24bit_packed',
+            'preferredBitPerfect': true,
+            'message': 'USB audio device detected',
+            'devices': [
+              {
+                'id': 10,
+                'name': 'USB DAC',
+                'type': 'usb_device',
+                'address': 'bus-001',
+                'sampleRates': [44100, 48000, 96000],
+                'encodings': ['pcm_16bit', 'pcm_24bit_packed'],
+                'channelCounts': [2],
+                'supportedMixerSampleRates': [48000, 96000],
+                'supportsBitPerfectMixer': true,
+              },
+            ],
+          };
+        }
+        throw PlatformException(code: 'unexpected_method');
+      });
+
+      final status = await service.refreshStatus();
+
+      expect(status.supported, isTrue);
+      expect(status.androidSdk, 35);
+      expect(status.activeDeviceId, 10);
+      expect(status.preferredSampleRate, 96000);
+      expect(status.preferredEncoding, 'pcm_24bit_packed');
+      expect(status.preferredBitPerfect, isTrue);
+      expect(status.devices, hasLength(1));
+      expect(status.devices.single.name, 'USB DAC');
+      expect(status.devices.single.sampleRates, [44100, 48000, 96000]);
+      expect(status.devices.single.supportsBitPerfectMixer, isTrue);
+      expect(usbAudioStatusNotifier.value, status);
+    },
+  );
+
+  test(
+    'applyPreferredOutput requests requested sample rate and device id',
+    () async {
+      final service = UsbAudioService(channel: channel, isAndroid: true);
+      Object? receivedArguments;
+
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        if (call.method == 'applyPreferredOutput') {
+          receivedArguments = call.arguments;
+          return {
+            'supported': true,
+            'androidSdk': 35,
+            'activeDeviceId': 10,
+            'preferredApplied': true,
+            'message': 'Applied preferred USB mixer attributes',
+            'devices': const [],
+          };
+        }
+        throw PlatformException(code: 'unexpected_method');
+      });
+
+      final status = await service.applyPreferredOutput(
+        deviceId: 10,
+        sampleRate: 96000,
+      );
+
+      expect(receivedArguments, {
+        'deviceId': 10,
+        'sampleRate': 96000,
+        'encoding': 'pcm_24bit_packed',
+        'bitPerfect': true,
+      });
+      expect(status.preferredApplied, isTrue);
+      expect(status.message, 'Applied preferred USB mixer attributes');
+    },
+  );
+}

--- a/test/usb_audio_service_test.dart
+++ b/test/usb_audio_service_test.dart
@@ -188,4 +188,119 @@ void main() {
     expect(result.interfaceClaimed, isTrue);
     expect(result.rawDescriptorLength, 257);
   });
+
+  test('getExclusiveCapabilities maps native exclusive USB capabilities', () async {
+    final service = UsbAudioService(channel: channel, isAndroid: true);
+
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      if (call.method == 'getExclusiveCapabilities') {
+        return {
+          'available': true,
+          'permissionGranted': true,
+          'deviceName': 'iBasso Macaron',
+          'deviceId': 31,
+          'interfaceNumber': 1,
+          'alternateSetting': 1,
+          'endpointAddress': 1,
+          'maxPacketSize': 196,
+          'sampleRates': [44100, 48000, 96000],
+          'bitDepths': [16, 24, 32],
+          'channelCounts': [2],
+          'message': 'USB exclusive endpoint is available.',
+        };
+      }
+      throw PlatformException(code: 'unexpected_method');
+    });
+
+    final capability = await service.getExclusiveCapabilities();
+
+    expect(capability.available, isTrue);
+    expect(capability.permissionGranted, isTrue);
+    expect(capability.deviceName, 'iBasso Macaron');
+    expect(capability.deviceId, 31);
+    expect(capability.interfaceNumber, 1);
+    expect(capability.alternateSetting, 1);
+    expect(capability.endpointAddress, 1);
+    expect(capability.maxPacketSize, 196);
+    expect(capability.sampleRates, [44100, 48000, 96000]);
+    expect(capability.bitDepths, [16, 24, 32]);
+    expect(capability.channelCounts, [2]);
+  });
+
+  test('startExclusivePlayback sends playback request to native layer', () async {
+    final service = UsbAudioService(channel: channel, isAndroid: true);
+    Object? receivedArguments;
+
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      if (call.method == 'startExclusivePlayback') {
+        receivedArguments = call.arguments;
+        return {
+          'active': true,
+          'playing': true,
+          'positionMs': 0,
+          'durationMs': 180000,
+          'sampleRate': 44100,
+          'bitDepth': 24,
+          'format': 'flac',
+          'message': 'USB exclusive playback started.',
+        };
+      }
+      throw PlatformException(code: 'unexpected_method');
+    });
+
+    final state = await service.startExclusivePlayback(
+      const UsbExclusivePlaybackRequest(
+        filePath: '/music/test.flac',
+        title: 'Test',
+        sampleRate: 44100,
+        bitDepth: 24,
+        startPaused: false,
+      ),
+    );
+
+    expect(receivedArguments, {
+      'filePath': '/music/test.flac',
+      'title': 'Test',
+      'sampleRate': 44100,
+      'bitDepth': 24,
+      'startPaused': false,
+    });
+    expect(state.active, isTrue);
+    expect(state.playing, isTrue);
+    expect(state.position, Duration.zero);
+    expect(state.duration, const Duration(minutes: 3));
+    expect(state.sampleRate, 44100);
+    expect(state.bitDepth, 24);
+    expect(state.format, 'flac');
+    expect(usbExclusivePlaybackStateNotifier.value, state);
+  });
+
+  test('native exclusive state event updates playback notifier', () async {
+    UsbAudioService(channel: channel, isAndroid: true);
+
+    await messenger.handlePlatformMessage(
+      channel.name,
+      const StandardMethodCodec().encodeMethodCall(
+        MethodCall('onUsbExclusiveStateChanged', {
+          'active': true,
+          'playing': false,
+          'positionMs': 42000,
+          'durationMs': 240000,
+          'sampleRate': 48000,
+          'bitDepth': 24,
+          'format': 'flac',
+          'message': 'Paused.',
+        }),
+      ),
+      (_) {},
+    );
+
+    final state = usbExclusivePlaybackStateNotifier.value;
+    expect(state.active, isTrue);
+    expect(state.playing, isFalse);
+    expect(state.position, const Duration(seconds: 42));
+    expect(state.duration, const Duration(minutes: 4));
+    expect(state.sampleRate, 48000);
+    expect(state.bitDepth, 24);
+  });
 }


### PR DESCRIPTION
## Summary
- Add Android platform channels for USB DAC status, preferred mixer attributes, and SuperLyric publishing.
- Add Flutter USB audio service plus lyrics-page output chip/sheet for source/output signal details and sample-rate selection.
- Optimize vivid lyric backgrounds by replacing full-screen BackdropFilter/saveLayer usage with downsampled CoverArtWidget + ImageFiltered, with tests and performance notes.

## Tests
- flutter analyze
- flutter test
- flutter build apk --debug