### PR TITLE
feat: add clean USB exclusive playback

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -39,10 +39,37 @@ android {
 
     defaultConfig {
         applicationId = "com.afalphy.sylvakru"
-        minSdk = flutter.minSdkVersion
+        minSdk = 26
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
+
+        ndk {
+            abiFilters.add("arm64-v8a")
+        }
+
+        externalNativeBuild {
+            cmake {
+                cppFlags += listOf("-std=c++17", "-Wall", "-Wextra")
+            }
+        }
+    }
+
+    externalNativeBuild {
+        cmake {
+            path = file("src/main/cpp/CMakeLists.txt")
+            version = "3.22.1"
+        }
+    }
+
+    packaging {
+        jniLibs {
+            excludes += setOf(
+                "lib/armeabi-v7a/**",
+                "lib/x86/**",
+                "lib/x86_64/**",
+            )
+        }
     }
 
     buildTypes {
@@ -51,6 +78,11 @@ android {
         }
         debug {
             applicationIdSuffix = ".debug" 
+        }
+        maybeCreate("profile").apply {
+            initWith(getByName("debug"))
+            applicationIdSuffix = ".profile"
+            signingConfig = signingConfigs.getByName("debug")
         }
     }
 
@@ -65,4 +97,8 @@ android {
 
 flutter {
     source = "../.."
+}
+
+dependencies {
+    implementation("com.github.HChenX:SuperLyricApi:3.4")
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -41,6 +41,13 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
                 <category android:name="android.intent.category.LEANBACK_LAUNCHER"/>
             </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"/>
+            </intent-filter>
+            <meta-data
+                android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"
+                android:resource="@xml/usb_audio_device_filter"/>
         </activity>
 
         <meta-data android:name="flutterEmbedding" android:value="2" />

--- a/android/app/src/main/cpp/CMakeLists.txt
+++ b/android/app/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.22.1)
+
+project(sylvakru_usb_exclusive)
+
+add_library(
+    sylvakru_usb_exclusive
+    SHARED
+    usb_exclusive_engine.cpp
+)
+
+find_library(log-lib log)
+
+target_link_libraries(
+    sylvakru_usb_exclusive
+    ${log-lib}
+)

--- a/android/app/src/main/cpp/usb_exclusive_engine.cpp
+++ b/android/app/src/main/cpp/usb_exclusive_engine.cpp
@@ -1,0 +1,695 @@
+#include <jni.h>
+#include <android/log.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/usbdevice_fs.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr const char* kTag = "SylvakruUsbExclusive";
+constexpr int kMaxIsoPacketsPerUrb = 16;
+constexpr int kDefaultMaxPendingUrbs = 8;
+constexpr int kAbsoluteMaxPendingUrbs = 512;
+
+struct PendingUrb {
+    usbdevfs_urb* urb;
+    uint8_t* buffer;
+    int length;
+    int packets;
+    bool feedback;
+};
+
+std::mutex g_mutex;
+int g_fd = -1;
+int g_interface_number = -1;
+int g_endpoint_address = -1;
+int g_max_packet_size = 0;
+int g_iso_packet_size = 0;
+int g_feedback_endpoint_address = 0;
+int g_feedback_packet_size = 0;
+int g_feedback_frames_per_packet_q16 = 0;
+int g_feedback_log_count = 0;
+int g_write_log_count = 0;
+long long g_total_bytes = 0;
+long long g_total_urbs = 0;
+long long g_total_iso_packets = 0;
+long long g_last_stats_ms = 0;
+long long g_iso_error_count = 0;
+int g_max_pending_urbs = kDefaultMaxPendingUrbs;
+std::vector<PendingUrb> g_pending_urbs;
+
+long long monotonicMillis() {
+    timespec now = {};
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    return static_cast<long long>(now.tv_sec) * 1000LL + now.tv_nsec / 1000000LL;
+}
+
+std::string errorMessage(const char* action) {
+    return std::string(action) + " failed: " + strerror(errno);
+}
+
+jstring toJString(JNIEnv* env, const std::string& value) {
+    return env->NewStringUTF(value.c_str());
+}
+
+jstring nullableError(JNIEnv* env, const std::string& error) {
+    if (error.empty()) {
+        return nullptr;
+    }
+    __android_log_print(ANDROID_LOG_WARN, kTag, "%s", error.c_str());
+    return toJString(env, error);
+}
+
+void freePendingUrb(PendingUrb pending) {
+    free(pending.buffer);
+    free(pending.urb);
+}
+
+std::string submitFeedbackLocked();
+
+void logCompletedUrb(PendingUrb pending) {
+    if (pending.feedback) {
+        return;
+    }
+    if (pending.urb->status != 0) {
+        ++g_iso_error_count;
+        __android_log_print(
+            ANDROID_LOG_WARN,
+            kTag,
+            "URB completed with status=%d length=%d packets=%d",
+            pending.urb->status,
+            pending.length,
+            pending.packets);
+    }
+    for (int i = 0; i < pending.packets; ++i) {
+        if (pending.urb->iso_frame_desc[i].status != 0) {
+            ++g_iso_error_count;
+            __android_log_print(
+                ANDROID_LOG_WARN,
+                kTag,
+                "iso frame status=%d actual=%u requested=%u index=%d/%d",
+                pending.urb->iso_frame_desc[i].status,
+                pending.urb->iso_frame_desc[i].actual_length,
+                pending.urb->iso_frame_desc[i].length,
+                i,
+                pending.packets);
+        }
+    }
+}
+
+void handleFeedbackUrb(PendingUrb pending) {
+    if (pending.urb->status != 0 || pending.packets <= 0) {
+        if (pending.urb->status != 0) {
+            __android_log_print(
+                ANDROID_LOG_WARN,
+                kTag,
+                "feedback URB status=%d length=%d packets=%d",
+                pending.urb->status,
+                pending.length,
+                pending.packets);
+        }
+        return;
+    }
+
+    const auto& frame = pending.urb->iso_frame_desc[0];
+    if (frame.status != 0 || frame.actual_length < 3) {
+        if (frame.status != 0 && g_feedback_log_count < 8) {
+            __android_log_print(
+                ANDROID_LOG_WARN,
+                kTag,
+                "feedback frame status=%d actual=%u requested=%u",
+                frame.status,
+                frame.actual_length,
+                frame.length);
+        }
+        return;
+    }
+
+    const int actual = std::min<int>(frame.actual_length, pending.length);
+    int raw = 0;
+    for (int i = 0; i < std::min(actual, 4); ++i) {
+        raw |= static_cast<int>(pending.buffer[i]) << (i * 8);
+    }
+
+    int q16 = 0;
+    if (actual >= 4) {
+        q16 = raw;
+    } else {
+        q16 = raw << 2;
+    }
+
+    if (q16 > 0) {
+        g_feedback_frames_per_packet_q16 = q16;
+    }
+    if (g_feedback_log_count < 12) {
+        ++g_feedback_log_count;
+        __android_log_print(
+            ANDROID_LOG_INFO,
+            kTag,
+            "USB feedback actual=%d raw=0x%x framesPerPacketQ16=%d approxFrames=%.6f",
+            actual,
+            raw,
+            q16,
+            static_cast<double>(q16) / 65536.0);
+    }
+}
+
+std::string reapOneLocked(bool blocking) {
+    if (g_pending_urbs.empty()) {
+        return {};
+    }
+
+    void* completed = nullptr;
+    const int request = blocking ? USBDEVFS_REAPURB : USBDEVFS_REAPURBNDELAY;
+    if (ioctl(g_fd, request, &completed) < 0) {
+        if (!blocking && errno == EAGAIN) {
+            return {};
+        }
+        return errorMessage(blocking ? "USBDEVFS_REAPURB" : "USBDEVFS_REAPURBNDELAY");
+    }
+    auto found = std::find_if(
+        g_pending_urbs.begin(),
+        g_pending_urbs.end(),
+        [completed](const PendingUrb& pending) { return pending.urb == completed; });
+    if (found == g_pending_urbs.end()) {
+        return "USBDEVFS_REAPURB returned an unknown URB.";
+    }
+
+    const PendingUrb completed_pending = *found;
+    if (completed_pending.feedback) {
+        handleFeedbackUrb(completed_pending);
+    } else {
+        logCompletedUrb(completed_pending);
+    }
+    freePendingUrb(completed_pending);
+    g_pending_urbs.erase(found);
+    if (completed_pending.feedback && g_fd >= 0 && g_feedback_endpoint_address != 0) {
+        const auto feedback_error = submitFeedbackLocked();
+        if (!feedback_error.empty()) {
+            return feedback_error;
+        }
+    }
+    return {};
+}
+
+std::string reapCompletedLocked() {
+    std::string error;
+    while (error.empty() && !g_pending_urbs.empty()) {
+        error = reapOneLocked(false);
+        if (error.empty()) {
+            break;
+        }
+    }
+    while (error.empty() && static_cast<int>(g_pending_urbs.size()) >= g_max_pending_urbs) {
+        error = reapOneLocked(true);
+    }
+    return error;
+}
+
+void discardPendingLocked() {
+    for (const auto& pending : g_pending_urbs) {
+        ioctl(g_fd, USBDEVFS_DISCARDURB, pending.urb);
+    }
+}
+
+void freeAllPendingLocked() {
+    for (auto& pending : g_pending_urbs) {
+        freePendingUrb(pending);
+    }
+    g_pending_urbs.clear();
+}
+
+std::string claimInterfaceLocked() {
+    usbdevfs_disconnect_claim disconnect_claim = {};
+    disconnect_claim.interface = static_cast<unsigned int>(g_interface_number);
+
+    if (ioctl(g_fd, USBDEVFS_DISCONNECT_CLAIM, &disconnect_claim) == 0) {
+        __android_log_print(
+            ANDROID_LOG_INFO,
+            kTag,
+            "USBDEVFS_DISCONNECT_CLAIM ok interface=%d",
+            g_interface_number);
+        return {};
+    }
+
+    const int disconnect_claim_errno = errno;
+    __android_log_print(
+        ANDROID_LOG_WARN,
+        kTag,
+        "USBDEVFS_DISCONNECT_CLAIM failed interface=%d: %s",
+        g_interface_number,
+        strerror(disconnect_claim_errno));
+
+    if (ioctl(g_fd, USBDEVFS_CLAIMINTERFACE, &g_interface_number) == 0) {
+        __android_log_print(
+            ANDROID_LOG_INFO,
+            kTag,
+            "USBDEVFS_CLAIMINTERFACE ok interface=%d",
+            g_interface_number);
+        return {};
+    }
+
+    return errorMessage("USBDEVFS_CLAIMINTERFACE");
+}
+
+void closeLocked() {
+    if (g_fd < 0) {
+        return;
+    }
+
+    __android_log_print(
+        ANDROID_LOG_INFO,
+        kTag,
+        "closing exclusive USB fd=%d interface=%d endpoint=0x%x pendingUrbs=%zu",
+        g_fd,
+        g_interface_number,
+        g_endpoint_address,
+        g_pending_urbs.size());
+    discardPendingLocked();
+    if (g_interface_number >= 0) {
+        ioctl(g_fd, USBDEVFS_RELEASEINTERFACE, &g_interface_number);
+    }
+    close(g_fd);
+    freeAllPendingLocked();
+    g_fd = -1;
+    g_interface_number = -1;
+    g_endpoint_address = -1;
+    g_max_packet_size = 0;
+    g_iso_packet_size = 0;
+    g_feedback_endpoint_address = 0;
+    g_feedback_packet_size = 0;
+    g_feedback_frames_per_packet_q16 = 0;
+    g_feedback_log_count = 0;
+    g_write_log_count = 0;
+    g_total_bytes = 0;
+    g_total_urbs = 0;
+    g_total_iso_packets = 0;
+    g_last_stats_ms = 0;
+    g_iso_error_count = 0;
+    g_max_pending_urbs = kDefaultMaxPendingUrbs;
+}
+
+std::string submitIsoPacketsLocked(
+    const uint8_t* data,
+    int length,
+    const int* packet_lengths,
+    int packet_count) {
+    if (g_fd < 0) {
+        return "USB exclusive device is not open.";
+    }
+    if (g_endpoint_address < 0 || g_max_packet_size <= 0) {
+        return "USB exclusive endpoint is not configured.";
+    }
+    if (data == nullptr || length <= 0 || packet_lengths == nullptr || packet_count <= 0) {
+        return {};
+    }
+
+    const int packets = std::min(packet_count, kMaxIsoPacketsPerUrb);
+    int described_length = 0;
+    for (int i = 0; i < packets; ++i) {
+        if (packet_lengths[i] <= 0 || packet_lengths[i] > g_max_packet_size) {
+            return "USB exclusive iso packet length is invalid.";
+        }
+        described_length += packet_lengths[i];
+    }
+    if (described_length != length) {
+        return "USB exclusive iso packet lengths do not match PCM length.";
+    }
+
+    const size_t urb_size =
+        sizeof(usbdevfs_urb) + sizeof(usbdevfs_iso_packet_desc) * packets;
+    auto* urb = static_cast<usbdevfs_urb*>(calloc(1, urb_size));
+    auto* buffer = static_cast<uint8_t*>(malloc(length));
+    if (urb == nullptr || buffer == nullptr) {
+        free(urb);
+        free(buffer);
+        return "Failed to allocate USB isochronous transfer.";
+    }
+
+    memcpy(buffer, data, length);
+    urb->type = USBDEVFS_URB_TYPE_ISO;
+    urb->endpoint = static_cast<unsigned char>(g_endpoint_address);
+    urb->status = 0;
+    urb->flags = USBDEVFS_URB_ISO_ASAP;
+    urb->buffer = buffer;
+    urb->buffer_length = length;
+    urb->number_of_packets = packets;
+
+    for (int i = 0; i < packets; ++i) {
+        urb->iso_frame_desc[i].length = packet_lengths[i];
+    }
+
+    if (ioctl(g_fd, USBDEVFS_SUBMITURB, urb) < 0) {
+        const auto error = errorMessage("USBDEVFS_SUBMITURB");
+        free(buffer);
+        free(urb);
+        return error;
+    }
+
+    g_pending_urbs.push_back(PendingUrb{urb, buffer, length, packets, false});
+    g_total_bytes += length;
+    g_total_urbs += 1;
+    g_total_iso_packets += packets;
+    const long long now_ms = monotonicMillis();
+    if (g_last_stats_ms == 0) {
+        g_last_stats_ms = now_ms;
+    } else if (now_ms - g_last_stats_ms >= 1000) {
+        __android_log_print(
+            ANDROID_LOG_INFO,
+            kTag,
+            "USB write stats bytes=%lld urbs=%lld isoPackets=%lld pendingUrbs=%zu isoPacketSize=%d endpoint=0x%x",
+            g_total_bytes,
+            g_total_urbs,
+            g_total_iso_packets,
+            g_pending_urbs.size(),
+            g_iso_packet_size,
+            g_endpoint_address);
+        g_last_stats_ms = now_ms;
+    }
+    return reapCompletedLocked();
+}
+
+std::string submitIsoChunkLocked(const uint8_t* data, int length) {
+    const int iso_packet_size =
+        g_iso_packet_size > 0 ? std::min(g_iso_packet_size, g_max_packet_size) : g_max_packet_size;
+    const int packets = std::max(
+        1,
+        std::min(kMaxIsoPacketsPerUrb, (length + iso_packet_size - 1) / iso_packet_size));
+    int remaining = length;
+    int packet_lengths[kMaxIsoPacketsPerUrb] = {};
+    for (int i = 0; i < packets; ++i) {
+        packet_lengths[i] = std::min(iso_packet_size, remaining);
+        remaining -= packet_lengths[i];
+    }
+    return submitIsoPacketsLocked(data, length, packet_lengths, packets);
+}
+
+std::string submitFeedbackLocked() {
+    if (g_fd < 0 || g_feedback_endpoint_address == 0 || g_feedback_packet_size <= 0) {
+        return {};
+    }
+
+    const int packets = 1;
+    const int length = std::min(4, std::max(3, g_feedback_packet_size));
+    const size_t urb_size =
+        sizeof(usbdevfs_urb) + sizeof(usbdevfs_iso_packet_desc) * packets;
+    auto* urb = static_cast<usbdevfs_urb*>(calloc(1, urb_size));
+    auto* buffer = static_cast<uint8_t*>(calloc(1, length));
+    if (urb == nullptr || buffer == nullptr) {
+        free(urb);
+        free(buffer);
+        return "Failed to allocate USB feedback transfer.";
+    }
+
+    urb->type = USBDEVFS_URB_TYPE_ISO;
+    urb->endpoint = static_cast<unsigned char>(g_feedback_endpoint_address);
+    urb->status = 0;
+    urb->flags = USBDEVFS_URB_ISO_ASAP;
+    urb->buffer = buffer;
+    urb->buffer_length = length;
+    urb->number_of_packets = packets;
+    urb->iso_frame_desc[0].length = length;
+
+    if (ioctl(g_fd, USBDEVFS_SUBMITURB, urb) < 0) {
+        const auto error = errorMessage("USBDEVFS_SUBMITURB feedback");
+        free(buffer);
+        free(urb);
+        return error;
+    }
+
+    g_pending_urbs.push_back(PendingUrb{urb, buffer, length, packets, true});
+    return {};
+}
+
+}  // namespace
+
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_afalphy_sylvakru_UsbExclusiveNative_open(
+    JNIEnv* env,
+    jobject,
+    jint fd,
+    jint interface_number,
+    jint alternate_setting,
+    jint endpoint_address,
+    jint max_packet_size,
+    jint feedback_endpoint_address,
+    jint feedback_max_packet_size,
+    jboolean interface_already_claimed) {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    closeLocked();
+
+    __android_log_print(
+        ANDROID_LOG_INFO,
+        kTag,
+        "open requested fd=%d interface=%d alt=%d endpoint=0x%x maxPacket=%d",
+        fd,
+        interface_number,
+        alternate_setting,
+        endpoint_address,
+        max_packet_size);
+
+    const int duplicated = dup(fd);
+    if (duplicated < 0) {
+        return nullableError(env, errorMessage("dup"));
+    }
+
+    g_fd = duplicated;
+    g_interface_number = interface_number;
+    g_endpoint_address = endpoint_address;
+    g_max_packet_size = max_packet_size;
+    g_feedback_endpoint_address = feedback_endpoint_address;
+    g_feedback_packet_size = feedback_max_packet_size;
+
+    if (interface_already_claimed == JNI_TRUE) {
+        __android_log_print(
+            ANDROID_LOG_INFO,
+            kTag,
+            "USB interface already claimed by UsbDeviceConnection interface=%d",
+            g_interface_number);
+    } else {
+        const auto claim_error = claimInterfaceLocked();
+        if (!claim_error.empty()) {
+            closeLocked();
+            return nullableError(env, claim_error);
+        }
+    }
+
+    usbdevfs_setinterface set_interface = {};
+    set_interface.interface = interface_number;
+    set_interface.altsetting = alternate_setting;
+    if (ioctl(g_fd, USBDEVFS_SETINTERFACE, &set_interface) < 0) {
+        const auto error = errorMessage("USBDEVFS_SETINTERFACE");
+        closeLocked();
+        return nullableError(env, error);
+    }
+    __android_log_print(
+        ANDROID_LOG_INFO,
+        kTag,
+        "USBDEVFS_SETINTERFACE ok interface=%d alt=%d",
+        interface_number,
+        alternate_setting);
+
+    if (g_feedback_endpoint_address != 0 && g_feedback_packet_size > 0) {
+        const auto feedback_error = submitFeedbackLocked();
+        if (!feedback_error.empty()) {
+            __android_log_print(
+                ANDROID_LOG_WARN,
+                kTag,
+                "%s",
+                feedback_error.c_str());
+        } else {
+            __android_log_print(
+                ANDROID_LOG_INFO,
+                kTag,
+                "USB feedback endpoint armed endpoint=0x%x maxPacket=%d",
+                g_feedback_endpoint_address,
+                g_feedback_packet_size);
+        }
+    }
+
+    return nullptr;
+}
+
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_afalphy_sylvakru_UsbExclusiveNative_writePcm(
+    JNIEnv* env,
+    jobject,
+    jbyteArray bytes,
+    jint length) {
+    if (bytes == nullptr || length <= 0) {
+        return nullptr;
+    }
+
+    const jsize array_length = env->GetArrayLength(bytes);
+    const int safe_length = std::min<int>(length, array_length);
+    auto* input = reinterpret_cast<uint8_t*>(env->GetByteArrayElements(bytes, nullptr));
+    if (input == nullptr) {
+        return nullableError(env, "Failed to access PCM buffer.");
+    }
+
+    std::string error;
+    int offset = 0;
+    {
+        std::lock_guard<std::mutex> lock(g_mutex);
+        const int iso_packet_size =
+            g_iso_packet_size > 0 ? std::min(g_iso_packet_size, g_max_packet_size) : g_max_packet_size;
+        const int max_chunk = std::max(1, iso_packet_size * kMaxIsoPacketsPerUrb);
+        while (offset < safe_length && error.empty()) {
+            const int chunk = std::min(max_chunk, safe_length - offset);
+            error = submitIsoChunkLocked(input + offset, chunk);
+            offset += chunk;
+        }
+    }
+
+    env->ReleaseByteArrayElements(bytes, reinterpret_cast<jbyte*>(input), JNI_ABORT);
+    if (error.empty() && g_write_log_count < 5) {
+        ++g_write_log_count;
+        __android_log_print(
+            ANDROID_LOG_DEBUG,
+            kTag,
+            "writePcm submitted %d bytes to endpoint=0x%x isoPacket=%d",
+            safe_length,
+            g_endpoint_address,
+            g_iso_packet_size);
+    }
+    return nullableError(env, error);
+}
+
+extern "C" JNIEXPORT jstring JNICALL
+Java_com_afalphy_sylvakru_UsbExclusiveNative_writeIsoPackets(
+    JNIEnv* env,
+    jobject,
+    jbyteArray bytes,
+    jintArray packet_lengths,
+    jint packet_count) {
+    if (bytes == nullptr || packet_lengths == nullptr || packet_count <= 0) {
+        return nullptr;
+    }
+
+    const jsize array_length = env->GetArrayLength(bytes);
+    const jsize lengths_length = env->GetArrayLength(packet_lengths);
+    const int safe_packet_count = std::min<int>(
+        std::min<int>(packet_count, lengths_length),
+        kMaxIsoPacketsPerUrb);
+    if (safe_packet_count <= 0) {
+        return nullptr;
+    }
+
+    int safe_length = 0;
+    jint stack_lengths[kMaxIsoPacketsPerUrb] = {};
+    env->GetIntArrayRegion(packet_lengths, 0, safe_packet_count, stack_lengths);
+    for (int i = 0; i < safe_packet_count; ++i) {
+        if (stack_lengths[i] <= 0) {
+            return nullableError(env, "USB exclusive iso packet length is invalid.");
+        }
+        safe_length += stack_lengths[i];
+    }
+    if (safe_length > array_length) {
+        return nullableError(env, "USB exclusive iso packet data is shorter than packet lengths.");
+    }
+
+    auto* input = reinterpret_cast<uint8_t*>(env->GetByteArrayElements(bytes, nullptr));
+    if (input == nullptr) {
+        return nullableError(env, "Failed to access PCM buffer.");
+    }
+
+    std::string error;
+    {
+        std::lock_guard<std::mutex> lock(g_mutex);
+        error = submitIsoPacketsLocked(input, safe_length, stack_lengths, safe_packet_count);
+    }
+
+    env->ReleaseByteArrayElements(bytes, reinterpret_cast<jbyte*>(input), JNI_ABORT);
+    if (error.empty() && g_write_log_count < 5) {
+        ++g_write_log_count;
+        __android_log_print(
+            ANDROID_LOG_DEBUG,
+            kTag,
+            "writeIsoPackets submitted %d bytes packets=%d endpoint=0x%x",
+            safe_length,
+            safe_packet_count,
+            g_endpoint_address);
+    }
+    return nullableError(env, error);
+}
+
+extern "C" JNIEXPORT jint JNICALL
+Java_com_afalphy_sylvakru_UsbExclusiveNative_feedbackFramesPerPacketQ16(JNIEnv*, jobject) {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    return g_feedback_frames_per_packet_q16;
+}
+
+extern "C" JNIEXPORT jlongArray JNICALL
+Java_com_afalphy_sylvakru_UsbExclusiveNative_transportTelemetry(JNIEnv* env, jobject) {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    if (g_fd >= 0) {
+        reapCompletedLocked();
+    }
+
+    long long pending_iso_packets = 0;
+    long long pending_output_urbs = 0;
+    for (const auto& pending : g_pending_urbs) {
+        if (!pending.feedback) {
+            pending_iso_packets += pending.packets;
+            ++pending_output_urbs;
+        }
+    }
+
+    const jlong values[] = {
+        static_cast<jlong>(pending_iso_packets),
+        static_cast<jlong>(g_total_iso_packets),
+        static_cast<jlong>(pending_output_urbs),
+        static_cast<jlong>(g_iso_error_count),
+    };
+    jlongArray result = env->NewLongArray(4);
+    if (result != nullptr) {
+        env->SetLongArrayRegion(result, 0, 4, values);
+    }
+    return result;
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_afalphy_sylvakru_UsbExclusiveNative_setIsoPacketSize(
+    JNIEnv*,
+    jobject,
+    jint packet_size) {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    g_iso_packet_size = std::max(0, std::min(static_cast<int>(packet_size), g_max_packet_size));
+    __android_log_print(
+        ANDROID_LOG_INFO,
+        kTag,
+        "iso packet size set to %d bytes",
+        g_iso_packet_size);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_afalphy_sylvakru_UsbExclusiveNative_setMaxPendingOutputUrbs(
+    JNIEnv*,
+    jobject,
+    jint max_pending_urbs) {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    g_max_pending_urbs = std::max(
+        kDefaultMaxPendingUrbs,
+        std::min(static_cast<int>(max_pending_urbs), kAbsoluteMaxPendingUrbs));
+    __android_log_print(
+        ANDROID_LOG_INFO,
+        kTag,
+        "max pending output URBs set to %d",
+        g_max_pending_urbs);
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_afalphy_sylvakru_UsbExclusiveNative_close(JNIEnv*, jobject) {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    closeLocked();
+}

--- a/android/app/src/main/kotlin/com/afalphy/particle_music/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/afalphy/particle_music/MainActivity.kt
@@ -1,5 +1,867 @@
 package com.afalphy.sylvakru
 
+import android.annotation.TargetApi
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.media.AudioDeviceCallback
+import android.media.AudioAttributes
+import android.media.AudioDeviceInfo
+import android.media.AudioFormat
+import android.media.AudioManager
+import android.media.AudioMixerAttributes
+import android.media.AudioTrack
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import android.hardware.usb.UsbConstants
+import android.hardware.usb.UsbDevice
+import android.hardware.usb.UsbDeviceConnection
+import android.hardware.usb.UsbInterface
+import android.hardware.usb.UsbManager
+import com.hchen.superlyricapi.SuperLyricData
+import com.hchen.superlyricapi.SuperLyricHelper
+import com.hchen.superlyricapi.SuperLyricLine
+import com.hchen.superlyricapi.SuperLyricWord
 import com.ryanheise.audioservice.AudioServiceActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
 
-class MainActivity : AudioServiceActivity()
+class MainActivity : AudioServiceActivity() {
+    private val tag = "UsbExclusiveAudioEngine"
+    private val channelName = "com.afalphy.sylvakru/usb_audio"
+    private val superLyricChannelName = "com.afalphy.sylvakru/super_lyric"
+    private val usbPermissionAction = "com.afalphy.sylvakru.USB_PERMISSION"
+    private lateinit var usbAudioChannel: MethodChannel
+    private lateinit var usbExclusiveAudioEngine: UsbExclusiveAudioEngine
+    private var usbAudioDeviceCallback: AudioDeviceCallback? = null
+    private var pendingExclusiveProbeResult: MethodChannel.Result? = null
+    private var pendingExclusiveProbeDevice: UsbDevice? = null
+    private var usbPermissionReceiver: BroadcastReceiver? = null
+
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+
+        usbAudioChannel = MethodChannel(flutterEngine.dartExecutor.binaryMessenger, channelName)
+        usbExclusiveAudioEngine = UsbExclusiveAudioEngine(
+            this,
+            emitState = { state ->
+                runOnUiThread {
+                    usbAudioChannel.invokeMethod("onUsbExclusiveStateChanged", state)
+                }
+            },
+            emitTelemetry = { telemetry ->
+                runOnUiThread {
+                    usbAudioChannel.invokeMethod("onUsbTransportTelemetryChanged", telemetry)
+                }
+            },
+        )
+        usbAudioChannel.setMethodCallHandler { call, result ->
+            when (call.method) {
+                "getStatus" -> result.success(getStatus())
+                "applyPreferredOutput" -> result.success(applyPreferredOutput(call))
+                "clearPreferredOutput" -> result.success(clearPreferredOutput(call))
+                "probeExclusiveAccess" -> probeExclusiveAccess(result)
+                "getExclusiveCapabilities" -> result.success(getExclusiveCapabilities())
+                "startExclusivePlayback" -> result.success(startExclusivePlayback(call))
+                "pauseExclusivePlayback" -> result.success(usbExclusiveAudioEngine.pause())
+                "resumeExclusivePlayback" -> result.success(usbExclusiveAudioEngine.resume())
+                "setExclusiveTargetBufferMs" -> {
+                    val targetBufferMs = call.argument<Number>("targetBufferMs")?.toInt() ?: 200
+                    result.success(usbExclusiveAudioEngine.setTargetBufferMs(targetBufferMs))
+                }
+                "seekExclusivePlayback" -> {
+                    val positionMs = call.argument<Number>("positionMs")?.toLong() ?: 0L
+                    result.success(usbExclusiveAudioEngine.seek(positionMs))
+                }
+                "stopExclusivePlayback" -> result.success(usbExclusiveAudioEngine.stop())
+                "releaseExclusiveDevice" -> result.success(usbExclusiveAudioEngine.release())
+                else -> result.notImplemented()
+            }
+        }
+        registerUsbAudioDeviceCallback()
+        registerUsbPermissionReceiver()
+
+        MethodChannel(flutterEngine.dartExecutor.binaryMessenger, superLyricChannelName)
+            .setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "sendLyric" -> result.success(sendSuperLyric(call))
+                    "sendStop" -> result.success(sendSuperLyricStop())
+                    else -> result.notImplemented()
+                }
+            }
+
+        ensureSuperLyricPublisherRegistered()
+    }
+
+    override fun onDestroy() {
+        unregisterUsbPermissionReceiver()
+        unregisterUsbAudioDeviceCallback()
+        if (::usbExclusiveAudioEngine.isInitialized) {
+            usbExclusiveAudioEngine.release()
+        }
+        sendSuperLyricStop()
+        super.onDestroy()
+    }
+
+    private fun registerUsbPermissionReceiver() {
+        if (usbPermissionReceiver != null) {
+            return
+        }
+
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context, intent: Intent) {
+                if (intent.action != usbPermissionAction) {
+                    return
+                }
+
+                val result = pendingExclusiveProbeResult ?: return
+                val device = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    intent.getParcelableExtra(UsbManager.EXTRA_DEVICE, UsbDevice::class.java)
+                } else {
+                    @Suppress("DEPRECATION")
+                    intent.getParcelableExtra(UsbManager.EXTRA_DEVICE)
+                } ?: pendingExclusiveProbeDevice
+                val granted = intent.getBooleanExtra(UsbManager.EXTRA_PERMISSION_GRANTED, false)
+
+                pendingExclusiveProbeResult = null
+                pendingExclusiveProbeDevice = null
+
+                if (device == null || !granted) {
+                    result.success(
+                        exclusiveProbeResult(
+                            supported = device != null,
+                            permissionGranted = false,
+                            device = device,
+                            audioInterfaceCount = device?.audioInterfaceCount() ?: 0,
+                            claimedInterfaceCount = 0,
+                            rawDescriptorLength = 0,
+                            message = "USB permission was denied.",
+                        ),
+                    )
+                    return
+                }
+
+                result.success(runExclusiveProbe(device))
+            }
+        }
+
+        val filter = IntentFilter(usbPermissionAction)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            registerReceiver(receiver, filter, Context.RECEIVER_NOT_EXPORTED)
+        } else {
+            @Suppress("DEPRECATION")
+            registerReceiver(receiver, filter)
+        }
+        usbPermissionReceiver = receiver
+    }
+
+    private fun unregisterUsbPermissionReceiver() {
+        val receiver = usbPermissionReceiver ?: return
+        unregisterReceiver(receiver)
+        usbPermissionReceiver = null
+    }
+
+    private fun registerUsbAudioDeviceCallback() {
+        if (usbAudioDeviceCallback != null) {
+            return
+        }
+
+        val audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
+        val callback = object : AudioDeviceCallback() {
+            override fun onAudioDevicesAdded(addedDevices: Array<out AudioDeviceInfo>) {
+                addedDevices
+                    .filter { it.isUsbAudioOutput() }
+                    .forEach { device -> sendUsbAudioDeviceEvent("added", device.id) }
+            }
+
+            override fun onAudioDevicesRemoved(removedDevices: Array<out AudioDeviceInfo>) {
+                removedDevices
+                    .filter { it.isUsbAudioOutput() }
+                    .forEach { device -> sendUsbAudioDeviceEvent("removed", device.id) }
+            }
+        }
+
+        audioManager.registerAudioDeviceCallback(callback, Handler(Looper.getMainLooper()))
+        usbAudioDeviceCallback = callback
+    }
+
+    private fun unregisterUsbAudioDeviceCallback() {
+        val callback = usbAudioDeviceCallback ?: return
+        val audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
+        audioManager.unregisterAudioDeviceCallback(callback)
+        usbAudioDeviceCallback = null
+    }
+
+    private fun sendUsbAudioDeviceEvent(type: String, deviceId: Int) {
+        runOnUiThread {
+            usbAudioChannel.invokeMethod(
+                "onUsbAudioDeviceEvent",
+                mapOf(
+                    "type" to type,
+                    "deviceId" to deviceId,
+                    "status" to getStatus(),
+                ),
+            )
+        }
+    }
+
+    private fun probeExclusiveAccess(result: MethodChannel.Result) {
+        val usbManager = getSystemService(Context.USB_SERVICE) as UsbManager
+        val device = findUsbAudioDevice(usbManager)
+        if (device == null) {
+            Log.i(tag, "probeExclusiveAccess: no USB Audio Class device found.")
+            result.success(
+                exclusiveProbeResult(
+                    supported = false,
+                    permissionGranted = false,
+                    device = null,
+                    audioInterfaceCount = 0,
+                    claimedInterfaceCount = 0,
+                    rawDescriptorLength = 0,
+                    message = "No USB Audio Class device was found.",
+                ),
+            )
+            return
+        }
+
+        if (!usbManager.hasPermission(device)) {
+            Log.i(tag, "probeExclusiveAccess: requesting USB permission for ${device.debugLabel()}.")
+            if (pendingExclusiveProbeResult != null) {
+                result.success(
+                    exclusiveProbeResult(
+                        supported = true,
+                        permissionGranted = false,
+                        device = device,
+                        audioInterfaceCount = device.audioInterfaceCount(),
+                        claimedInterfaceCount = 0,
+                        rawDescriptorLength = 0,
+                        message = "USB permission request is already pending.",
+                    ),
+                )
+                return
+            }
+
+            pendingExclusiveProbeResult = result
+            pendingExclusiveProbeDevice = device
+            val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                PendingIntent.FLAG_MUTABLE
+            } else {
+                0
+            }
+            val permissionIntent = PendingIntent.getBroadcast(
+                this,
+                0,
+                Intent(usbPermissionAction).setPackage(packageName),
+                flags,
+            )
+            usbManager.requestPermission(device, permissionIntent)
+            return
+        }
+
+        Log.i(tag, "probeExclusiveAccess: permission already granted for ${device.debugLabel()}.")
+        result.success(runExclusiveProbe(device))
+    }
+
+    private fun runExclusiveProbe(device: UsbDevice): Map<String, Any?> {
+        val usbManager = getSystemService(Context.USB_SERVICE) as UsbManager
+        val audioInterfaces = device.audioInterfaces()
+        Log.i(
+            tag,
+            "runExclusiveProbe: opening ${device.debugLabel()}, audioInterfaces=${audioInterfaces.size}.",
+        )
+        val connection = usbManager.openDevice(device)
+            ?: return exclusiveProbeResult(
+                supported = true,
+                permissionGranted = true,
+                device = device,
+                audioInterfaceCount = audioInterfaces.size,
+                claimedInterfaceCount = 0,
+                rawDescriptorLength = 0,
+                message = "Failed to open USB device.",
+            )
+                .also { Log.w(tag, "runExclusiveProbe: openDevice failed for ${device.debugLabel()}.") }
+
+        return connection.useConnection {
+            val claimed = mutableListOf<UsbInterface>()
+            var rawDescriptorLength = 0
+            try {
+                rawDescriptorLength = connection.rawDescriptors?.size ?: 0
+                for (usbInterface in audioInterfaces) {
+                    if (connection.claimInterface(usbInterface, true)) {
+                        claimed.add(usbInterface)
+                        Log.i(
+                            tag,
+                            "runExclusiveProbe: claimInterface ok id=${usbInterface.id}, " +
+                                "class=${usbInterface.interfaceClass}, alt=${usbInterface.alternateSetting}.",
+                        )
+                    } else {
+                        Log.w(
+                            tag,
+                            "runExclusiveProbe: claimInterface failed id=${usbInterface.id}, " +
+                                "class=${usbInterface.interfaceClass}, alt=${usbInterface.alternateSetting}.",
+                        )
+                    }
+                }
+                exclusiveProbeResult(
+                    supported = true,
+                    permissionGranted = true,
+                    device = device,
+                    audioInterfaceCount = audioInterfaces.size,
+                    claimedInterfaceCount = claimed.size,
+                    rawDescriptorLength = rawDescriptorLength,
+                    message = if (claimed.isNotEmpty()) {
+                        "USB Audio interface can be claimed."
+                    } else {
+                        "USB Audio interface was found but could not be claimed."
+                    },
+                )
+            } catch (error: RuntimeException) {
+                exclusiveProbeResult(
+                    supported = true,
+                    permissionGranted = true,
+                    device = device,
+                    audioInterfaceCount = audioInterfaces.size,
+                    claimedInterfaceCount = claimed.size,
+                    rawDescriptorLength = rawDescriptorLength,
+                    message = "USB exclusive probe failed: ${error.message}",
+                )
+            } finally {
+                claimed.forEach { connection.releaseInterface(it) }
+            }
+        }
+    }
+
+    private inline fun UsbDeviceConnection.useConnection(
+        block: () -> Map<String, Any?>,
+    ): Map<String, Any?> {
+        return try {
+            block()
+        } finally {
+            close()
+        }
+    }
+
+    private fun findUsbAudioDevice(usbManager: UsbManager): UsbDevice? {
+        val devices = usbManager.deviceList.values.toList()
+        Log.i(
+            tag,
+            "enumerating USB devices count=${devices.size}: " +
+                devices.joinToString { it.debugLabel() },
+        )
+        val device = devices.firstOrNull { it.audioInterfaceCount() > 0 }
+        Log.i(tag, "selected USB Audio device=${device?.debugLabel() ?: "none"}.")
+        return device
+    }
+
+    private fun getExclusiveCapabilities(): Map<String, Any?> {
+        val usbManager = getSystemService(Context.USB_SERVICE) as UsbManager
+        val device = findUsbAudioDevice(usbManager)
+        val capabilities = usbExclusiveAudioEngine.capabilities(
+            usbManager,
+            device,
+        )
+        Log.i(tag, "getExclusiveCapabilities: $capabilities")
+        return capabilities
+    }
+
+    private fun startExclusivePlayback(call: MethodCall): Map<String, Any?> {
+        val usbManager = getSystemService(Context.USB_SERVICE) as UsbManager
+        val device = findUsbAudioDevice(usbManager)
+        Log.i(
+            tag,
+            "startExclusivePlayback: device=${device?.debugLabel() ?: "none"}, " +
+                "arguments=${call.argumentsMap()}",
+        )
+        return usbExclusiveAudioEngine.start(
+            usbManager,
+            device,
+            call.argumentsMap(),
+        )
+    }
+
+    private fun MethodCall.argumentsMap(): Map<String, Any?> {
+        val raw = arguments as? Map<*, *> ?: return emptyMap()
+        return raw.entries.associate { (key, value) -> key.toString() to value }
+    }
+
+    private fun UsbDevice.audioInterfaces(): List<UsbInterface> {
+        val interfaces = mutableListOf<UsbInterface>()
+        for (index in 0 until interfaceCount) {
+            val usbInterface = getInterface(index)
+            if (usbInterface.interfaceClass == UsbConstants.USB_CLASS_AUDIO) {
+                interfaces.add(usbInterface)
+            }
+        }
+        return interfaces
+    }
+
+    private fun UsbDevice.audioInterfaceCount(): Int {
+        return audioInterfaces().size
+    }
+
+    private fun UsbDevice.debugLabel(): String {
+        return "name=${productName ?: deviceName}, vendor=$vendorId, product=$productId, " +
+            "id=$deviceId, interfaces=$interfaceCount, audioInterfaces=${audioInterfaceCount()}"
+    }
+
+    private fun exclusiveProbeResult(
+        supported: Boolean,
+        permissionGranted: Boolean,
+        device: UsbDevice?,
+        audioInterfaceCount: Int,
+        claimedInterfaceCount: Int,
+        rawDescriptorLength: Int,
+        message: String,
+    ): Map<String, Any?> {
+        return mapOf(
+            "supported" to supported,
+            "permissionGranted" to permissionGranted,
+            "deviceName" to device?.productName,
+            "deviceId" to device?.deviceId,
+            "audioInterfaceCount" to audioInterfaceCount,
+            "claimedInterfaceCount" to claimedInterfaceCount,
+            "rawDescriptorLength" to rawDescriptorLength,
+            "message" to message,
+        )
+    }
+
+    private fun sendSuperLyric(call: MethodCall): Boolean {
+        val lyric = call.argument<String>("lyric")?.trim().orEmpty()
+        if (lyric.isEmpty()) {
+            return sendSuperLyricStop()
+        }
+
+        val startTime = call.argument<Number>("startTime")?.toLong() ?: 0L
+        val endTime = call.argument<Number>("endTime")?.toLong() ?: startTime
+        val words = parseSuperLyricWords(call.argument<List<Any?>>("tokens"))
+
+        return runSuperLyricAction("sendLyric") {
+            SuperLyricHelper.sendLyric(
+                SuperLyricData().setLyric(
+                    if (words.isNotEmpty()) {
+                        SuperLyricLine(lyric, words.toTypedArray(), startTime, endTime)
+                    } else if (endTime > startTime) {
+                        SuperLyricLine(lyric, startTime, endTime)
+                    } else {
+                        SuperLyricLine(lyric)
+                    },
+                ),
+            )
+        }
+    }
+
+    private fun parseSuperLyricWords(tokens: List<Any?>?): List<SuperLyricWord> {
+        return tokens
+            ?.mapNotNull { token ->
+                val map = token as? Map<*, *> ?: return@mapNotNull null
+                val text = map["text"] as? String ?: return@mapNotNull null
+                if (text.isEmpty()) return@mapNotNull null
+
+                val startTime = (map["startTime"] as? Number)?.toLong() ?: return@mapNotNull null
+                val endTime = (map["endTime"] as? Number)?.toLong() ?: return@mapNotNull null
+                SuperLyricWord(text, startTime, endTime)
+            }
+            .orEmpty()
+    }
+
+    private fun sendSuperLyricStop(): Boolean {
+        return runSuperLyricAction("sendStop") {
+            SuperLyricHelper.sendStop(SuperLyricData())
+        }
+    }
+
+    private fun runSuperLyricAction(actionName: String, action: () -> Unit): Boolean {
+        if (!ensureSuperLyricPublisherRegistered()) {
+            return false
+        }
+
+        return try {
+            action()
+            true
+        } catch (error: Throwable) {
+            Log.w("MainActivity", "SuperLyric $actionName failed.", error)
+            false
+        }
+    }
+
+    private fun ensureSuperLyricPublisherRegistered(): Boolean {
+        return try {
+            if (!SuperLyricHelper.isAvailable()) {
+                return false
+            }
+
+            if (!SuperLyricHelper.isPublisherRegistered()) {
+                SuperLyricHelper.registerPublisher()
+            }
+            true
+        } catch (error: Throwable) {
+            Log.w("MainActivity", "SuperLyric service is unavailable.", error)
+            false
+        }
+    }
+
+    private fun getStatus(
+        preferredApplied: Boolean = false,
+        message: String? = null,
+    ): Map<String, Any?> {
+        val audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
+        val devices = getUsbAudioDevices(audioManager)
+        val activeDevice = getActiveUsbAudioDevice(audioManager, devices)
+        val outputDevice = activeDevice ?: getActiveOutputDevice(audioManager)
+        val preferredMixerAttributes = if (
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE &&
+            activeDevice != null
+        ) {
+            getPreferredMixerAttributes(audioManager, activeDevice)
+        } else {
+            null
+        }
+
+        return mapOf(
+            "supported" to devices.isNotEmpty(),
+            "androidSdk" to Build.VERSION.SDK_INT,
+            "activeDeviceId" to activeDevice?.id,
+            "preferredApplied" to preferredApplied,
+            "preferredSampleRate" to preferredMixerAttributes?.format?.sampleRate,
+            "preferredEncoding" to preferredMixerAttributes?.format?.encoding?.let {
+                encodingName(it)
+            },
+            "preferredBitPerfect" to (
+                preferredMixerAttributes?.mixerBehavior ==
+                    AudioMixerAttributes.MIXER_BEHAVIOR_BIT_PERFECT
+                ),
+            "outputDeviceName" to outputDevice?.productName?.toString(),
+            "outputSampleRate" to outputSampleRate(outputDevice),
+            "outputEncoding" to outputEncoding(outputDevice),
+            "message" to (message ?: defaultStatusMessage(devices)),
+            "devices" to devices.map { it.toMap(audioManager) },
+        )
+    }
+
+    private fun applyPreferredOutput(call: MethodCall): Map<String, Any?> {
+        val audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
+        val devices = getUsbAudioDevices(audioManager)
+        val device = findRequestedDevice(audioManager, devices, call.argument<Int>("deviceId"))
+            ?: return getStatus(message = "No USB audio output device detected.")
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            return getStatus(
+                message = "USB mixer attributes require Android 14 or newer.",
+            )
+        }
+
+        return applyPreferredOutputApi34(audioManager, device, call)
+    }
+
+    private fun clearPreferredOutput(call: MethodCall): Map<String, Any?> {
+        val audioManager = getSystemService(Context.AUDIO_SERVICE) as AudioManager
+        val devices = getUsbAudioDevices(audioManager)
+        val device = findRequestedDevice(audioManager, devices, call.argument<Int>("deviceId"))
+            ?: return getStatus(message = "No USB audio output device detected.")
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            return getStatus(
+                message = "USB mixer attributes require Android 14 or newer.",
+            )
+        }
+
+        val cleared = clearPreferredOutputApi34(audioManager, device)
+        return getStatus(
+            preferredApplied = false,
+            message = if (cleared) {
+                "Cleared preferred USB mixer attributes."
+            } else {
+                "No preferred USB mixer attributes were cleared."
+            },
+        )
+    }
+
+    @TargetApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    private fun applyPreferredOutputApi34(
+        audioManager: AudioManager,
+        device: AudioDeviceInfo,
+        call: MethodCall,
+    ): Map<String, Any?> {
+        val requestedSampleRate = call.argument<Int>("sampleRate")
+        if (requestedSampleRate != null && !isValidMixerSampleRate(requestedSampleRate)) {
+            return getStatus(
+                message = "Skipped preferred USB mixer attributes: Android rejected sample rate $requestedSampleRate.",
+            )
+        }
+        val sampleRate = requestedSampleRate
+            ?: chooseSampleRate(audioManager, device)
+            ?: 48000
+        val encoding = encodingFromName(
+            call.argument<String>("encoding") ?: "pcm_24bit_packed",
+        )
+        val bitPerfect = call.argument<Boolean>("bitPerfect") ?: true
+
+        return try {
+            Log.i(tag, "applyPreferredOutputApi34: requesting sampleRate=$sampleRate, encoding=$encoding.")
+            val format = AudioFormat.Builder()
+                .setSampleRate(sampleRate)
+                .setEncoding(encoding)
+                .setChannelMask(AudioFormat.CHANNEL_OUT_STEREO)
+                .build()
+            val mixerAttributes = AudioMixerAttributes.Builder(format)
+                .setMixerBehavior(
+                    if (bitPerfect) {
+                        AudioMixerAttributes.MIXER_BEHAVIOR_BIT_PERFECT
+                    } else {
+                        AudioMixerAttributes.MIXER_BEHAVIOR_DEFAULT
+                    },
+                )
+                .build()
+            val applied = audioManager.setPreferredMixerAttributes(
+                mediaAudioAttributes(),
+                device,
+                mixerAttributes,
+            )
+            getStatus(
+                preferredApplied = applied,
+                message = if (applied) {
+                    "Applied preferred USB mixer attributes."
+                } else {
+                    "Device rejected preferred USB mixer attributes."
+                },
+            )
+        } catch (error: RuntimeException) {
+            getStatus(message = "Failed to apply USB mixer attributes: ${error.message}")
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    private fun clearPreferredOutputApi34(
+        audioManager: AudioManager,
+        device: AudioDeviceInfo,
+    ): Boolean {
+        return try {
+            audioManager.clearPreferredMixerAttributes(mediaAudioAttributes(), device)
+        } catch (_: RuntimeException) {
+            false
+        }
+    }
+
+    private fun getUsbAudioDevices(audioManager: AudioManager): List<AudioDeviceInfo> {
+        return audioManager
+            .getDevices(AudioManager.GET_DEVICES_OUTPUTS)
+            .filter { it.isUsbAudioOutput() }
+    }
+
+    private fun getActiveUsbAudioDevice(
+        audioManager: AudioManager,
+        devices: List<AudioDeviceInfo>,
+    ): AudioDeviceInfo? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            return null
+        }
+
+        val activeDevices = audioManager.getAudioDevicesForAttributes(mediaAudioAttributes())
+        return activeDevices.firstOrNull { active ->
+            devices.any { it.id == active.id }
+        }
+    }
+
+    private fun getActiveOutputDevice(audioManager: AudioManager): AudioDeviceInfo? {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            audioManager
+                .getAudioDevicesForAttributes(mediaAudioAttributes())
+                .firstOrNull()
+                ?.let { return it }
+        }
+
+        return audioManager
+            .getDevices(AudioManager.GET_DEVICES_OUTPUTS)
+            .firstOrNull { it.type == AudioDeviceInfo.TYPE_BUILTIN_SPEAKER }
+            ?: audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS).firstOrNull()
+    }
+
+    private fun outputSampleRate(device: AudioDeviceInfo?): Int? {
+        chooseStableSampleRate(device?.sampleRates?.toList().orEmpty())?.let { return it }
+        return AudioTrack
+            .getNativeOutputSampleRate(AudioManager.STREAM_MUSIC)
+            .takeIf { it > 0 }
+    }
+
+    private fun outputEncoding(device: AudioDeviceInfo?): String? {
+        return device
+            ?.encodings
+            ?.firstOrNull { it == AudioFormat.ENCODING_PCM_16BIT }
+            ?.let { encodingName(it) }
+            ?: device?.encodings?.firstOrNull()?.let { encodingName(it) }
+    }
+
+    private fun isValidMixerSampleRate(sampleRate: Int): Boolean {
+        return sampleRate in 4000..192000
+    }
+
+    private fun findRequestedDevice(
+        audioManager: AudioManager,
+        devices: List<AudioDeviceInfo>,
+        requestedDeviceId: Int?,
+    ): AudioDeviceInfo? {
+        if (requestedDeviceId != null) {
+            return devices.firstOrNull { it.id == requestedDeviceId }
+        }
+        return getActiveUsbAudioDevice(audioManager, devices) ?: devices.firstOrNull()
+    }
+
+    @TargetApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    private fun chooseSampleRate(
+        audioManager: AudioManager,
+        device: AudioDeviceInfo,
+    ): Int? {
+        val mixerSampleRates = getSupportedMixerSampleRates(audioManager, device)
+        val rates = if (mixerSampleRates.isNotEmpty()) {
+            mixerSampleRates
+        } else {
+            device.sampleRates.toList()
+        }
+        return chooseStableSampleRate(rates)
+    }
+
+    private fun chooseStableSampleRate(rates: List<Int>): Int? {
+        if (rates.isEmpty()) {
+            return null
+        }
+        val validRates = rates.filter { isValidMixerSampleRate(it) }.toSet()
+        for (rate in listOf(48000, 44100, 96000, 88200, 192000, 176400)) {
+            if (validRates.contains(rate)) {
+                return rate
+            }
+        }
+        return validRates.maxOrNull()
+    }
+
+    private fun mediaAudioAttributes(): AudioAttributes {
+        return AudioAttributes.Builder()
+            .setUsage(AudioAttributes.USAGE_MEDIA)
+            .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+            .build()
+    }
+
+    private fun defaultStatusMessage(devices: List<AudioDeviceInfo>): String {
+        return if (devices.isEmpty()) {
+            "No USB audio output device detected."
+        } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            "USB audio device detected. Preferred mixer attributes require Android 14 or newer."
+        } else {
+            "USB audio device detected."
+        }
+    }
+
+    private fun AudioDeviceInfo.isUsbAudioOutput(): Boolean {
+        return type == AudioDeviceInfo.TYPE_USB_DEVICE ||
+            type == AudioDeviceInfo.TYPE_USB_HEADSET ||
+            type == AudioDeviceInfo.TYPE_USB_ACCESSORY
+    }
+
+    private fun AudioDeviceInfo.toMap(audioManager: AudioManager): Map<String, Any?> {
+        return mapOf(
+            "id" to id,
+            "name" to productName.toString(),
+            "type" to audioDeviceTypeName(type),
+            "address" to address,
+            "sampleRates" to sampleRates.toList(),
+            "encodings" to encodings.map { encodingName(it) },
+            "channelCounts" to channelCounts.toList(),
+            "supportedMixerSampleRates" to if (
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+            ) {
+                getSupportedMixerSampleRates(audioManager, this)
+            } else {
+                emptyList()
+            },
+            "supportsBitPerfectMixer" to if (
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+            ) {
+                supportsBitPerfectMixer(audioManager, this)
+            } else {
+                false
+            },
+        )
+    }
+
+    @TargetApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    private fun getSupportedMixerSampleRates(
+        audioManager: AudioManager,
+        device: AudioDeviceInfo,
+    ): List<Int> {
+        return try {
+            audioManager
+                .getSupportedMixerAttributes(device)
+                .map { it.format.sampleRate }
+                .filter { it > 0 }
+                .distinct()
+                .sorted()
+        } catch (_: RuntimeException) {
+            emptyList()
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    private fun supportsBitPerfectMixer(
+        audioManager: AudioManager,
+        device: AudioDeviceInfo,
+    ): Boolean {
+        return try {
+            audioManager
+                .getSupportedMixerAttributes(device)
+                .any { it.mixerBehavior == AudioMixerAttributes.MIXER_BEHAVIOR_BIT_PERFECT }
+        } catch (_: RuntimeException) {
+            false
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    private fun getPreferredMixerAttributes(
+        audioManager: AudioManager,
+        device: AudioDeviceInfo,
+    ): AudioMixerAttributes? {
+        return try {
+            audioManager.getPreferredMixerAttributes(mediaAudioAttributes(), device)
+        } catch (_: RuntimeException) {
+            null
+        }
+    }
+
+    private fun audioDeviceTypeName(type: Int): String {
+        return when (type) {
+            AudioDeviceInfo.TYPE_USB_DEVICE -> "usb_device"
+            AudioDeviceInfo.TYPE_USB_HEADSET -> "usb_headset"
+            AudioDeviceInfo.TYPE_USB_ACCESSORY -> "usb_accessory"
+            AudioDeviceInfo.TYPE_BUILTIN_SPEAKER -> "builtin_speaker"
+            AudioDeviceInfo.TYPE_BLUETOOTH_A2DP -> "bluetooth_a2dp"
+            AudioDeviceInfo.TYPE_BLUETOOTH_SCO -> "bluetooth_sco"
+            AudioDeviceInfo.TYPE_WIRED_HEADPHONES -> "wired_headphones"
+            AudioDeviceInfo.TYPE_WIRED_HEADSET -> "wired_headset"
+            else -> "unknown"
+        }
+    }
+
+    private fun encodingName(encoding: Int): String {
+        return when (encoding) {
+            AudioFormat.ENCODING_PCM_8BIT -> "pcm_8bit"
+            AudioFormat.ENCODING_PCM_16BIT -> "pcm_16bit"
+            AudioFormat.ENCODING_PCM_24BIT_PACKED -> "pcm_24bit_packed"
+            AudioFormat.ENCODING_PCM_32BIT -> "pcm_32bit"
+            AudioFormat.ENCODING_PCM_FLOAT -> "pcm_float"
+            else -> "encoding_$encoding"
+        }
+    }
+
+    private fun encodingFromName(name: String): Int {
+        return when (name) {
+            "pcm_8bit" -> AudioFormat.ENCODING_PCM_8BIT
+            "pcm_16bit" -> AudioFormat.ENCODING_PCM_16BIT
+            "pcm_32bit" -> AudioFormat.ENCODING_PCM_32BIT
+            "pcm_float" -> AudioFormat.ENCODING_PCM_FLOAT
+            else -> AudioFormat.ENCODING_PCM_24BIT_PACKED
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/afalphy/particle_music/UsbExclusiveAudioEngine.kt
+++ b/android/app/src/main/kotlin/com/afalphy/particle_music/UsbExclusiveAudioEngine.kt
@@ -1,0 +1,1637 @@
+package com.afalphy.sylvakru
+
+import android.content.Context
+import android.hardware.usb.UsbConstants
+import android.hardware.usb.UsbDevice
+import android.hardware.usb.UsbDeviceConnection
+import android.hardware.usb.UsbEndpoint
+import android.hardware.usb.UsbInterface
+import android.hardware.usb.UsbManager
+import android.media.MediaCodec
+import android.media.MediaExtractor
+import android.media.MediaFormat
+import android.os.Build
+import android.os.SystemClock
+import android.util.Log
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.nio.ByteBuffer
+import java.util.Locale
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+
+object UsbExclusiveNative {
+    init {
+        System.loadLibrary("sylvakru_usb_exclusive")
+    }
+
+    external fun open(
+        fd: Int,
+        interfaceNumber: Int,
+        alternateSetting: Int,
+        endpointAddress: Int,
+        maxPacketSize: Int,
+        feedbackEndpointAddress: Int,
+        feedbackMaxPacketSize: Int,
+        interfaceAlreadyClaimed: Boolean,
+    ): String?
+
+    external fun writePcm(bytes: ByteArray, length: Int): String?
+
+    external fun writeIsoPackets(bytes: ByteArray, packetLengths: IntArray, packetCount: Int): String?
+
+    external fun setIsoPacketSize(packetSize: Int)
+
+    external fun feedbackFramesPerPacketQ16(): Int
+
+    external fun transportTelemetry(): LongArray
+
+    external fun setMaxPendingOutputUrbs(maxPendingUrbs: Int)
+
+    external fun close()
+}
+
+private const val NATIVE_USB_EXCLUSIVE_STREAMING_ENABLED = true
+private const val NATIVE_USB_EXCLUSIVE_DISABLED_MESSAGE =
+    "真独占 USB 流式输出暂未启用，已回退到系统 USB 输出。"
+private const val USB_RECIP_INTERFACE = 0x01
+private const val USB_RECIP_ENDPOINT = 0x02
+
+class UsbExclusiveAudioEngine(
+    private val context: Context,
+    private val emitState: (Map<String, Any?>) -> Unit,
+    private val emitTelemetry: (Map<String, Any?>) -> Unit,
+) {
+    private val tag = "UsbExclusiveAudioEngine"
+    private var worker: Thread? = null
+    private var connection: UsbDeviceConnection? = null
+    private val paused = AtomicBoolean(false)
+    private val stopped = AtomicBoolean(false)
+    private val pendingSeekMs = AtomicLong(-1L)
+
+    @Volatile private var currentState = inactiveState()
+    private var targetBufferMs = 200
+    private var minimumBufferLevelMs: Long? = null
+    private var lastTelemetryEmitMs = 0L
+    private var lastTelemetryBufferMs: Long? = null
+    private var zeroBufferUnderruns = 0L
+    private var activePacketsPerSecond = 0
+
+    fun capabilities(usbManager: UsbManager, device: UsbDevice?): Map<String, Any?> {
+        if (!NATIVE_USB_EXCLUSIVE_STREAMING_ENABLED) {
+            return capability(
+                available = false,
+                permissionGranted = device?.let { usbManager.hasPermission(it) } ?: false,
+                device = device,
+                target = null,
+                message = NATIVE_USB_EXCLUSIVE_DISABLED_MESSAGE,
+            )
+        }
+
+        if (device == null) {
+            return capability(
+                available = false,
+                permissionGranted = false,
+                device = null,
+                target = null,
+                message = "No USB Audio Class output endpoint was found.",
+            )
+        }
+
+        val target = findOutputTarget(device)
+        return capability(
+            available = target != null,
+            permissionGranted = usbManager.hasPermission(device),
+            device = device,
+            target = target,
+            message = if (target != null) {
+                "USB exclusive endpoint is available."
+            } else {
+                "USB Audio device was found, but no isochronous OUT endpoint was exposed."
+            },
+        )
+    }
+
+    fun start(
+        usbManager: UsbManager,
+        device: UsbDevice?,
+        arguments: Map<String, Any?>,
+    ): Map<String, Any?> {
+        stop()
+
+        if (!NATIVE_USB_EXCLUSIVE_STREAMING_ENABLED) {
+            return updateState(inactiveState(NATIVE_USB_EXCLUSIVE_DISABLED_MESSAGE))
+        }
+
+        if (device == null) {
+            return updateState(inactiveState("No USB Audio Class device was found."))
+        }
+        if (!usbManager.hasPermission(device)) {
+            return updateState(inactiveState("USB permission is required before exclusive playback."))
+        }
+
+        val filePath = arguments["filePath"] as? String
+        val sourceFormat = (arguments["sourceFormat"] as? String)
+            ?.lowercase(Locale.ROOT)
+            ?.trim()
+            ?.takeIf { it.isNotEmpty() }
+        if (filePath.isNullOrBlank()) {
+            return updateState(inactiveState("Exclusive playback requires a local audio file path."))
+        }
+
+        val file = File(filePath)
+        if (!file.exists()) {
+            return updateState(inactiveState("Exclusive playback file does not exist: $filePath"))
+        }
+        Log.i(
+            tag,
+            "start exclusive playback file=${file.name}, sourceFormat=$sourceFormat, size=${file.length()}",
+        )
+
+        if (!isSupportedFile(filePath, sourceFormat)) {
+            return updateState(inactiveState("Exclusive playback currently supports FLAC and WAV only."))
+        }
+
+        val requestedSampleRate = (arguments["sampleRate"] as? Number)?.toInt()
+        val requestedBitDepth = (arguments["bitDepth"] as? Number)?.toInt()
+        targetBufferMs = ((arguments["targetBufferMs"] as? Number)?.toInt() ?: 200).coerceIn(50, 5000)
+        minimumBufferLevelMs = null
+        lastTelemetryEmitMs = 0L
+        lastTelemetryBufferMs = null
+        zeroBufferUnderruns = 0L
+        activePacketsPerSecond = 0
+        val requestedChannels = 2
+        val openedConnection = usbManager.openDevice(device)
+            ?: return updateState(inactiveState("Failed to open USB device for exclusive playback."))
+        val descriptors = openedConnection.rawDescriptors
+        val streamingFormats = parseStreamingFormatInfo(descriptors)
+        val target = findOutputTarget(
+            device,
+            streamingFormats = streamingFormats,
+            sampleRate = requestedSampleRate,
+            channels = requestedChannels,
+            bitDepth = requestedBitDepth,
+        )
+            ?: run {
+                openedConnection.close()
+                return updateState(inactiveState("No isochronous USB Audio OUT endpoint was found."))
+            }
+        Log.i(
+            tag,
+            "exclusive target interface=${target.usbInterface.id}, alt=${target.alternateSetting}, " +
+                "endpoint=0x${target.endpoint.address.toString(16)}, maxPacket=${target.endpoint.maxPacketSize}, " +
+                "feedback=${target.feedbackEndpointLabel}, " +
+                "requestedSampleRate=$requestedSampleRate, requestedBitDepth=${requestedBitDepth ?: "auto"}, " +
+                "usbFormat=${target.formatInfo}",
+        )
+
+        val openError = UsbExclusiveNative.open(
+            openedConnection.fileDescriptor,
+            target.usbInterface.id,
+            target.alternateSetting,
+            target.endpoint.address,
+            target.endpoint.maxPacketSize,
+            target.feedbackEndpoint?.address ?: 0,
+            target.feedbackEndpoint?.maxPacketSize ?: 0,
+            false,
+        )
+        if (openError != null) {
+            openedConnection.close()
+            return updateState(inactiveState(openError))
+        }
+        Log.i(tag, "native USB exclusive endpoint opened.")
+
+        if (requestedSampleRate != null) {
+            configureUsbAudioClock(openedConnection, device, target, requestedSampleRate)
+        }
+
+        connection = openedConnection
+        paused.set(arguments["startPaused"] == true)
+        stopped.set(false)
+        pendingSeekMs.set(-1L)
+
+        val initialState = mapOf(
+            "active" to true,
+            "playing" to !paused.get(),
+            "positionMs" to 0,
+            "durationMs" to null,
+            "sampleRate" to arguments["sampleRate"],
+            "bitDepth" to arguments["bitDepth"],
+            "format" to (sourceFormat ?: file.extension.lowercase(Locale.ROOT)),
+            "message" to "USB exclusive playback prepared.",
+        )
+        updateState(initialState)
+        emitTransportTelemetry(target.packetsPerSecond, force = true)
+
+        worker = Thread({
+            decodeAndWrite(file, target)
+        }, "SylvakruUsbExclusive")
+        worker?.start()
+        return currentState
+    }
+
+    fun pause(): Map<String, Any?> {
+        Log.i(tag, "pause exclusive playback.")
+        paused.set(true)
+        return updateState(currentState + mapOf("playing" to false, "message" to "Paused."))
+    }
+
+    fun resume(): Map<String, Any?> {
+        if (currentState["active"] != true) {
+            Log.w(tag, "resume ignored because exclusive playback is not active: $currentState")
+            return updateState(inactiveState("No exclusive playback is active."))
+        }
+        Log.i(
+            tag,
+            "resume exclusive playback position=${currentState["positionMs"]}, wasPaused=${paused.get()}",
+        )
+        paused.set(false)
+        return updateState(currentState + mapOf("playing" to true, "message" to "Playing."))
+    }
+
+    fun seek(positionMs: Long): Map<String, Any?> {
+        if (currentState["active"] != true) {
+            Log.w(tag, "seek ignored because exclusive playback is not active: $currentState")
+            return updateState(inactiveState("No exclusive playback is active."))
+        }
+        val safePositionMs = positionMs.coerceAtLeast(0L)
+        pendingSeekMs.set(safePositionMs)
+        return updateState(
+            currentState + mapOf(
+                "message" to "Seeking.",
+                "positionMs" to safePositionMs,
+            ),
+        )
+    }
+
+    fun setTargetBufferMs(value: Int): Map<String, Any?> {
+        targetBufferMs = value.coerceIn(50, 5000)
+        applyNativeTargetBuffer(activePacketsPerSecond)
+        if (activePacketsPerSecond > 0) {
+            emitTransportTelemetry(activePacketsPerSecond, force = true)
+        }
+        return currentState + mapOf("targetBufferMs" to targetBufferMs)
+    }
+
+    fun stop(): Map<String, Any?> {
+        stopped.set(true)
+        paused.set(false)
+        pendingSeekMs.set(-1L)
+        val thread = worker
+        worker = null
+        if (thread != null && thread != Thread.currentThread()) {
+            thread.join(500)
+        }
+        UsbExclusiveNative.close()
+        connection?.close()
+        connection = null
+        activePacketsPerSecond = 0
+        return updateState(inactiveState("USB exclusive playback stopped."))
+    }
+
+    fun release(): Map<String, Any?> = stop()
+
+    private fun emitTransportTelemetry(packetsPerSecond: Int, force: Boolean = false) {
+        val nowMs = SystemClock.elapsedRealtime()
+        if (!force && nowMs - lastTelemetryEmitMs < 100) {
+            return
+        }
+        lastTelemetryEmitMs = nowMs
+
+        val nativeTelemetry = UsbExclusiveNative.transportTelemetry()
+        val pendingIsoPackets = nativeTelemetry.getOrNull(0) ?: 0L
+        val totalIsoPackets = nativeTelemetry.getOrNull(1) ?: 0L
+        val pendingUrbs = nativeTelemetry.getOrNull(2) ?: 0L
+        val nativeIsoErrors = nativeTelemetry.getOrNull(3) ?: 0L
+        val bufferLevelMs = if (packetsPerSecond > 0) {
+            (pendingIsoPackets * 1000L) / packetsPerSecond
+        } else {
+            0L
+        }
+        val active = currentState["active"] == true
+
+        if (active && lastTelemetryBufferMs != null && lastTelemetryBufferMs!! > 0 && bufferLevelMs == 0L) {
+            zeroBufferUnderruns += 1
+        }
+        lastTelemetryBufferMs = bufferLevelMs
+
+        if (active && bufferLevelMs > 0) {
+            minimumBufferLevelMs = minimumBufferLevelMs?.let { minOf(it, bufferLevelMs) } ?: bufferLevelMs
+        }
+
+        emitTelemetry(
+            mapOf(
+                "active" to active,
+                "bufferLevelMs" to if (active) bufferLevelMs else 0L,
+                "minimumBufferLevelMs" to minimumBufferLevelMs,
+                "targetBufferMs" to targetBufferMs,
+                "isoPacketCount" to totalIsoPackets,
+                "pendingUrbs" to pendingUrbs,
+                "underrunCount" to (nativeIsoErrors + zeroBufferUnderruns),
+                "updatedAtMs" to nowMs,
+            ),
+        )
+    }
+
+    private fun emitInactiveTelemetry() {
+        lastTelemetryBufferMs = null
+        emitTelemetry(
+            mapOf(
+                "active" to false,
+                "bufferLevelMs" to 0,
+                "minimumBufferLevelMs" to null,
+                "targetBufferMs" to targetBufferMs,
+                "isoPacketCount" to 0,
+                "pendingUrbs" to 0,
+                "underrunCount" to 0,
+                "updatedAtMs" to SystemClock.elapsedRealtime(),
+            ),
+        )
+    }
+
+    private fun applyNativeTargetBuffer(packetsPerSecond: Int) {
+        if (packetsPerSecond <= 0) {
+            return
+        }
+        val packetCount = ((targetBufferMs.toLong() * packetsPerSecond) + 999L) / 1000L
+        val maxPendingUrbs = ((packetCount + 15L) / 16L).coerceIn(8L, 512L).toInt()
+        UsbExclusiveNative.setMaxPendingOutputUrbs(maxPendingUrbs)
+        Log.i(
+            tag,
+            "USB target buffer targetMs=$targetBufferMs packetsPerSecond=$packetsPerSecond " +
+                "maxPendingUrbs=$maxPendingUrbs",
+        )
+    }
+
+    private fun decodeAndWrite(file: File, target: OutputTarget) {
+        val extractor = MediaExtractor()
+        var codec: MediaCodec? = null
+        var sawInputEos = false
+        var outputDone = false
+        val info = MediaCodec.BufferInfo()
+        val startMs = SystemClock.elapsedRealtime()
+        var lastPositionEmitMs = 0L
+        var packetizer: PcmIsoPacketizer? = null
+
+        try {
+            extractor.setDataSource(file.absolutePath)
+            val trackIndex = findAudioTrack(extractor)
+            if (trackIndex < 0) {
+                emitError("No audio track was found in ${file.name}.")
+                return
+            }
+
+            extractor.selectTrack(trackIndex)
+            val format = extractor.getTrackFormat(trackIndex)
+            val mime = format.getString(MediaFormat.KEY_MIME)
+            if (mime.isNullOrBlank()) {
+                emitError("Audio MIME type is missing.")
+                return
+            }
+
+            val durationMs = if (format.containsKey(MediaFormat.KEY_DURATION)) {
+                format.getLong(MediaFormat.KEY_DURATION) / 1000
+            } else {
+                null
+            }
+            val sampleRate = if (format.containsKey(MediaFormat.KEY_SAMPLE_RATE)) {
+                format.getInteger(MediaFormat.KEY_SAMPLE_RATE)
+            } else {
+                null
+            }
+            val channels = if (format.containsKey(MediaFormat.KEY_CHANNEL_COUNT)) {
+                format.getInteger(MediaFormat.KEY_CHANNEL_COUNT)
+            } else {
+                null
+            }
+
+            Log.i(
+                tag,
+                "decoder input format=$format, mime=$mime, sampleRate=$sampleRate, channels=$channels, " +
+                    "durationMs=$durationMs, endpointInterval=${target.endpoint.interval}",
+            )
+
+            if (mime == "audio/raw") {
+                writeRawPcm(extractor, file, format, sampleRate, channels, durationMs, target, startMs)
+                return
+            }
+
+            codec = MediaCodec.createDecoderByType(mime)
+            codec.configure(format, null, null, 0)
+            codec.start()
+
+            if (sampleRate != null && channels != null) {
+                packetizer = createPacketizer(sampleRate, channels, 16, target)
+            }
+
+            updateState(
+                currentState + mapOf(
+                    "active" to true,
+                    "playing" to !paused.get(),
+                    "durationMs" to durationMs,
+                    "sampleRate" to sampleRate,
+                    "bitDepth" to (target.usbBitResolution ?: 16),
+                    "message" to "USB exclusive decoding ${file.name} to ${target.endpointLabel}, channels=$channels.",
+                ),
+            )
+
+            while (!stopped.get() && !outputDone) {
+                val wasPaused = paused.get()
+                if (wasPaused) {
+                    Log.i(tag, "exclusive worker waiting because playback is paused.")
+                }
+                while (paused.get() && !stopped.get()) {
+                    Thread.sleep(25)
+                }
+                if (wasPaused && !stopped.get()) {
+                    Log.i(tag, "exclusive worker resumed.")
+                }
+                if (stopped.get()) break
+
+                consumePendingSeekMs()?.let { seekMs ->
+                    val seekUs = seekMs * 1000
+                    Log.i(tag, "exclusive decoder seek to ${seekMs}ms.")
+                    extractor.seekTo(seekUs, MediaExtractor.SEEK_TO_CLOSEST_SYNC)
+                    codec.flush()
+                    packetizer?.reset()
+                    sawInputEos = false
+                    outputDone = false
+                    lastPositionEmitMs = -1L
+                    updateState(
+                        currentState + mapOf(
+                            "active" to true,
+                            "playing" to !paused.get(),
+                            "positionMs" to seekMs,
+                            "message" to "Seeked.",
+                        ),
+                    )
+                }
+
+                if (!sawInputEos) {
+                    val inputIndex = codec.dequeueInputBuffer(10_000)
+                    if (inputIndex >= 0) {
+                        val inputBuffer = codec.getInputBuffer(inputIndex)
+                        val sampleSize = if (inputBuffer != null) {
+                            extractor.readSampleData(inputBuffer, 0)
+                        } else {
+                            -1
+                        }
+                        if (sampleSize < 0) {
+                            codec.queueInputBuffer(
+                                inputIndex,
+                                0,
+                                0,
+                                0,
+                                MediaCodec.BUFFER_FLAG_END_OF_STREAM,
+                            )
+                            sawInputEos = true
+                        } else {
+                            codec.queueInputBuffer(
+                                inputIndex,
+                                0,
+                                sampleSize,
+                                extractor.sampleTime,
+                                0,
+                            )
+                            extractor.advance()
+                        }
+                    }
+                }
+
+                val outputIndex = codec.dequeueOutputBuffer(info, 10_000)
+                if (outputIndex >= 0) {
+                    val outputBuffer = codec.getOutputBuffer(outputIndex)
+                    if (outputBuffer != null && info.size > 0) {
+                        val writer = packetizer
+                            ?: createPacketizer(
+                                sampleRate ?: 48000,
+                                channels ?: 2,
+                                16,
+                                target,
+                            ).also { packetizer = it }
+                        writeOutputBuffer(outputBuffer, info, writer)
+                    }
+                    if ((info.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
+                        outputDone = true
+                    }
+                    codec.releaseOutputBuffer(outputIndex, false)
+
+                    val positionMs = if (info.presentationTimeUs > 0) {
+                        info.presentationTimeUs / 1000
+                    } else {
+                        SystemClock.elapsedRealtime() - startMs
+                    }
+                    if (positionMs - lastPositionEmitMs >= 250) {
+                        lastPositionEmitMs = positionMs
+                        updateState(
+                            currentState + mapOf(
+                                "active" to true,
+                                "playing" to !paused.get(),
+                                "positionMs" to positionMs,
+                            ),
+                        )
+                    }
+                } else if (outputIndex == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED) {
+                    val outputFormat = codec.outputFormat
+                    val outputSampleRate = if (outputFormat.containsKey(MediaFormat.KEY_SAMPLE_RATE)) {
+                        outputFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE)
+                    } else {
+                        null
+                    }
+                    val pcmEncoding = if (
+                        Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
+                        outputFormat.containsKey(MediaFormat.KEY_PCM_ENCODING)
+                    ) {
+                        outputFormat.getInteger(MediaFormat.KEY_PCM_ENCODING)
+                    } else {
+                        null
+                    }
+                    val outputChannels = if (outputFormat.containsKey(MediaFormat.KEY_CHANNEL_COUNT)) {
+                        outputFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT)
+                    } else {
+                        channels
+                    }
+                    val outputBitDepth = bitDepthFromPcmEncoding(pcmEncoding)
+                    Log.i(
+                        tag,
+                        "decoder output format changed: $outputFormat, pcmEncoding=$pcmEncoding, " +
+                            "decoderBitDepth=$outputBitDepth, usbBitDepth=${target.usbBitResolution}",
+                    )
+                    if (outputSampleRate != null && outputChannels != null) {
+                        packetizer?.flush()
+                        packetizer = createPacketizer(
+                            outputSampleRate,
+                            outputChannels,
+                            outputBitDepth,
+                            target,
+                        )
+                    }
+                    updateState(
+                        currentState + mapOf(
+                            "sampleRate" to outputSampleRate,
+                            "bitDepth" to (target.usbBitResolution ?: outputBitDepth),
+                        ),
+                    )
+                }
+            }
+
+            packetizer?.flush()
+            if (!stopped.get()) {
+                updateState(inactiveState("USB exclusive playback completed."))
+            }
+        } catch (error: Throwable) {
+            Log.w("UsbExclusiveAudioEngine", "Exclusive playback failed.", error)
+            emitError(error.message ?: "USB exclusive playback failed.")
+        } finally {
+            try {
+                codec?.stop()
+            } catch (_: Throwable) {
+            }
+            codec?.release()
+            extractor.release()
+            UsbExclusiveNative.close()
+            connection?.close()
+            connection = null
+        }
+    }
+
+    private fun writeRawPcm(
+        extractor: MediaExtractor,
+        file: File,
+        format: MediaFormat,
+        sampleRate: Int?,
+        channels: Int?,
+        durationMs: Long?,
+        target: OutputTarget,
+        startMs: Long,
+    ) {
+        if (sampleRate == null || channels == null) {
+            emitError("Raw PCM stream is missing sample rate or channel count.")
+            return
+        }
+
+        val pcmEncoding = if (
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.N &&
+            format.containsKey(MediaFormat.KEY_PCM_ENCODING)
+        ) {
+            format.getInteger(MediaFormat.KEY_PCM_ENCODING)
+        } else {
+            null
+        }
+        val containerBitDepth = if (format.containsKey("bits-per-sample")) {
+            format.getInteger("bits-per-sample")
+        } else {
+            null
+        }
+        val sourceBitDepth = pcmEncoding
+            ?.let { bitDepthFromPcmEncoding(it) }
+            ?: containerBitDepth
+            ?: 16
+        val maxInputSize = if (format.containsKey(MediaFormat.KEY_MAX_INPUT_SIZE)) {
+            format.getInteger(MediaFormat.KEY_MAX_INPUT_SIZE).coerceAtLeast(4096)
+        } else {
+            64 * 1024
+        }
+        val buffer = ByteBuffer.allocate(maxInputSize)
+        val packetizer = createPacketizer(sampleRate, channels, sourceBitDepth, target)
+        var lastPositionEmitMs = 0L
+        var lastSampleTimeUs: Long? = null
+        var rawChunkLogCount = 0
+
+        Log.i(
+            tag,
+            "raw PCM direct path sampleRate=$sampleRate, channels=$channels, " +
+                "sourceBitDepth=$sourceBitDepth, pcmEncoding=$pcmEncoding, " +
+                "containerBitDepth=$containerBitDepth, maxInputSize=$maxInputSize, " +
+                "targetBitDepth=${target.usbBitResolution}",
+        )
+        updateState(
+            currentState + mapOf(
+                "active" to true,
+                "playing" to !paused.get(),
+                "durationMs" to durationMs,
+                "sampleRate" to sampleRate,
+                "bitDepth" to (target.usbBitResolution ?: sourceBitDepth),
+                "message" to "USB exclusive streaming raw PCM ${file.name} to ${target.endpointLabel}.",
+            ),
+        )
+
+        while (!stopped.get()) {
+            val wasPaused = paused.get()
+            if (wasPaused) {
+                Log.i(tag, "exclusive worker waiting because playback is paused.")
+            }
+            while (paused.get() && !stopped.get()) {
+                Thread.sleep(25)
+            }
+            if (wasPaused && !stopped.get()) {
+                Log.i(tag, "exclusive worker resumed.")
+            }
+            if (stopped.get()) break
+
+            consumePendingSeekMs()?.let { seekMs ->
+                val seekUs = seekMs * 1000
+                Log.i(tag, "exclusive raw PCM seek to ${seekMs}ms.")
+                extractor.seekTo(seekUs, MediaExtractor.SEEK_TO_CLOSEST_SYNC)
+                packetizer.reset()
+                lastPositionEmitMs = -1L
+                lastSampleTimeUs = null
+                updateState(
+                    currentState + mapOf(
+                        "active" to true,
+                        "playing" to !paused.get(),
+                        "positionMs" to seekMs,
+                        "message" to "Seeked.",
+                    ),
+                )
+            }
+
+            buffer.clear()
+            val sampleTimeUs = extractor.sampleTime
+            val sampleSize = extractor.readSampleData(buffer, 0)
+            if (sampleSize < 0) {
+                break
+            }
+            val data = ByteArray(sampleSize)
+            buffer.position(0)
+            buffer.limit(sampleSize)
+            buffer.get(data)
+            if (rawChunkLogCount < 12) {
+                val frameBytes = channels * bytesPerSampleForBitDepth(sourceBitDepth)
+                val frames = if (frameBytes > 0) sampleSize / frameBytes else 0
+                val deltaUs = lastSampleTimeUs?.let { sampleTimeUs - it }
+                Log.i(
+                    tag,
+                    "raw PCM chunk size=$sampleSize, sampleTimeUs=$sampleTimeUs, " +
+                        "deltaUs=${deltaUs ?: "n/a"}, frames=$frames, frameBytes=$frameBytes, " +
+                        "sourceBitDepth=$sourceBitDepth",
+                )
+                rawChunkLogCount++
+            }
+            lastSampleTimeUs = sampleTimeUs
+            packetizer.write(data)
+
+            val positionMs = if (sampleTimeUs > 0) {
+                sampleTimeUs / 1000
+            } else {
+                SystemClock.elapsedRealtime() - startMs
+            }
+            if (positionMs - lastPositionEmitMs >= 250) {
+                lastPositionEmitMs = positionMs
+                updateState(
+                    currentState + mapOf(
+                        "active" to true,
+                        "playing" to !paused.get(),
+                        "positionMs" to positionMs,
+                    ),
+                )
+            }
+            extractor.advance()
+        }
+
+        packetizer.flush()
+        if (!stopped.get()) {
+            updateState(inactiveState("USB exclusive playback completed."))
+        }
+    }
+
+    private fun createPacketizer(
+        sampleRate: Int,
+        channels: Int,
+        bitDepth: Int,
+        target: OutputTarget,
+    ): PcmIsoPacketizer {
+        val inputBytesPerSample = bytesPerSampleForBitDepth(bitDepth)
+        val usbBytesPerSample = target.usbBytesPerSample
+        val usbBitResolution = target.usbBitResolution ?: (usbBytesPerSample * 8)
+        Log.i(
+            tag,
+            "USB PCM packetizer sampleRate=$sampleRate, channels=$channels, " +
+                "decoderBitDepth=$bitDepth, inputBytesPerSample=$inputBytesPerSample, " +
+                "usbBytesPerSample=$usbBytesPerSample, usbBitResolution=$usbBitResolution, " +
+                "packetsPerSecond=${target.packetsPerSecond}, endpointInterval=${target.endpoint.interval}, " +
+                "format=${target.formatInfo}",
+        )
+        val packetBytes = requiredIsoPacketBytes(
+            sampleRate,
+            target.packetsPerSecond,
+            channels,
+            usbBytesPerSample,
+        )
+        activePacketsPerSecond = target.packetsPerSecond
+        applyNativeTargetBuffer(target.packetsPerSecond)
+        UsbExclusiveNative.setIsoPacketSize(packetBytes)
+        val outputIntervalMicroframes = isoIntervalMicroframes(target.endpoint.interval)
+        val feedbackOutputPacketDivisor = target.feedbackEndpoint?.let {
+            val feedbackIntervalMicroframes = isoIntervalMicroframes(it.interval)
+            Log.i(
+                tag,
+                "USB feedback intervals outputMicroframes=$outputIntervalMicroframes, " +
+                    "feedbackMicroframes=$feedbackIntervalMicroframes",
+            )
+            1
+        } ?: 1
+        Log.i(
+            tag,
+            "USB feedback scaling outputIntervalMicroframes=$outputIntervalMicroframes, " +
+                "feedbackDivisor=$feedbackOutputPacketDivisor, feedback=${target.feedbackEndpointLabel}",
+        )
+        return PcmIsoPacketizer(
+            sampleRate,
+            target.packetsPerSecond,
+            channels,
+            inputBytesPerSample,
+            bitDepth,
+            usbBytesPerSample,
+            usbBitResolution,
+            feedbackOutputPacketDivisor,
+            feedbackFramesPerPacketQ16 = target.feedbackEndpoint?.let {
+                { UsbExclusiveNative.feedbackFramesPerPacketQ16() }
+            },
+        ) { data, packetLengths, packetCount ->
+            val error = UsbExclusiveNative.writeIsoPackets(data, packetLengths, packetCount)
+            if (error != null) {
+                throw IllegalStateException(error)
+            }
+            emitTransportTelemetry(target.packetsPerSecond)
+        }
+    }
+
+    private fun configureUsbAudioClock(
+        connection: UsbDeviceConnection,
+        device: UsbDevice,
+        target: OutputTarget,
+        sampleRate: Int,
+    ) {
+        val controlInterface = findAudioControlInterface(device)
+        val controlInterfaceNumber = controlInterface?.id ?: target.usbInterface.id
+        val clockSourceId = findUac2ClockSourceId(
+            connection.rawDescriptors,
+            streamingInterfaceNumber = target.usbInterface.id,
+            streamingAlternateSetting = target.alternateSetting,
+        )
+
+        val claimedControl = controlInterface?.let {
+            runCatching { connection.claimInterface(it, true) }.getOrDefault(false)
+        } == true
+        try {
+            if (clockSourceId != null) {
+                readUac2ClockSampleRate(
+                    connection,
+                    clockSourceId,
+                    controlInterfaceNumber,
+                    "before",
+                )
+                val data = byteArrayOf(
+                    (sampleRate and 0xff).toByte(),
+                    ((sampleRate ushr 8) and 0xff).toByte(),
+                    ((sampleRate ushr 16) and 0xff).toByte(),
+                    ((sampleRate ushr 24) and 0xff).toByte(),
+                )
+                val result = connection.controlTransfer(
+                    UsbConstants.USB_DIR_OUT or UsbConstants.USB_TYPE_CLASS or USB_RECIP_INTERFACE,
+                    0x01,
+                    0x01 shl 8,
+                    (clockSourceId shl 8) or controlInterfaceNumber,
+                    data,
+                    data.size,
+                    1000,
+                )
+                Log.i(
+                    tag,
+                    "UAC2 clock SET_CUR sampleRate=$sampleRate, clockSourceId=$clockSourceId, " +
+                    "controlInterface=$controlInterfaceNumber, result=$result",
+                )
+                readUac2ClockSampleRate(
+                    connection,
+                    clockSourceId,
+                    controlInterfaceNumber,
+                    "after",
+                )
+                return
+            }
+
+            val data = byteArrayOf(
+                (sampleRate and 0xff).toByte(),
+                ((sampleRate ushr 8) and 0xff).toByte(),
+                ((sampleRate ushr 16) and 0xff).toByte(),
+            )
+            val result = connection.controlTransfer(
+                UsbConstants.USB_DIR_OUT or UsbConstants.USB_TYPE_CLASS or USB_RECIP_ENDPOINT,
+                0x01,
+                0x01 shl 8,
+                target.endpoint.address,
+                data,
+                data.size,
+                1000,
+            )
+            Log.i(
+                tag,
+                "UAC1 endpoint SET_CUR sampleRate=$sampleRate, endpoint=0x${
+                    target.endpoint.address.toString(16)
+                }, result=$result",
+            )
+        } catch (error: RuntimeException) {
+            Log.w(tag, "USB audio clock configuration failed.", error)
+        } finally {
+            if (claimedControl && controlInterface != null) {
+                runCatching { connection.releaseInterface(controlInterface) }
+            }
+        }
+    }
+
+    private fun readUac2ClockSampleRate(
+        connection: UsbDeviceConnection,
+        clockSourceId: Int,
+        controlInterfaceNumber: Int,
+        label: String,
+    ): Int? {
+        val data = ByteArray(4)
+        val result = connection.controlTransfer(
+            UsbConstants.USB_DIR_IN or UsbConstants.USB_TYPE_CLASS or USB_RECIP_INTERFACE,
+            0x81,
+            0x01 shl 8,
+            (clockSourceId shl 8) or controlInterfaceNumber,
+            data,
+            data.size,
+            1000,
+        )
+        val sampleRate = if (result == 4) {
+            (data[0].toInt() and 0xff) or
+                ((data[1].toInt() and 0xff) shl 8) or
+                ((data[2].toInt() and 0xff) shl 16) or
+                ((data[3].toInt() and 0xff) shl 24)
+        } else {
+            null
+        }
+        Log.i(
+            tag,
+            "UAC2 clock GET_CUR $label result=$result, clockSourceId=$clockSourceId, " +
+                "controlInterface=$controlInterfaceNumber, sampleRate=${sampleRate ?: "n/a"}, " +
+                "raw=${hexPreview(data)}",
+        )
+        return sampleRate
+    }
+
+    private fun hexPreview(data: ByteArray, limit: Int = 16): String =
+        data.take(minOf(data.size, limit)).joinToString(" ") { byte ->
+            (byte.toInt() and 0xff).toString(16).padStart(2, '0')
+        }
+
+    private fun findAudioControlInterface(device: UsbDevice): UsbInterface? {
+        for (index in 0 until device.interfaceCount) {
+            val usbInterface = device.getInterface(index)
+            if (
+                usbInterface.interfaceClass == UsbConstants.USB_CLASS_AUDIO &&
+                usbInterface.interfaceSubclass == 1
+            ) {
+                return usbInterface
+            }
+        }
+        return null
+    }
+
+    private fun writeOutputBuffer(
+        outputBuffer: ByteBuffer,
+        info: MediaCodec.BufferInfo,
+        packetizer: PcmIsoPacketizer,
+    ) {
+        val data = ByteArray(info.size)
+        outputBuffer.position(info.offset)
+        outputBuffer.limit(info.offset + info.size)
+        outputBuffer.get(data)
+        packetizer.write(data)
+    }
+
+    private fun findAudioTrack(extractor: MediaExtractor): Int {
+        for (index in 0 until extractor.trackCount) {
+            val format = extractor.getTrackFormat(index)
+            val mime = format.getString(MediaFormat.KEY_MIME)
+            if (mime?.startsWith("audio/") == true) {
+                return index
+            }
+        }
+        return -1
+    }
+
+    private fun findOutputTarget(
+        device: UsbDevice,
+        streamingFormats: Map<Pair<Int, Int>, StreamingFormatInfo> = emptyMap(),
+        sampleRate: Int? = null,
+        channels: Int = 2,
+        bitDepth: Int? = null,
+    ): OutputTarget? {
+        val candidates = mutableListOf<OutputTarget>()
+        for (index in 0 until device.interfaceCount) {
+            val usbInterface = device.getInterface(index)
+            if (usbInterface.interfaceClass != UsbConstants.USB_CLASS_AUDIO) {
+                continue
+            }
+            for (endpointIndex in 0 until usbInterface.endpointCount) {
+                val endpoint = usbInterface.getEndpoint(endpointIndex)
+                if (
+                    endpoint.direction == UsbConstants.USB_DIR_OUT &&
+                    endpoint.type == UsbConstants.USB_ENDPOINT_XFER_ISOC
+                ) {
+                    val alt = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                        usbInterface.alternateSetting
+                    } else {
+                        0
+                    }
+                    candidates += OutputTarget(
+                        usbInterface = usbInterface,
+                        endpoint = endpoint,
+                        feedbackEndpoint = findFeedbackEndpoint(usbInterface),
+                        formatInfo = streamingFormats[usbInterface.id to alt],
+                    )
+                }
+            }
+        }
+
+        if (candidates.isEmpty()) {
+            return null
+        }
+
+        if (sampleRate == null) {
+            return candidates.minWith(compareBy<OutputTarget> {
+                it.endpoint.maxPacketSize
+            }.thenBy { it.alternateSetting })
+        }
+
+        val sortedCandidates = candidates.sortedWith(compareBy<OutputTarget> {
+            it.endpoint.maxPacketSize
+        }.thenBy { it.alternateSetting })
+        val fittingCandidates = sortedCandidates.filter {
+            it.endpoint.maxPacketSize >= requiredIsoPacketBytes(
+                sampleRate,
+                it.packetsPerSecond,
+                channels,
+                it.usbBytesPerSample,
+            )
+        }
+        val exactBitDepthCandidates = bitDepth?.let { requested ->
+            fittingCandidates.filter { it.usbBitResolution == requested }
+        } ?: emptyList()
+        val autoBitDepthCandidates = if (bitDepth == null) {
+            listOf(24, 32, 16)
+                .firstNotNullOfOrNull { preferred ->
+                    fittingCandidates.filter { it.usbBitResolution == preferred }.takeIf { it.isNotEmpty() }
+                }
+                ?: fittingCandidates
+        } else {
+            emptyList()
+        }
+        val selectedPool = when {
+            exactBitDepthCandidates.isNotEmpty() -> exactBitDepthCandidates
+            autoBitDepthCandidates.isNotEmpty() -> autoBitDepthCandidates
+            fittingCandidates.isNotEmpty() -> fittingCandidates
+            else -> sortedCandidates
+        }
+        val selected = selectedPool.minWith(
+            compareBy<OutputTarget> { it.usbBytesPerSample }
+                .thenBy { it.endpoint.maxPacketSize }
+                .thenBy { it.alternateSetting },
+        )
+        val selectedRequiredPacketBytes = requiredIsoPacketBytes(
+            sampleRate,
+            selected.packetsPerSecond,
+            channels,
+            selected.usbBytesPerSample,
+        )
+        if (selected.endpoint.maxPacketSize < selectedRequiredPacketBytes) {
+            Log.w(
+                tag,
+                "selected USB alt may be too small: requiredPacketBytes=$selectedRequiredPacketBytes, " +
+                    "selectedMaxPacket=${selected.endpoint.maxPacketSize}, sampleRate=$sampleRate, " +
+                    "channels=$channels, bitDepth=${bitDepth ?: "auto"}",
+            )
+        }
+        Log.i(
+            tag,
+            "selected USB alt=${selected.alternateSetting}, maxPacket=${selected.endpoint.maxPacketSize}, " +
+                "requiredPacketBytes=$selectedRequiredPacketBytes, " +
+                "requestedBitDepth=${bitDepth ?: "auto"}, selectedBitDepth=${selected.usbBitResolution}, " +
+                "packetsPerSecond=${selected.packetsPerSecond}, candidates=${sortedCandidates.joinToString { candidate ->
+                    val required = requiredIsoPacketBytes(
+                        sampleRate,
+                        candidate.packetsPerSecond,
+                        channels,
+                        candidate.usbBytesPerSample,
+                    )
+                    "alt=${candidate.alternateSetting}/max=${candidate.endpoint.maxPacketSize}/" +
+                        "outAttr=0x${candidate.endpoint.attributes.toString(16)}/" +
+                        "feedback=${candidate.feedbackEndpointLabel}/" +
+                        "usbBytes=${candidate.usbBytesPerSample}/bits=${candidate.usbBitResolution}/" +
+                        "required=$required/format=${candidate.formatInfo}"
+                }}",
+        )
+        return selected
+    }
+
+    private fun findFeedbackEndpoint(usbInterface: UsbInterface): UsbEndpoint? {
+        for (endpointIndex in 0 until usbInterface.endpointCount) {
+            val endpoint = usbInterface.getEndpoint(endpointIndex)
+            val isIsochronous = endpoint.type == UsbConstants.USB_ENDPOINT_XFER_ISOC
+            val isInput = endpoint.direction == UsbConstants.USB_DIR_IN
+            val usageType = endpoint.attributes and 0x30
+            if (isIsochronous && isInput && usageType == 0x10) {
+                return endpoint
+            }
+        }
+        return null
+    }
+
+    private fun parseStreamingFormatInfo(descriptors: ByteArray?): Map<Pair<Int, Int>, StreamingFormatInfo> {
+        if (descriptors == null) {
+            Log.w(tag, "USB raw descriptors unavailable; cannot parse AS format descriptors.")
+            return emptyMap()
+        }
+
+        val formats = mutableMapOf<Pair<Int, Int>, StreamingFormatInfo>()
+        var offset = 0
+        var currentInterfaceNumber = -1
+        var currentAlternateSetting = -1
+        var currentInterfaceSubclass = -1
+        var currentInterfaceProtocol = -1
+
+        while (offset + 1 < descriptors.size) {
+            val length = descriptors[offset].toInt() and 0xff
+            val descriptorType = descriptors[offset + 1].toInt() and 0xff
+            if (length < 2 || offset + length > descriptors.size) {
+                break
+            }
+
+            if (descriptorType == 0x04 && length >= 9) {
+                currentInterfaceNumber = descriptors[offset + 2].toInt() and 0xff
+                currentAlternateSetting = descriptors[offset + 3].toInt() and 0xff
+                currentInterfaceSubclass = descriptors[offset + 6].toInt() and 0xff
+                currentInterfaceProtocol = descriptors[offset + 8].toInt() and 0xff
+            } else if (
+                descriptorType == 0x24 &&
+                currentInterfaceSubclass == 2 &&
+                length >= 3
+            ) {
+                val key = currentInterfaceNumber to currentAlternateSetting
+                val subtype = descriptors[offset + 2].toInt() and 0xff
+                val existing = formats[key] ?: StreamingFormatInfo(
+                    interfaceNumber = currentInterfaceNumber,
+                    alternateSetting = currentAlternateSetting,
+                    protocol = currentInterfaceProtocol,
+                )
+                when (subtype) {
+                    0x01 -> {
+                        val terminalLink = if (length >= 4) {
+                            descriptors[offset + 3].toInt() and 0xff
+                        } else {
+                            existing.terminalLink
+                        }
+                        val formatType = if (length >= 6) {
+                            descriptors[offset + 5].toInt() and 0xff
+                        } else {
+                            existing.formatType
+                        }
+                        val channels = if (length >= 11) {
+                            descriptors[offset + 10].toInt() and 0xff
+                        } else {
+                            existing.channels
+                        }
+                        formats[key] = existing.copy(
+                            terminalLink = terminalLink,
+                            formatType = formatType,
+                            channels = channels,
+                        )
+                    }
+                    0x02 -> {
+                        if (length >= 6) {
+                            formats[key] = existing.copy(
+                                formatType = descriptors[offset + 3].toInt() and 0xff,
+                                subslotSize = descriptors[offset + 4].toInt() and 0xff,
+                                bitResolution = descriptors[offset + 5].toInt() and 0xff,
+                            )
+                        } else if (length >= 7) {
+                            formats[key] = existing.copy(
+                                formatType = descriptors[offset + 3].toInt() and 0xff,
+                                channels = descriptors[offset + 4].toInt() and 0xff,
+                                subslotSize = descriptors[offset + 5].toInt() and 0xff,
+                                bitResolution = descriptors[offset + 6].toInt() and 0xff,
+                            )
+                        }
+                    }
+                }
+            }
+
+            offset += length
+        }
+
+        Log.i(
+            tag,
+            "USB AS formats parsed: ${formats.values.sortedWith(
+                compareBy<StreamingFormatInfo> { it.interfaceNumber }.thenBy { it.alternateSetting },
+            ).joinToString()}",
+        )
+        return formats
+    }
+
+    private fun findUac2ClockSourceId(
+        descriptors: ByteArray?,
+        streamingInterfaceNumber: Int,
+        streamingAlternateSetting: Int,
+    ): Int? {
+        if (descriptors == null) {
+            return null
+        }
+
+        var offset = 0
+        var currentInterfaceNumber = -1
+        var currentAlternateSetting = -1
+        var currentInterfaceSubclass = -1
+        var terminalLink: Int? = null
+        var firstClockSourceId: Int? = null
+        val inputTerminalClockIds = mutableMapOf<Int, Int>()
+        val outputTerminalClockIds = mutableMapOf<Int, Int>()
+
+        while (offset + 1 < descriptors.size) {
+            val length = descriptors[offset].toInt() and 0xff
+            val descriptorType = descriptors[offset + 1].toInt() and 0xff
+            if (length < 2 || offset + length > descriptors.size) {
+                break
+            }
+
+            if (descriptorType == 0x04 && length >= 9) {
+                currentInterfaceNumber = descriptors[offset + 2].toInt() and 0xff
+                currentAlternateSetting = descriptors[offset + 3].toInt() and 0xff
+                currentInterfaceSubclass = descriptors[offset + 6].toInt() and 0xff
+            } else if (descriptorType == 0x24 && length >= 3) {
+                val subtype = descriptors[offset + 2].toInt() and 0xff
+                when (subtype) {
+                    0x0a -> {
+                        if (length >= 4 && firstClockSourceId == null) {
+                            firstClockSourceId = descriptors[offset + 3].toInt() and 0xff
+                        }
+                    }
+                    0x02 -> {
+                        if (length >= 8) {
+                            val terminalId = descriptors[offset + 3].toInt() and 0xff
+                            inputTerminalClockIds[terminalId] =
+                                descriptors[offset + 7].toInt() and 0xff
+                        }
+                    }
+                    0x03 -> {
+                        if (length >= 9) {
+                            val terminalId = descriptors[offset + 3].toInt() and 0xff
+                            outputTerminalClockIds[terminalId] =
+                                descriptors[offset + 8].toInt() and 0xff
+                        }
+                    }
+                    0x01 -> {
+                        if (
+                            currentInterfaceNumber == streamingInterfaceNumber &&
+                            currentAlternateSetting == streamingAlternateSetting &&
+                            currentInterfaceSubclass == 2 &&
+                            length >= 4
+                        ) {
+                            terminalLink = descriptors[offset + 3].toInt() and 0xff
+                        }
+                    }
+                }
+            }
+
+            offset += length
+        }
+
+        val linkedTerminal = terminalLink
+        val result = linkedTerminal?.let {
+            inputTerminalClockIds[it] ?: outputTerminalClockIds[it]
+        } ?: firstClockSourceId
+        Log.i(
+            tag,
+            "parsed UAC2 clock source: streamingInterface=$streamingInterfaceNumber, " +
+                "alt=$streamingAlternateSetting, terminalLink=$terminalLink, clockSourceId=$result",
+        )
+        return result
+    }
+
+    private fun requiredIsoPacketBytes(
+        sampleRate: Int,
+        packetsPerSecond: Int,
+        channels: Int,
+        bytesPerSample: Int,
+    ): Int {
+        val maxFramesPerPacket = (sampleRate + packetsPerSecond - 1) / packetsPerSecond
+        return maxFramesPerPacket * channels * bytesPerSample
+    }
+
+    private fun isoIntervalMicroframes(interval: Int): Int {
+        return 1 shl (interval.coerceIn(1, 4) - 1)
+    }
+
+    private fun bytesPerSampleForBitDepth(bitDepth: Int): Int {
+        return when {
+            bitDepth <= 8 -> 1
+            bitDepth <= 16 -> 2
+            bitDepth <= 24 -> 3
+            else -> 4
+        }
+    }
+
+    private fun isSupportedFile(filePath: String, sourceFormat: String?): Boolean {
+        if (sourceFormat == "flac" || sourceFormat == "wav" || sourceFormat == "wave") {
+            return true
+        }
+        val lower = filePath.lowercase(Locale.ROOT)
+        return lower.endsWith(".flac") || lower.endsWith(".wav") || lower.endsWith(".wave")
+    }
+
+    private fun capability(
+        available: Boolean,
+        permissionGranted: Boolean,
+        device: UsbDevice?,
+        target: OutputTarget?,
+        message: String,
+    ): Map<String, Any?> {
+        return mapOf(
+            "available" to available,
+            "permissionGranted" to permissionGranted,
+            "deviceName" to device?.productName,
+            "deviceId" to device?.deviceId,
+            "interfaceNumber" to target?.usbInterface?.id,
+            "alternateSetting" to target?.alternateSetting,
+            "endpointAddress" to target?.endpoint?.address,
+            "maxPacketSize" to target?.endpoint?.maxPacketSize,
+            "sampleRates" to listOf(44100, 48000, 88200, 96000, 176400, 192000),
+            "bitDepths" to listOf(16, 24, 32),
+            "channelCounts" to listOf(2),
+            "message" to message,
+        )
+    }
+
+    private fun emitError(message: String) {
+        updateState(inactiveState(message))
+    }
+
+    private fun consumePendingSeekMs(): Long? {
+        val seekMs = pendingSeekMs.getAndSet(-1L)
+        return if (seekMs >= 0L) seekMs else null
+    }
+
+    private fun updateState(state: Map<String, Any?>): Map<String, Any?> {
+        currentState = state
+        emitState(state)
+        if (state["active"] != true) {
+            emitInactiveTelemetry()
+        }
+        return state
+    }
+
+    private fun inactiveState(message: String? = null): Map<String, Any?> {
+        return mapOf(
+            "active" to false,
+            "playing" to false,
+            "positionMs" to 0,
+            "durationMs" to null,
+            "sampleRate" to null,
+            "bitDepth" to null,
+            "format" to null,
+            "message" to message,
+        )
+    }
+
+    private fun bitDepthFromPcmEncoding(pcmEncoding: Int?): Int {
+        return when (pcmEncoding) {
+            3 -> 8
+            4 -> 32
+            0x80000000.toInt() -> 24
+            else -> 16
+        }
+    }
+
+    private data class OutputTarget(
+        val usbInterface: UsbInterface,
+        val endpoint: UsbEndpoint,
+        val feedbackEndpoint: UsbEndpoint? = null,
+        val formatInfo: StreamingFormatInfo? = null,
+    ) {
+        val alternateSetting: Int
+            get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                usbInterface.alternateSetting
+            } else {
+                0
+            }
+
+        val endpointLabel: String
+            get() = "interface=${usbInterface.id}, alt=$alternateSetting, endpoint=0x${
+                endpoint.address.toString(16)
+            }"
+
+        val feedbackEndpointLabel: String
+            get() = feedbackEndpoint?.let {
+                "0x${it.address.toString(16)}/max=${it.maxPacketSize}/interval=${it.interval}/attr=0x${
+                    it.attributes.toString(16)
+                }"
+            } ?: "none"
+
+        val packetsPerSecond: Int
+            get() {
+                if (usbInterface.interfaceProtocol == 32) {
+                    val interval = endpoint.interval.coerceIn(1, 4)
+                    return 8000 / (1 shl (interval - 1))
+                }
+                return 1000
+            }
+
+        val usbBytesPerSample: Int
+            get() = formatInfo?.subslotSize?.takeIf { it > 0 } ?: 2
+
+        val usbBitResolution: Int?
+            get() = formatInfo?.bitResolution?.takeIf { it > 0 }
+    }
+
+    private data class StreamingFormatInfo(
+        val interfaceNumber: Int,
+        val alternateSetting: Int,
+        val protocol: Int,
+        val terminalLink: Int? = null,
+        val formatType: Int? = null,
+        val channels: Int? = null,
+        val subslotSize: Int? = null,
+        val bitResolution: Int? = null,
+    )
+
+    private class PcmIsoPacketizer(
+        private val sampleRate: Int,
+        private val packetsPerSecond: Int,
+        channels: Int,
+        private val inputBytesPerSample: Int,
+        private val inputBitDepth: Int,
+        private val usbBytesPerSample: Int,
+        private val usbBitResolution: Int,
+        private val feedbackOutputPacketDivisor: Int,
+        private val feedbackFramesPerPacketQ16: (() -> Int)? = null,
+        private val writePackets: (ByteArray, IntArray, Int) -> Unit,
+    ) {
+        private val pending = ByteArrayOutputStream()
+        private val transfer = ByteArrayOutputStream()
+        private val transferPacketLengths = IntArray(16)
+        private val bytesPerFrame = channels * usbBytesPerSample
+        private val inputBytesPerFrame = channels * inputBytesPerSample
+        private var sampleRemainder = 0
+        private var feedbackRemainderQ16 = 0L
+        private var transferPacketCount = 0
+        private var packetLogCount = 0
+        private var feedbackRejectLogCount = 0
+        private var pcmPreviewLogged = false
+        private var pcmPreviewAttempts = 0
+
+        fun write(data: ByteArray) {
+            val converted = convertPcmToUsbSlots(data)
+            if (!pcmPreviewLogged) {
+                pcmPreviewAttempts++
+                val forcePreview = pcmPreviewAttempts >= 64
+                if (hasAudibleSamples(data) || forcePreview) {
+                    pcmPreviewLogged = true
+                    logPcmPreview(
+                        data,
+                        converted,
+                        if (forcePreview) "forced-after-silence" else "first-nonzero",
+                    )
+                }
+            }
+            pending.write(converted)
+            drain(fullPacketsOnly = true)
+        }
+
+        fun flush() {
+            drain(fullPacketsOnly = false)
+        }
+
+        fun reset() {
+            pending.reset()
+            transfer.reset()
+            transferPacketCount = 0
+            sampleRemainder = 0
+            feedbackRemainderQ16 = 0L
+            packetLogCount = 0
+            feedbackRejectLogCount = 0
+            pcmPreviewLogged = false
+            pcmPreviewAttempts = 0
+        }
+
+        private fun drain(fullPacketsOnly: Boolean) {
+            while (pending.size() > 0) {
+                val packetBytes = nextPacketBytes()
+                if (fullPacketsOnly && pending.size() < packetBytes) {
+                    return
+                }
+                val source = pending.toByteArray()
+                val length = minOf(packetBytes, source.size)
+                val packet = ByteArray(packetBytes)
+                System.arraycopy(source, 0, packet, 0, length)
+                pending.reset()
+                if (source.size > length) {
+                    pending.write(source, length, source.size - length)
+                }
+                if (packetLogCount < 5) {
+                    ++packetLogCount
+                    Log.d(
+                        "UsbExclusiveAudioEngine",
+                        "USB PCM packet bytes=${packet.size}, filled=$length",
+                    )
+                }
+                transfer.write(packet)
+                transferPacketLengths[transferPacketCount] = packet.size
+                transferPacketCount++
+                if (transferPacketCount >= transferPacketLengths.size) {
+                    flushTransfer()
+                }
+            }
+
+            if (!fullPacketsOnly) {
+                flushTransfer()
+            }
+        }
+
+        private fun flushTransfer() {
+            if (transferPacketCount == 0) {
+                return
+            }
+            writePackets(
+                transfer.toByteArray(),
+                transferPacketLengths.copyOf(transferPacketCount),
+                transferPacketCount,
+            )
+            transfer.reset()
+            transferPacketCount = 0
+        }
+
+        private fun nextPacketBytes(): Int {
+            val feedbackQ16 = feedbackFramesPerPacketQ16?.invoke() ?: 0
+            if (feedbackQ16 > 0) {
+                val outputFeedbackQ16 = feedbackQ16 / feedbackOutputPacketDivisor
+                val nominalFramesQ16 = ((sampleRate.toLong() shl 16) / packetsPerSecond).toInt()
+                val minFeedbackQ16 = nominalFramesQ16 - (nominalFramesQ16 / 8)
+                val maxFeedbackQ16 = nominalFramesQ16 + (nominalFramesQ16 / 2)
+                if (outputFeedbackQ16 in minFeedbackQ16..maxFeedbackQ16) {
+                    feedbackRemainderQ16 += outputFeedbackQ16.toLong()
+                    val frames = (feedbackRemainderQ16 ushr 16).toInt()
+                    feedbackRemainderQ16 = feedbackRemainderQ16 and 0xffff
+                    if (frames > 0) {
+                        return maxOf(bytesPerFrame, frames * bytesPerFrame)
+                    }
+                } else if (feedbackRejectLogCount < 8) {
+                    ++feedbackRejectLogCount
+                    Log.w(
+                        "UsbExclusiveAudioEngine",
+                        "USB feedback ignored outputFrames=${q16ToFrames(outputFeedbackQ16)}, " +
+                            "nominalFrames=${q16ToFrames(nominalFramesQ16)}, " +
+                            "sampleRate=$sampleRate, packetsPerSecond=$packetsPerSecond",
+                    )
+                }
+            }
+
+            sampleRemainder += sampleRate
+            val frames = sampleRemainder / packetsPerSecond
+            sampleRemainder %= packetsPerSecond
+            return maxOf(bytesPerFrame, frames * bytesPerFrame)
+        }
+
+        private fun q16ToFrames(value: Int): String =
+            String.format(Locale.US, "%.6f", value.toDouble() / 65536.0)
+
+        private fun convertPcmToUsbSlots(data: ByteArray): ByteArray {
+            if (inputBytesPerSample == usbBytesPerSample && inputBitDepth == usbBitResolution) {
+                return data
+            }
+
+            val frames = data.size / inputBytesPerFrame
+            val output = ByteArray(frames * bytesPerFrame)
+            var inputOffset = 0
+            var outputOffset = 0
+            repeat(frames) {
+                repeat(inputBytesPerFrame / inputBytesPerSample) {
+                    val sample = readSignedLittleEndian(data, inputOffset, inputBytesPerSample, inputBitDepth)
+                    val shifted = if (usbBitResolution >= inputBitDepth) {
+                        sample shl (usbBitResolution - inputBitDepth)
+                    } else {
+                        sample shr (inputBitDepth - usbBitResolution)
+                    }
+                    writeLittleEndian(output, outputOffset, usbBytesPerSample, shifted)
+                    inputOffset += inputBytesPerSample
+                    outputOffset += usbBytesPerSample
+                }
+            }
+            return output
+        }
+
+        private fun hasAudibleSamples(input: ByteArray): Boolean {
+            val frames = input.size / inputBytesPerFrame
+            val samplesPerFrame = inputBytesPerFrame / inputBytesPerSample
+            val samplesToInspect = minOf(4096, frames * samplesPerFrame)
+            var sumAbs = 0L
+            for (index in 0 until samplesToInspect) {
+                val offset = index * inputBytesPerSample
+                val sample = readSignedLittleEndian(input, offset, inputBytesPerSample, inputBitDepth)
+                val abs = kotlin.math.abs(sample.toLong())
+                sumAbs += abs
+                if (abs > 512) {
+                    return true
+                }
+            }
+            return samplesToInspect > 0 && (sumAbs / samplesToInspect) > 64
+        }
+
+        private fun logPcmPreview(input: ByteArray, converted: ByteArray, reason: String) {
+            val frames = input.size / inputBytesPerFrame
+            val samplesPerFrame = inputBytesPerFrame / inputBytesPerSample
+            val samplesToInspect = minOf(4096, frames * samplesPerFrame)
+            var minSample = 0
+            var maxSample = 0
+            var sumAbs = 0L
+            for (index in 0 until samplesToInspect) {
+                val offset = index * inputBytesPerSample
+                val sample = readSignedLittleEndian(input, offset, inputBytesPerSample, inputBitDepth)
+                if (index == 0 || sample < minSample) minSample = sample
+                if (index == 0 || sample > maxSample) maxSample = sample
+                sumAbs += kotlin.math.abs(sample.toLong())
+            }
+            val averageAbs = if (samplesToInspect > 0) sumAbs / samplesToInspect else 0
+            Log.i(
+                "UsbExclusiveAudioEngine",
+                "USB PCM preview reason=$reason, inputBytes=${input.size}, convertedBytes=${converted.size}, frames=$frames, " +
+                    "inputBitDepth=$inputBitDepth, usbBytesPerSample=$usbBytesPerSample, " +
+                    "usbBitResolution=$usbBitResolution, min=$minSample, max=$maxSample, avgAbs=$averageAbs, " +
+                    "inputHead=${input.toHexPreview()}, usbHead=${converted.toHexPreview()}",
+            )
+        }
+
+        private fun ByteArray.toHexPreview(limit: Int = 64): String {
+            return take(minOf(size, limit)).joinToString(" ") { byte ->
+                (byte.toInt() and 0xff).toString(16).padStart(2, '0')
+            }
+        }
+
+        private fun readSignedLittleEndian(
+            data: ByteArray,
+            offset: Int,
+            bytes: Int,
+            bitDepth: Int,
+        ): Int {
+            var value = 0
+            for (index in 0 until bytes) {
+                value = value or ((data[offset + index].toInt() and 0xff) shl (index * 8))
+            }
+            val shift = (32 - bitDepth).coerceIn(0, 31)
+            return (value shl shift) shr shift
+        }
+
+        private fun writeLittleEndian(
+            data: ByteArray,
+            offset: Int,
+            bytes: Int,
+            value: Int,
+        ) {
+            for (index in 0 until bytes) {
+                data[offset + index] = ((value ushr (index * 8)) and 0xff).toByte()
+            }
+        }
+    }
+}

--- a/android/app/src/main/res/xml/usb_audio_device_filter.xml
+++ b/android/app/src/main/res/xml/usb_audio_device_filter.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Standard USB Audio Class devices. -->
+    <usb-device class="1" />
+
+    <!-- iBasso Macaron fallback for devices that do not expose class at device level. -->
+    <usb-device vendor-id="9770" product-id="6667" />
+</resources>

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -2,6 +2,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        maven("https://jitpack.io")
     }
 }
 

--- a/docs/usb-output-settings-status.md
+++ b/docs/usb-output-settings-status.md
@@ -1,0 +1,44 @@
+# USB 输出设置接入状态
+
+本文档记录 `USB 输出设置` 页面里哪些项目已经接入真实链路，哪些只是先放在 UI 和偏好层，作为后续 USB 独占链路改造的参考。
+
+## 已接入运行链路
+
+| 项目 | 状态 | 说明 |
+| --- | --- | --- |
+| Android USB 插入声明 | 已接入 | `AndroidManifest.xml` 已声明 `android.hardware.usb.action.USB_DEVICE_ATTACHED`，`usb_audio_device_filter.xml` 已包含 USB Audio Class 和 Macaron VID/PID。`dumpsys usb` 能看到 `com.afalphy.sylvakru.debug` 注册到 `device_attached_activities`。 |
+| USB 设备识别 | 已接入 | 通过 Android 侧 USB/AudioDevice 状态回传，设置页能显示 DAC 名称、USB ID、系统输出设备、采样率和编码等信息。 |
+| USB 权限与独占诊断 | 已接入 | `probeExclusiveAccess()` 会检查 USB 权限、Audio Interface 数量、claim 能力和原始描述符长度。 |
+| 固定采样率输出 | 部分接入 | 偏好已用于 `preferredExclusiveSampleRate()` 和系统 preferred output 请求；真实独占写流仍要看底层能力是否支持对应采样率。 |
+| PCM 位深偏好 | 部分接入 | `UsbAudioPreferences.preferredEncoding()` 会把 `16/24/32 bits` 映射到 Android PCM encoding，用于输出偏好请求。 |
+| USB 独占播放状态 | 已接入快照 | `UsbExclusivePlaybackState` 会由 start/pause/resume/seek/stop 等 native 调用回传，页面监听这个 notifier 展示当前快照。它不是连续实时水位。 |
+| 后台保活 | 已接入偏好 | 偏好已持久化，并用于 App 内 USB 输出策略判断；是否能完全防止系统杀后台取决于系统电池策略。 |
+| 播放后释放 USB 带宽 | 已接入偏好 | 偏好已保存，供停止播放后释放 USB 资源策略使用。 |
+| DSD 模式和 DSD 转 PCM 采样率 | 已接入偏好 | `PCM / DoP / Native` 和 DSD64/128/256/512 转 PCM 目标采样率均已持久化。底层 Native DSD/DoP 是否真正输出取决于后续独占链路实现。 |
+| 音量锁定和 DSD 增益补偿 | 已接入偏好 | 设置已持久化，供播放链路读取；硬件音量实时检测暂未接入。 |
+
+## 参考或占位项
+
+| 项目 | 状态 | 当前用途 |
+| --- | --- | --- |
+| 位深兼容 | UI/偏好占位 | 可保存，用于后续在独占链路里按 DAC 能力回退位深。当前不直接改变 PCM 数据写入。 |
+| 采样率兼容 | UI/偏好占位 | 可保存，用于后续按 DAC 支持列表自动回退采样率。当前主要还是固定采样率和系统 preferred output 在生效。 |
+| 声道兼容 | UI/偏好占位 | 可保存，用于后续处理单声道/多声道回退。当前不做实际声道重排。 |
+| TPDF 抖动 | UI/偏好占位 | 可保存，但当前没有接入高位深转 16-bit 的音频处理链路。 |
+| 前台缓冲区 / 后台缓冲区 | UI/偏好占位 | 可保存，并用于设置页显示目标水位；当前未接入底层 USB isochronous 写入队列。 |
+| 音量平滑交接 | UI/偏好占位 | 可保存，用于后续数字音量和 DAC 硬件音量切换时做淡入淡出。当前没有实时硬件音量检测。 |
+| 延迟建立 USB 输出链路 | UI/偏好占位 | 可保存，用于后续把 claim/open endpoint 推迟到播放开始。当前不改变建链时机。 |
+| USB 总线速度 | UI/偏好占位 | 可保存，用于后续诊断或策略选择。普通 Android App 通常不能强制 USB bus speed。 |
+| DAC 端点格式 | 信息占位 | 无独占播放时显示系统/设备能力；真实 endpoint alt setting 需要底层能力解析后再展示。 |
+
+## 传输状态卡说明
+
+传输状态卡现在按快照表达，不再伪装成实时仪表：
+
+- 主数值：`UsbExclusivePlaybackState.position`，目前代表 native 回传的播放/水位快照。
+- 状态：`active + playing` 显示为稳定，`active + !playing` 显示为暂停，否则为待机。
+- ISO：当前没有底层 isochronous 传输实时计数，固定显示 `ISO 0`。
+- 目标：来自前台缓冲区偏好，默认 `200 ms`，只作为目标水位参考。
+- 最低：当前没有底层最低水位统计，播放中暂用本次快照值；待机显示 `最低 --`。
+
+如果后续要让它真正实时，需要 native 层周期性上报 USB 写入队列水位、iso packet 计数、underrun 次数和最低水位，再更新 `UsbExclusivePlaybackState` 或新增专门的传输 telemetry notifier。

--- a/lib/base/audio_handler.dart
+++ b/lib/base/audio_handler.dart
@@ -7,6 +7,9 @@ import 'package:flutter/material.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:sylvakru/base/services/emby_client.dart';
 import 'package:sylvakru/base/services/metadata_service.dart';
+import 'package:sylvakru/base/services/playback_position_bridge.dart';
+import 'package:sylvakru/base/services/super_lyric_bridge.dart';
+import 'package:sylvakru/base/services/super_lyric_position_publisher.dart';
 import 'package:sylvakru/base/services/webdav_client.dart';
 import 'package:sylvakru/base/services/color_manager.dart';
 import 'package:sylvakru/base/app.dart';
@@ -21,6 +24,8 @@ import 'package:sylvakru/base/utils/contrast_color_generator.dart';
 import 'package:sylvakru/base/data/library.dart';
 import 'package:sylvakru/base/my_audio_metadata.dart';
 import 'package:sylvakru/base/services/navidrome_client.dart';
+import 'package:sylvakru/base/services/usb_audio_preferences.dart';
+import 'package:sylvakru/base/services/usb_audio_service.dart';
 import 'package:sylvakru/base/utils/metadata_utils.dart';
 import 'package:sylvakru/mini_view/mini_view.dart';
 import 'dart:async';
@@ -56,25 +61,44 @@ Future<void> initAudioService() async {
 
   await _session.setActive(true);
 
+  final usbAudioStatus = await usbAudioService.refreshStatus();
+  if (usbAudioStatus.supported) {
+    logger.output("usb audio:${usbAudioStatus.message}");
+  }
+
   _session.becomingNoisyEventStream.listen((_) {
+    debugPrint(
+      "audio session becoming noisy; usbExclusiveActive=${audioHandler._usbExclusiveActive}",
+    );
+    if (audioHandler._usbExclusiveActive) {
+      return;
+    }
     audioHandler.pause();
   });
 
   _session.interruptionEventStream.listen((event) {
-    if (event.begin) {
+    debugPrint(
+      "audio session interruption begin=${event.begin}; usbExclusiveActive=${audioHandler._usbExclusiveActive}",
+    );
+    if (event.begin && !audioHandler._usbExclusiveActive) {
       audioHandler.pause();
     }
   });
 }
 
-class MyAudioHandler extends BaseAudioHandler {
+class MyAudioHandler extends BaseAudioHandler with WidgetsBindingObserver {
   final _player = Player();
+  late final SuperLyricPositionPublisher _superLyricPublisher;
   bool _started = false;
   int currentIndex = -1;
   List<MyAudioMetadata> _playQueueTmp = [];
   int _tmpPlayMode = 0;
   DateTime? _playLastSyncTime;
   Duration _playedDuration = Duration.zero;
+  Duration _usbExclusivePosition = Duration.zero;
+  bool _usbExclusiveActive = false;
+  bool _suppressPlayerCompleted = false;
+  late final PlaybackPositionBridge _positionBridge;
 
   late final File _playQueueState;
   late final File _playState;
@@ -84,6 +108,11 @@ class MyAudioHandler extends BaseAudioHandler {
   bool isSyncing = false;
 
   MyAudioHandler() {
+    _superLyricPublisher = SuperLyricPositionPublisher(
+      sendLyricLine: SuperLyricBridge.sendLyricLine,
+      sendStop: SuperLyricBridge.sendStop,
+    );
+
     // avoid reading .lrc files
     (_player.platform as NativePlayer).setProperty('sub-auto', 'no');
 
@@ -92,6 +121,9 @@ class MyAudioHandler extends BaseAudioHandler {
     });
 
     _player.stream.completed.listen((completed) async {
+      if (_suppressPlayerCompleted) {
+        return;
+      }
       if (completed) {
         final position = _player.state.position;
         final duration = _player.state.duration;
@@ -129,7 +161,21 @@ class MyAudioHandler extends BaseAudioHandler {
       if (isLoading || isSyncing) {
         return;
       }
+      if (!isPlayingNotifier.value) {
+        return;
+      }
+      unawaited(_superLyricPublisher.publishAt(position));
     });
+
+    _positionBridge = PlaybackPositionBridge(
+      playerPositionStream: _player.stream.position,
+      playerPosition: () => _player.state.position,
+      exclusiveStateListenable: usbExclusivePlaybackStateNotifier,
+    );
+    usbExclusivePlaybackStateNotifier.addListener(_handleUsbExclusiveState);
+    if (Platform.isAndroid) {
+      WidgetsBinding.instance.addObserver(this);
+    }
   }
 
   void updateIsPlaying(bool isPlaying) {
@@ -144,6 +190,9 @@ class MyAudioHandler extends BaseAudioHandler {
   }
 
   void updatePlaybackState({Duration? postion, bool stop = false}) {
+    final position =
+        postion ??
+        (_usbExclusiveActive ? _usbExclusivePosition : _player.state.position);
     playbackState.add(
       PlaybackState(
         controls: [
@@ -154,9 +203,65 @@ class MyAudioHandler extends BaseAudioHandler {
         systemActions: {MediaAction.seek},
         playing: isPlayingNotifier.value,
         processingState: stop ? .idle : .ready,
-        speed: _player.state.rate,
-        updatePosition: postion ?? _player.state.position,
+        speed: _usbExclusiveActive ? 1.0 : _player.state.rate,
+        updatePosition: position,
       ),
+    );
+  }
+
+  void _handleUsbExclusiveState() {
+    final state = usbExclusivePlaybackStateNotifier.value;
+    final wasActive = _usbExclusiveActive;
+    _usbExclusivePosition = state.position;
+    _usbExclusiveActive = state.active;
+
+    if (state.active) {
+      if (isPlayingNotifier.value != state.playing) {
+        updateIsPlaying(state.playing);
+      }
+      updatePlaybackState(postion: state.position);
+      if (state.playing) {
+        unawaited(_superLyricPublisher.publishAt(state.position));
+      }
+      return;
+    }
+
+    if (wasActive && state.message?.contains('completed') == true) {
+      unawaited(skipToNext());
+    }
+  }
+
+  Future<void> _stopPlayerForUsbExclusive() async {
+    _suppressPlayerCompleted = true;
+    try {
+      await _player.stop();
+    } finally {
+      scheduleMicrotask(() {
+        _suppressPlayerCompleted = false;
+      });
+    }
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (!_usbExclusiveActive) {
+      return;
+    }
+    final targetBufferMs = _exclusiveTargetBufferMsForLifecycle(state);
+    debugPrint("usb exclusive lifecycle=$state targetBufferMs=$targetBufferMs");
+    unawaited(usbAudioService.setExclusiveTargetBufferMs(targetBufferMs));
+  }
+
+  int _exclusiveTargetBufferMsForLifecycle(AppLifecycleState? state) {
+    return preferredUsbExclusiveTargetBufferMs(
+      background: switch (state) {
+        AppLifecycleState.resumed => false,
+        AppLifecycleState.inactive ||
+        AppLifecycleState.hidden ||
+        AppLifecycleState.paused ||
+        AppLifecycleState.detached => true,
+        null => false,
+      },
     );
   }
 
@@ -499,47 +604,63 @@ class MyAudioHandler extends BaseAudioHandler {
     final currentSong = playQueue[currentIndex];
 
     await _setLyricsAndUpdateColors(currentSong);
+    _superLyricPublisher.updateLines(currentSong.parsedLyrics!.lines);
 
     currentSongNotifier.value = currentSong;
 
     isLoading = true;
     try {
-      if (currentSong.cacheExist) {
-        await _player.open(
-          Media(currentSong.cachePath!),
-          play: isPlayingNotifier.value,
-        );
-      } else {
-        String? resource;
-        bool needHeader = false;
-        switch (currentSong.sourceType) {
-          case .webdav:
-            final tmpPath = await convertToRealPathIfNeed(currentSong.path!);
-            if (tmpPath == null) {
-              needHeader = true;
-            } else {
-              resource = tmpPath;
-            }
-            break;
-          case .navidrome:
-            currentSong.path ??= navidromeClient!.getStreamUrl(currentSong.id);
-            break;
-          case .emby:
-            currentSong.path ??= embyClient!.audioUrl(currentSong.id);
-            break;
-          default:
-            break;
+      await usbAudioService.stopExclusivePlayback();
+      _usbExclusiveActive = false;
+      _usbExclusivePosition = Duration.zero;
+
+      final openedExclusive = await _tryOpenUsbExclusive(currentSong);
+      if (openedExclusive) {
+        await _stopPlayerForUsbExclusive();
+        if (isPlayingNotifier.value) {
+          _playLastSyncTime = DateTime.now();
         }
+      } else {
+        await _applyUsbOutputForSong(currentSong);
+        if (currentSong.cacheExist) {
+          await _player.open(
+            Media(currentSong.cachePath!),
+            play: isPlayingNotifier.value,
+          );
+        } else {
+          String? resource;
+          bool needHeader = false;
+          switch (currentSong.sourceType) {
+            case .webdav:
+              final tmpPath = await convertToRealPathIfNeed(currentSong.path!);
+              if (tmpPath == null) {
+                needHeader = true;
+              } else {
+                resource = tmpPath;
+              }
+              break;
+            case .navidrome:
+              currentSong.path ??= navidromeClient!.getStreamUrl(
+                currentSong.id,
+              );
+              break;
+            case .emby:
+              currentSong.path ??= embyClient!.audioUrl(currentSong.id);
+              break;
+            default:
+              break;
+          }
 
-        resource ??= currentSong.path!;
+          resource ??= currentSong.path!;
 
-        await _player.open(
-          Media(
-            resource,
-            httpHeaders: needHeader ? webdavClient?.headers : null,
-          ),
-          play: isPlayingNotifier.value,
-        );
+          await _player.open(
+            Media(
+              resource,
+              httpHeaders: needHeader ? webdavClient?.headers : null,
+            ),
+            play: isPlayingNotifier.value,
+          );
+        }
       }
 
       if (isPlayingNotifier.value) {
@@ -553,7 +674,234 @@ class MyAudioHandler extends BaseAudioHandler {
 
     updateServiceMediaItem(currentSong);
 
+    if (isPlayingNotifier.value) {
+      unawaited(_superLyricPublisher.publishAt(Duration.zero));
+    } else {
+      _superLyricPublisher.reset();
+      unawaited(SuperLyricBridge.sendStop());
+    }
     updatePlaybackState(postion: Duration.zero);
+  }
+
+  Future<bool> _tryOpenUsbExclusive(MyAudioMetadata song) async {
+    if (!_shouldTryUsbExclusive(song)) {
+      return false;
+    }
+
+    final capability = await usbAudioService.getExclusiveCapabilities();
+    var exclusiveCapability = capability;
+    if (exclusiveCapability.available &&
+        !exclusiveCapability.permissionGranted) {
+      logger.output(
+        "usb exclusive requesting permission:${exclusiveCapability.message}",
+      );
+      debugPrint(
+        "usb exclusive requesting permission:${exclusiveCapability.message}",
+      );
+      await usbAudioService.probeExclusiveAccess();
+      exclusiveCapability = await usbAudioService.getExclusiveCapabilities();
+    }
+
+    if (!exclusiveCapability.available ||
+        !exclusiveCapability.permissionGranted) {
+      logger.output("usb exclusive unavailable:${exclusiveCapability.message}");
+      debugPrint("usb exclusive unavailable:${exclusiveCapability.message}");
+      return false;
+    }
+
+    final filePath = await _exclusivePlayablePath(song);
+    if (filePath == null) {
+      return false;
+    }
+
+    final state = await usbAudioService.startExclusivePlayback(
+      UsbExclusivePlaybackRequest(
+        filePath: filePath,
+        title: getTitle(song),
+        sourceFormat: _normalizedExclusiveFormat(song),
+        sampleRate: _preferredExclusiveSampleRate(song),
+        bitDepth: _preferredExclusiveBitDepth(),
+        targetBufferMs: _exclusiveTargetBufferMsForLifecycle(
+          WidgetsBinding.instance.lifecycleState,
+        ),
+        startPaused: !isPlayingNotifier.value,
+      ),
+    );
+
+    if (!state.active) {
+      logger.output("usb exclusive fallback:${state.message}");
+      debugPrint("usb exclusive fallback:${state.message}");
+      return false;
+    }
+
+    _usbExclusiveActive = true;
+    _usbExclusivePosition = state.position;
+    updateIsPlaying(state.playing);
+    updatePlaybackState(postion: state.position);
+    debugPrint(
+      "usb exclusive opened: active=${state.active}, playing=${state.playing}, position=${state.position.inMilliseconds}",
+    );
+    return true;
+  }
+
+  bool _shouldTryUsbExclusive(MyAudioMetadata song) {
+    if (!Platform.isAndroid) {
+      logger.output("usb exclusive skipped:not android");
+      debugPrint("usb exclusive skipped:not android");
+      return false;
+    }
+    if (!usbAudioPreferences.performanceModeNotifier.value) {
+      logger.output("usb exclusive skipped:performance mode off");
+      debugPrint("usb exclusive skipped:performance mode off");
+      return false;
+    }
+    return true;
+  }
+
+  String? _normalizedExclusiveFormat(MyAudioMetadata song) {
+    final format = song.format?.toLowerCase().trim();
+    if (format != null && format.isNotEmpty) {
+      if (format.contains('flac')) return 'flac';
+      if (format.contains('wav') || format.contains('wave')) return 'wav';
+      return format;
+    }
+
+    final path = (song.cachePath ?? song.path ?? '').toLowerCase();
+    if (path.endsWith('.flac')) return 'flac';
+    if (path.endsWith('.wav') || path.endsWith('.wave')) return 'wav';
+    return null;
+  }
+
+  Future<String?> _exclusivePlayablePath(MyAudioMetadata song) async {
+    if (song.sourceType == .local && song.path != null) {
+      return await convertToRealPathIfNeed(song.path!) ?? song.path;
+    }
+
+    if (song.cacheExist && song.cachePath != null) {
+      return song.cachePath;
+    }
+
+    try {
+      await library.tryAddCache(song);
+    } catch (error) {
+      logger.output("usb exclusive cache failed:$error");
+      return null;
+    }
+
+    if (song.cacheExist && song.cachePath != null) {
+      return song.cachePath;
+    }
+    return null;
+  }
+
+  int? _preferredExclusiveBitDepth() {
+    return preferredUsbExclusiveBitDepth();
+  }
+
+  int? _preferredExclusiveSampleRate(MyAudioMetadata song) {
+    return usbAudioPreferences.preferredFixedSampleRate() ??
+        _matchedSafeSampleRate(song.samplerate);
+  }
+
+  Future<void> _applyUsbOutputForSong(MyAudioMetadata song) async {
+    if (!Platform.isAndroid ||
+        !usbAudioPreferences.performanceModeNotifier.value) {
+      return;
+    }
+
+    try {
+      final status = await usbAudioService.refreshStatus();
+      final sampleRate = _preferredSystemUsbSampleRate(status, song);
+      logger.output(
+        "usb output apply song samplerate=${song.samplerate}, request=$sampleRate",
+      );
+      debugPrint(
+        "usb output apply song samplerate=${song.samplerate}, request=$sampleRate",
+      );
+      await usbAudioService.applyPreferredOutput(
+        deviceId: status.bestAvailableDeviceId,
+        sampleRate: sampleRate,
+        encoding: usbAudioPreferences.preferredEncoding(),
+      );
+    } catch (error) {
+      logger.output("usb output apply failed:$error");
+      debugPrint("usb output apply failed:$error");
+    }
+  }
+
+  int? _matchedSafeSampleRate(int? sourceSampleRate) {
+    if (sourceSampleRate == null || sourceSampleRate <= 0) {
+      return null;
+    }
+
+    final supportedRates = UsbAudioPreferences.sampleRates;
+    if (supportedRates.contains(sourceSampleRate)) {
+      return sourceSampleRate;
+    }
+
+    final sameFamilyRates =
+        supportedRates.where((rate) => sourceSampleRate % rate == 0).toList()
+          ..sort();
+    if (sameFamilyRates.isNotEmpty) {
+      return sameFamilyRates.last;
+    }
+
+    return supportedRates
+        .where((rate) => rate <= sourceSampleRate)
+        .fold<int?>(
+          null,
+          (best, rate) => best == null || rate > best ? rate : best,
+        );
+  }
+
+  int? _preferredSystemUsbSampleRate(
+    UsbAudioStatus status,
+    MyAudioMetadata song,
+  ) {
+    final fixedRate = usbAudioPreferences.preferredFixedSampleRate();
+    if (fixedRate != null) {
+      return fixedRate;
+    }
+
+    final matchedSourceRate = _matchedSafeSampleRate(song.samplerate);
+    if (matchedSourceRate != null &&
+        _statusSupportsSampleRate(status, matchedSourceRate)) {
+      return matchedSourceRate;
+    }
+    return _bestSystemUsbSampleRate(status);
+  }
+
+  bool _statusSupportsSampleRate(UsbAudioStatus status, int sampleRate) {
+    final deviceId = status.bestAvailableDeviceId;
+    for (final device in status.devices) {
+      if (device.id != deviceId) {
+        continue;
+      }
+      final rates = device.supportedMixerSampleRates.isNotEmpty
+          ? device.supportedMixerSampleRates
+          : device.sampleRates;
+      return rates.contains(sampleRate);
+    }
+    return false;
+  }
+
+  int? _bestSystemUsbSampleRate(UsbAudioStatus status) {
+    final deviceId = status.bestAvailableDeviceId;
+    for (final device in status.devices) {
+      if (device.id != deviceId) {
+        continue;
+      }
+      final rates = device.supportedMixerSampleRates.isNotEmpty
+          ? device.supportedMixerSampleRates
+          : device.sampleRates;
+      final validRates =
+          rates.where(UsbAudioPreferences.sampleRates.contains).toList()
+            ..sort();
+      return validRates.isEmpty
+          ? status.bestAvailableSampleRate
+          : validRates.last;
+    }
+    return status.bestAvailableSampleRate;
   }
 
   void updateServiceMediaItem(MyAudioMetadata currentSong) {
@@ -578,22 +926,69 @@ class MyAudioHandler extends BaseAudioHandler {
   @override
   Future<void> play() async {
     if (playQueue.isEmpty) return;
+    if (_usbExclusiveActive) {
+      debugPrint(
+        "usb exclusive resume requested: playing=${isPlayingNotifier.value}, position=${_usbExclusivePosition.inMilliseconds}",
+      );
+      final state = await usbAudioService.resumeExclusivePlayback();
+      debugPrint(
+        "usb exclusive resume result: active=${state.active}, playing=${state.playing}, position=${state.position.inMilliseconds}, message=${state.message}",
+      );
+      updateIsPlaying(state.playing);
+      unawaited(_superLyricPublisher.publishAt(state.position));
+      updatePlaybackState(postion: state.position);
+      return;
+    }
+
+    final currentSong = playQueue[currentIndex];
+    updateIsPlaying(true);
+    final openedExclusive = await _tryOpenUsbExclusive(currentSong);
+    if (openedExclusive) {
+      await _stopPlayerForUsbExclusive();
+      unawaited(_superLyricPublisher.publishAt(_usbExclusivePosition));
+      updatePlaybackState(postion: _usbExclusivePosition);
+      return;
+    }
+
+    await _applyUsbOutputForSong(currentSong);
     _player.play();
 
-    updateIsPlaying(true);
+    unawaited(_superLyricPublisher.publishAt(_player.state.position));
     updatePlaybackState();
   }
 
   @override
   Future<void> pause() async {
+    debugPrint(
+      "audio handler pause requested: usbExclusiveActive=$_usbExclusiveActive, playing=${isPlayingNotifier.value}",
+    );
+    if (_usbExclusiveActive) {
+      final state = await usbAudioService.pauseExclusivePlayback();
+      unawaited(SuperLyricBridge.sendStop());
+      _superLyricPublisher.reset();
+      updateIsPlaying(state.playing);
+      updatePlaybackState(postion: state.position);
+      return;
+    }
+
     _player.pause();
+    unawaited(SuperLyricBridge.sendStop());
+    _superLyricPublisher.reset();
     updateIsPlaying(false);
     updatePlaybackState();
   }
 
   @override
   Future<void> stop() async {
+    if (_usbExclusiveActive) {
+      await usbAudioService.stopExclusivePlayback();
+      _usbExclusiveActive = false;
+      _usbExclusivePosition = Duration.zero;
+    }
+
     _player.stop();
+    unawaited(SuperLyricBridge.sendStop());
+    _superLyricPublisher.reset();
     updateIsPlaying(false);
     updatePlaybackState(stop: true);
   }
@@ -601,9 +996,22 @@ class MyAudioHandler extends BaseAudioHandler {
   @override
   Future<void> seek(Duration position) async {
     updatePlaybackState(postion: position);
+    if (_usbExclusiveActive) {
+      final state = await usbAudioService.seekExclusivePlayback(position);
+      if (isPlayingNotifier.value) {
+        unawaited(_superLyricPublisher.publishAt(state.position));
+      }
+      updateLyricsNotifier.value++;
+      updatePlaybackState(postion: state.position);
+      return;
+    }
+
     await _player.seek(position);
     // ensure position is updated
     await Future.delayed(Duration(milliseconds: 50));
+    if (isPlayingNotifier.value) {
+      unawaited(_superLyricPublisher.publishAt(position));
+    }
     updateLyricsNotifier.value++;
   }
 
@@ -632,11 +1040,11 @@ class MyAudioHandler extends BaseAudioHandler {
   }
 
   Stream<Duration> getPositionStream() {
-    return _player.stream.position;
+    return _positionBridge.stream;
   }
 
   Duration getPosition() {
-    return _player.state.position;
+    return _positionBridge.position;
   }
 
   void setVolume(double volume) {

--- a/lib/base/data/setting.dart
+++ b/lib/base/data/setting.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:sylvakru/base/audio_handler.dart';
 import 'package:sylvakru/base/data/playlist.dart';
 import 'package:sylvakru/base/services/interaction.dart';
+import 'package:sylvakru/base/services/usb_audio_preferences.dart';
 import 'package:sylvakru/base/widgets/lyric_list_view.dart';
 import 'package:sylvakru/base/data/artist_album.dart';
 import 'package:sylvakru/base/app.dart';
@@ -29,6 +30,7 @@ class Setting {
         jsonDecode(content) as Map<String, dynamic>;
 
     artistAlbumManager.loadSetting(json);
+    usbAudioPreferences.load(json);
 
     playlistManager.useLargePictureNotifier.value =
         json['playlistsUseLargePicture'] as bool? ??
@@ -76,6 +78,7 @@ class Setting {
     file.writeAsStringSync(
       jsonEncode({
         ...artistAlbumManager.settingToMap(),
+        ...usbAudioPreferences.toMap(),
 
         'playlistsUseLargePicture':
             playlistManager.useLargePictureNotifier.value,

--- a/lib/base/services/playback_position_bridge.dart
+++ b/lib/base/services/playback_position_bridge.dart
@@ -1,0 +1,64 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:sylvakru/base/services/usb_audio_service.dart';
+
+class PlaybackPositionBridge {
+  final Duration Function() _playerPosition;
+  final ValueListenable<UsbExclusivePlaybackState> _exclusiveStateListenable;
+  final _controller = StreamController<Duration>.broadcast();
+  late final StreamSubscription<Duration> _playerPositionSubscription;
+  late final VoidCallback _exclusiveStateListener;
+
+  Duration _exclusivePosition = Duration.zero;
+  bool _exclusiveActive = false;
+  bool _disposed = false;
+
+  PlaybackPositionBridge({
+    required Stream<Duration> playerPositionStream,
+    required Duration Function() playerPosition,
+    required ValueListenable<UsbExclusivePlaybackState>
+    exclusiveStateListenable,
+  }) : _playerPosition = playerPosition,
+       _exclusiveStateListenable = exclusiveStateListenable {
+    _exclusiveStateListener = _handleExclusiveState;
+    _exclusiveStateListenable.addListener(_exclusiveStateListener);
+    _handleExclusiveState();
+
+    _playerPositionSubscription = playerPositionStream.listen((position) {
+      if (!_exclusiveActive) {
+        _emit(position);
+      }
+    });
+  }
+
+  Stream<Duration> get stream => _controller.stream;
+
+  Duration get position =>
+      _exclusiveActive ? _exclusivePosition : _playerPosition();
+
+  void dispose() {
+    if (_disposed) {
+      return;
+    }
+    _disposed = true;
+    _exclusiveStateListenable.removeListener(_exclusiveStateListener);
+    unawaited(_playerPositionSubscription.cancel());
+    unawaited(_controller.close());
+  }
+
+  void _handleExclusiveState() {
+    final state = _exclusiveStateListenable.value;
+    _exclusiveActive = state.active;
+    if (state.active) {
+      _exclusivePosition = state.position;
+      _emit(state.position);
+    }
+  }
+
+  void _emit(Duration position) {
+    if (!_disposed && !_controller.isClosed) {
+      _controller.add(position);
+    }
+  }
+}

--- a/lib/base/services/super_lyric_bridge.dart
+++ b/lib/base/services/super_lyric_bridge.dart
@@ -1,0 +1,137 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:sylvakru/base/services/lyric.dart';
+
+class SuperLyricBridge {
+  static const MethodChannel _defaultChannel = MethodChannel(
+    'com.afalphy.sylvakru/super_lyric',
+  );
+
+  static MethodChannel _channel = _defaultChannel;
+  static bool _isAndroid = Platform.isAndroid;
+  static String? _lastLyric;
+  static bool _hasSentStop = false;
+
+  SuperLyricBridge._();
+
+  static Future<void> sendLyric(String lyric) async {
+    final text = lyric.trim();
+    if (_shouldStopForLyric(text)) {
+      await sendStop();
+      return;
+    }
+
+    if (text == _lastLyric) {
+      return;
+    }
+
+    _lastLyric = text;
+    _hasSentStop = false;
+    if (!_isAndroid) {
+      return;
+    }
+
+    await _invokeSendLyric({'lyric': text});
+  }
+
+  static Future<void> sendLyricLine(LyricLine line) async {
+    final text = line.text.trim();
+    if (_shouldStopForLyric(text)) {
+      await sendStop();
+      return;
+    }
+
+    final arguments = _lineToArguments(line, text);
+    final dedupeKey = arguments.toString();
+    if (dedupeKey == _lastLyric) {
+      return;
+    }
+
+    _lastLyric = dedupeKey;
+    _hasSentStop = false;
+    if (!_isAndroid) {
+      return;
+    }
+
+    await _invokeSendLyric(arguments);
+  }
+
+  static Future<void> _invokeSendLyric(Map<String, Object?> arguments) async {
+    try {
+      await _channel.invokeMethod<void>('sendLyric', arguments);
+    } on PlatformException {
+      return;
+    } on MissingPluginException {
+      return;
+    }
+  }
+
+  static Future<void> sendStop() async {
+    if (_hasSentStop) {
+      return;
+    }
+
+    _lastLyric = null;
+    _hasSentStop = true;
+    if (!_isAndroid) {
+      return;
+    }
+
+    try {
+      await _channel.invokeMethod<void>('sendStop');
+    } on PlatformException {
+      return;
+    } on MissingPluginException {
+      return;
+    }
+  }
+
+  static bool _shouldStopForLyric(String lyric) {
+    return lyric.isEmpty ||
+        lyric == 'There are no lyrics' ||
+        lyric == 'Lyrics parsing failed';
+  }
+
+  static Map<String, Object?> _lineToArguments(LyricLine line, String text) {
+    return {
+      'lyric': text,
+      'startTime': line.start.inMilliseconds,
+      'endTime': _lineEnd(line)?.inMilliseconds,
+      'tokens': line.tokens
+          .where((token) => token.text.isNotEmpty && token.end != null)
+          .map(
+            (token) => {
+              'text': token.text,
+              'startTime': token.start.inMilliseconds,
+              'endTime': token.end!.inMilliseconds,
+            },
+          )
+          .toList(growable: false),
+    };
+  }
+
+  static Duration? _lineEnd(LyricLine line) {
+    if (line.tokens.isEmpty) {
+      return null;
+    }
+    return line.tokens.last.end;
+  }
+
+  static void configureForTest({
+    required MethodChannel channel,
+    required bool isAndroid,
+  }) {
+    _channel = channel;
+    _isAndroid = isAndroid;
+    _lastLyric = null;
+    _hasSentStop = false;
+  }
+
+  static void resetForTest() {
+    _channel = _defaultChannel;
+    _isAndroid = Platform.isAndroid;
+    _lastLyric = null;
+    _hasSentStop = false;
+  }
+}

--- a/lib/base/services/super_lyric_position_publisher.dart
+++ b/lib/base/services/super_lyric_position_publisher.dart
@@ -1,0 +1,57 @@
+import 'package:sylvakru/base/services/lyric.dart';
+
+class SuperLyricPositionPublisher {
+  final Future<void> Function(LyricLine line) sendLyricLine;
+  final Future<void> Function() sendStop;
+
+  List<LyricLine> _lines = const [];
+  int? _lastPublishedIndex;
+
+  SuperLyricPositionPublisher({
+    required this.sendLyricLine,
+    required this.sendStop,
+  });
+
+  void updateLines(List<LyricLine> lines) {
+    _lines = lines;
+    reset();
+  }
+
+  void reset() {
+    _lastPublishedIndex = null;
+  }
+
+  Future<void> publishAt(Duration position) async {
+    if (position < Duration.zero) {
+      return;
+    }
+
+    final currentIndex = _currentIndexAt(position);
+    if (currentIndex == _lastPublishedIndex) {
+      return;
+    }
+
+    _lastPublishedIndex = currentIndex;
+    if (currentIndex >= 0 && currentIndex < _lines.length) {
+      await sendLyricLine(_lines[currentIndex]);
+    } else {
+      await sendStop();
+    }
+  }
+
+  int _currentIndexAt(Duration position) {
+    var current = -1;
+
+    for (var i = 0; i < _lines.length; i++) {
+      final line = _lines[i];
+      if (position < line.start) {
+        break;
+      }
+      if (current == -1 || line.start > _lines[current].start) {
+        current = i;
+      }
+    }
+
+    return current;
+  }
+}

--- a/lib/base/services/usb_audio_preferences.dart
+++ b/lib/base/services/usb_audio_preferences.dart
@@ -1,0 +1,180 @@
+import 'package:flutter/foundation.dart';
+
+final usbAudioPreferences = UsbAudioPreferences();
+
+int preferredUsbExclusiveTargetBufferMs({required bool background}) {
+  if (background && usbAudioPreferences.keepAliveInBackgroundNotifier.value) {
+    return usbAudioPreferences.backgroundBufferMsNotifier.value;
+  }
+  return usbAudioPreferences.foregroundBufferMsNotifier.value;
+}
+
+int? preferredUsbExclusiveBitDepth() {
+  return switch (usbAudioPreferences.bitDepthModeNotifier.value) {
+    UsbBitDepthMode.auto => null,
+    UsbBitDepthMode.pcm16 => 16,
+    UsbBitDepthMode.pcm24 => 24,
+    UsbBitDepthMode.pcm32 => 32,
+  };
+}
+
+enum UsbDsdMode { pcm, dop, native }
+
+enum UsbVolumeLockMode { off, dsdOnly, always }
+
+enum UsbBusSpeedMode { auto, full, high, superSpeed }
+
+enum UsbBitDepthMode { auto, pcm16, pcm24, pcm32 }
+
+class UsbAudioPreferences {
+  static const sampleRates = [44100, 48000, 88200, 96000, 176400, 192000];
+
+  final fixedSampleRateEnabledNotifier = ValueNotifier(false);
+  final fixedSampleRateNotifier = ValueNotifier<int?>(null);
+  final dsdModeNotifier = ValueNotifier(UsbDsdMode.dop);
+  final dsd64PcmRateNotifier = ValueNotifier(88200);
+  final dsd128PcmRateNotifier = ValueNotifier(88200);
+  final dsd256PcmRateNotifier = ValueNotifier(88200);
+  final dsd512PcmRateNotifier = ValueNotifier(88200);
+  final performanceModeNotifier = ValueNotifier(true);
+  final volumeLockModeNotifier = ValueNotifier(UsbVolumeLockMode.dsdOnly);
+  final dsdGainCompensationNotifier = ValueNotifier(0);
+  final busSpeedModeNotifier = ValueNotifier(UsbBusSpeedMode.auto);
+  final bitDepthModeNotifier = ValueNotifier(UsbBitDepthMode.auto);
+  final releaseUsbBandwidthAfterPlaybackNotifier = ValueNotifier(false);
+  final keepAliveInBackgroundNotifier = ValueNotifier(true);
+  final bitDepthCompatNotifier = ValueNotifier(true);
+  final sampleRateCompatNotifier = ValueNotifier(true);
+  final channelCompatNotifier = ValueNotifier(true);
+  final tpdfDitherNotifier = ValueNotifier(false);
+  final foregroundBufferMsNotifier = ValueNotifier(200);
+  final backgroundBufferMsNotifier = ValueNotifier(1500);
+  final volumeSmoothHandoffNotifier = ValueNotifier(true);
+  final delayedUsbLinkNotifier = ValueNotifier(false);
+
+  void load(Map<String, dynamic> json) {
+    fixedSampleRateEnabledNotifier.value =
+        json['usbFixedSampleRateEnabled'] as bool? ?? false;
+    fixedSampleRateNotifier.value = _validRate(
+      json['usbFixedSampleRate'] as int?,
+    );
+    dsdModeNotifier.value = _enumByName(
+      UsbDsdMode.values,
+      json['usbDsdMode'] as String?,
+      UsbDsdMode.dop,
+    );
+    dsd64PcmRateNotifier.value =
+        _validRate(json['usbDsd64PcmRate'] as int?) ?? 88200;
+    dsd128PcmRateNotifier.value =
+        _validRate(json['usbDsd128PcmRate'] as int?) ?? 88200;
+    dsd256PcmRateNotifier.value =
+        _validRate(json['usbDsd256PcmRate'] as int?) ?? 88200;
+    dsd512PcmRateNotifier.value =
+        _validRate(json['usbDsd512PcmRate'] as int?) ?? 88200;
+    performanceModeNotifier.value = json['usbPerformanceMode'] as bool? ?? true;
+    volumeLockModeNotifier.value = _enumByName(
+      UsbVolumeLockMode.values,
+      json['usbVolumeLockMode'] as String?,
+      UsbVolumeLockMode.dsdOnly,
+    );
+    dsdGainCompensationNotifier.value =
+        json['usbDsdGainCompensation'] as int? ?? 0;
+    busSpeedModeNotifier.value = _enumByName(
+      UsbBusSpeedMode.values,
+      json['usbBusSpeedMode'] as String?,
+      UsbBusSpeedMode.auto,
+    );
+    bitDepthModeNotifier.value = _enumByName(
+      UsbBitDepthMode.values,
+      json['usbBitDepthMode'] as String?,
+      UsbBitDepthMode.auto,
+    );
+    releaseUsbBandwidthAfterPlaybackNotifier.value =
+        json['usbReleaseBandwidthAfterPlayback'] as bool? ?? false;
+    keepAliveInBackgroundNotifier.value =
+        json['usbKeepAliveInBackground'] as bool? ?? true;
+    bitDepthCompatNotifier.value = json['usbBitDepthCompat'] as bool? ?? true;
+    sampleRateCompatNotifier.value =
+        json['usbSampleRateCompat'] as bool? ?? true;
+    channelCompatNotifier.value = json['usbChannelCompat'] as bool? ?? true;
+    tpdfDitherNotifier.value = json['usbTpdfDither'] as bool? ?? false;
+    foregroundBufferMsNotifier.value = _validBufferMs(
+      json['usbForegroundBufferMs'] as int?,
+      200,
+    );
+    backgroundBufferMsNotifier.value = _validBufferMs(
+      json['usbBackgroundBufferMs'] as int?,
+      1500,
+    );
+    volumeSmoothHandoffNotifier.value =
+        json['usbVolumeSmoothHandoff'] as bool? ?? true;
+    delayedUsbLinkNotifier.value = json['usbDelayedUsbLink'] as bool? ?? false;
+  }
+
+  Map<String, Object?> toMap() {
+    return {
+      'usbFixedSampleRateEnabled': fixedSampleRateEnabledNotifier.value,
+      'usbFixedSampleRate': fixedSampleRateNotifier.value,
+      'usbDsdMode': dsdModeNotifier.value.name,
+      'usbDsd64PcmRate': dsd64PcmRateNotifier.value,
+      'usbDsd128PcmRate': dsd128PcmRateNotifier.value,
+      'usbDsd256PcmRate': dsd256PcmRateNotifier.value,
+      'usbDsd512PcmRate': dsd512PcmRateNotifier.value,
+      'usbPerformanceMode': performanceModeNotifier.value,
+      'usbVolumeLockMode': volumeLockModeNotifier.value.name,
+      'usbDsdGainCompensation': dsdGainCompensationNotifier.value,
+      'usbBusSpeedMode': busSpeedModeNotifier.value.name,
+      'usbBitDepthMode': bitDepthModeNotifier.value.name,
+      'usbReleaseBandwidthAfterPlayback':
+          releaseUsbBandwidthAfterPlaybackNotifier.value,
+      'usbKeepAliveInBackground': keepAliveInBackgroundNotifier.value,
+      'usbBitDepthCompat': bitDepthCompatNotifier.value,
+      'usbSampleRateCompat': sampleRateCompatNotifier.value,
+      'usbChannelCompat': channelCompatNotifier.value,
+      'usbTpdfDither': tpdfDitherNotifier.value,
+      'usbForegroundBufferMs': foregroundBufferMsNotifier.value,
+      'usbBackgroundBufferMs': backgroundBufferMsNotifier.value,
+      'usbVolumeSmoothHandoff': volumeSmoothHandoffNotifier.value,
+      'usbDelayedUsbLink': delayedUsbLinkNotifier.value,
+    };
+  }
+
+  int? preferredFixedSampleRate() {
+    if (!fixedSampleRateEnabledNotifier.value) {
+      return null;
+    }
+    return _validRate(fixedSampleRateNotifier.value);
+  }
+
+  String preferredEncoding() {
+    return switch (bitDepthModeNotifier.value) {
+      UsbBitDepthMode.pcm16 => 'pcm_16bit',
+      UsbBitDepthMode.pcm24 => 'pcm_24bit_packed',
+      UsbBitDepthMode.pcm32 => 'pcm_32bit',
+      UsbBitDepthMode.auto => 'pcm_24bit_packed',
+    };
+  }
+
+  void resetForTest() {
+    load(const {});
+  }
+
+  T _enumByName<T extends Enum>(List<T> values, String? name, T fallback) {
+    for (final value in values) {
+      if (value.name == name) {
+        return value;
+      }
+    }
+    return fallback;
+  }
+
+  int? _validRate(int? rate) {
+    if (rate == null) return null;
+    return sampleRates.contains(rate) ? rate : null;
+  }
+
+  int _validBufferMs(int? value, int fallback) {
+    if (value == null) return fallback;
+    return value.clamp(50, 5000);
+  }
+}

--- a/lib/base/services/usb_audio_service.dart
+++ b/lib/base/services/usb_audio_service.dart
@@ -1,0 +1,701 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+import 'package:sylvakru/base/services/usb_audio_preferences.dart';
+
+final usbAudioService = UsbAudioService();
+final usbAudioStatusNotifier = ValueNotifier(UsbAudioStatus.unavailable());
+final usbAudioEventNotifier = ValueNotifier<UsbAudioDeviceEvent?>(null);
+final usbExclusivePlaybackStateNotifier = ValueNotifier(
+  UsbExclusivePlaybackState.inactive(),
+);
+final usbTransportTelemetryNotifier = ValueNotifier(
+  UsbTransportTelemetry.inactive(),
+);
+
+enum UsbAudioDeviceEventType { added, removed }
+
+class UsbAudioService {
+  static const MethodChannel _defaultChannel = MethodChannel(
+    'com.afalphy.sylvakru/usb_audio',
+  );
+
+  final MethodChannel _channel;
+  final bool _isAndroid;
+
+  UsbAudioService({MethodChannel channel = _defaultChannel, bool? isAndroid})
+    : _channel = channel,
+      _isAndroid = isAndroid ?? Platform.isAndroid {
+    _channel.setMethodCallHandler(_handleNativeCall);
+  }
+
+  Future<UsbAudioStatus> refreshStatus() async {
+    if (!_isAndroid) {
+      final status = UsbAudioStatus.unavailable(
+        message: 'USB audio optimization is only available on Android.',
+      );
+      usbAudioStatusNotifier.value = status;
+      return status;
+    }
+
+    return _invokeStatus('getStatus');
+  }
+
+  Future<UsbAudioStatus> applyPreferredOutput({
+    int? deviceId,
+    int? sampleRate,
+    String encoding = 'pcm_24bit_packed',
+    bool bitPerfect = true,
+  }) async {
+    if (!_isAndroid) {
+      final status = UsbAudioStatus.unavailable(
+        message: 'USB audio optimization is only available on Android.',
+      );
+      usbAudioStatusNotifier.value = status;
+      return status;
+    }
+
+    return _invokeStatus('applyPreferredOutput', {
+      'deviceId': ?deviceId,
+      'sampleRate': ?sampleRate,
+      'encoding': encoding,
+      'bitPerfect': bitPerfect,
+    });
+  }
+
+  Future<UsbAudioStatus> clearPreferredOutput() async {
+    if (!_isAndroid) {
+      final status = UsbAudioStatus.unavailable(
+        message: 'USB audio optimization is only available on Android.',
+      );
+      usbAudioStatusNotifier.value = status;
+      return status;
+    }
+
+    return _invokeStatus('clearPreferredOutput');
+  }
+
+  Future<UsbExclusiveProbeResult> probeExclusiveAccess() async {
+    if (!_isAndroid) {
+      return const UsbExclusiveProbeResult(
+        supported: false,
+        permissionGranted: false,
+        deviceName: null,
+        deviceId: null,
+        audioInterfaceCount: 0,
+        claimedInterfaceCount: 0,
+        rawDescriptorLength: 0,
+        message: 'USB exclusive access probing is only available on Android.',
+      );
+    }
+
+    try {
+      final result = await _channel.invokeMapMethod<String, Object?>(
+        'probeExclusiveAccess',
+      );
+      return UsbExclusiveProbeResult.fromMap(result ?? const {});
+    } on PlatformException catch (error) {
+      return UsbExclusiveProbeResult(
+        supported: false,
+        permissionGranted: false,
+        deviceName: null,
+        deviceId: null,
+        audioInterfaceCount: 0,
+        claimedInterfaceCount: 0,
+        rawDescriptorLength: 0,
+        message: error.message,
+      );
+    }
+  }
+
+  Future<UsbExclusiveCapability> getExclusiveCapabilities() async {
+    if (!_isAndroid) {
+      return const UsbExclusiveCapability(
+        available: false,
+        permissionGranted: false,
+        deviceName: null,
+        deviceId: null,
+        interfaceNumber: null,
+        alternateSetting: null,
+        endpointAddress: null,
+        maxPacketSize: null,
+        sampleRates: [],
+        bitDepths: [],
+        channelCounts: [],
+        message: 'USB exclusive playback is only available on Android.',
+      );
+    }
+
+    try {
+      final result = await _channel.invokeMapMethod<String, Object?>(
+        'getExclusiveCapabilities',
+      );
+      return UsbExclusiveCapability.fromMap(result ?? const {});
+    } on PlatformException catch (error) {
+      return UsbExclusiveCapability.unavailable(message: error.message);
+    }
+  }
+
+  Future<UsbExclusivePlaybackState> startExclusivePlayback(
+    UsbExclusivePlaybackRequest request,
+  ) {
+    return _invokeExclusiveState('startExclusivePlayback', request.toMap());
+  }
+
+  Future<UsbExclusivePlaybackState> pauseExclusivePlayback() {
+    return _invokeExclusiveState('pauseExclusivePlayback');
+  }
+
+  Future<UsbExclusivePlaybackState> resumeExclusivePlayback() {
+    return _invokeExclusiveState('resumeExclusivePlayback');
+  }
+
+  Future<void> setExclusiveTargetBufferMs(int targetBufferMs) async {
+    if (!_isAndroid) {
+      return;
+    }
+
+    await _channel.invokeMethod<void>('setExclusiveTargetBufferMs', {
+      'targetBufferMs': targetBufferMs.clamp(50, 5000),
+    });
+  }
+
+  Future<UsbExclusivePlaybackState> seekExclusivePlayback(Duration position) {
+    return _invokeExclusiveState('seekExclusivePlayback', {
+      'positionMs': position.inMilliseconds,
+    });
+  }
+
+  Future<UsbExclusivePlaybackState> stopExclusivePlayback() {
+    return _invokeExclusiveState('stopExclusivePlayback');
+  }
+
+  Future<UsbExclusivePlaybackState> releaseExclusiveDevice() {
+    return _invokeExclusiveState('releaseExclusiveDevice');
+  }
+
+  Future<UsbAudioStatus> _invokeStatus(
+    String method, [
+    Map<String, Object?>? arguments,
+  ]) async {
+    try {
+      final result = await _channel.invokeMapMethod<String, Object?>(
+        method,
+        arguments,
+      );
+      final status = UsbAudioStatus.fromMap(result ?? const {});
+      usbAudioStatusNotifier.value = status;
+      return status;
+    } on PlatformException catch (error) {
+      final status = UsbAudioStatus.unavailable(message: error.message);
+      usbAudioStatusNotifier.value = status;
+      return status;
+    }
+  }
+
+  Future<UsbExclusivePlaybackState> _invokeExclusiveState(
+    String method, [
+    Map<String, Object?>? arguments,
+  ]) async {
+    if (!_isAndroid) {
+      final state = UsbExclusivePlaybackState.inactive(
+        message: 'USB exclusive playback is only available on Android.',
+      );
+      usbExclusivePlaybackStateNotifier.value = state;
+      return state;
+    }
+
+    try {
+      final result = await _channel.invokeMapMethod<String, Object?>(
+        method,
+        arguments,
+      );
+      final state = UsbExclusivePlaybackState.fromMap(result ?? const {});
+      usbExclusivePlaybackStateNotifier.value = state;
+      return state;
+    } on PlatformException catch (error) {
+      final state = UsbExclusivePlaybackState.inactive(message: error.message);
+      usbExclusivePlaybackStateNotifier.value = state;
+      return state;
+    }
+  }
+
+  Future<Object?> _handleNativeCall(MethodCall call) async {
+    if (call.method == 'onUsbAudioDeviceEvent') {
+      final event = UsbAudioDeviceEvent.fromMap(
+        (call.arguments as Map).cast<String, Object?>(),
+      );
+      usbAudioStatusNotifier.value = event.status;
+      usbAudioEventNotifier.value = event;
+      return null;
+    }
+
+    if (call.method == 'onUsbExclusiveStateChanged' ||
+        call.method == 'onUsbExclusivePosition' ||
+        call.method == 'onUsbExclusiveError') {
+      final state = UsbExclusivePlaybackState.fromMap(
+        (call.arguments as Map?)?.cast<String, Object?>() ?? const {},
+      );
+      usbExclusivePlaybackStateNotifier.value = state;
+      return null;
+    }
+
+    if (call.method == 'onUsbTransportTelemetryChanged') {
+      final telemetry = UsbTransportTelemetry.fromMap(
+        (call.arguments as Map?)?.cast<String, Object?>() ?? const {},
+      );
+      usbTransportTelemetryNotifier.value = telemetry;
+      return null;
+    }
+
+    throw PlatformException(
+      code: 'unimplemented',
+      message: 'Unknown USB audio callback: ${call.method}',
+    );
+  }
+}
+
+@immutable
+class UsbExclusiveCapability {
+  final bool available;
+  final bool permissionGranted;
+  final String? deviceName;
+  final int? deviceId;
+  final int? interfaceNumber;
+  final int? alternateSetting;
+  final int? endpointAddress;
+  final int? maxPacketSize;
+  final List<int> sampleRates;
+  final List<int> bitDepths;
+  final List<int> channelCounts;
+  final String? message;
+
+  const UsbExclusiveCapability({
+    required this.available,
+    required this.permissionGranted,
+    required this.deviceName,
+    required this.deviceId,
+    required this.interfaceNumber,
+    required this.alternateSetting,
+    required this.endpointAddress,
+    required this.maxPacketSize,
+    required this.sampleRates,
+    required this.bitDepths,
+    required this.channelCounts,
+    required this.message,
+  });
+
+  factory UsbExclusiveCapability.unavailable({String? message}) {
+    return UsbExclusiveCapability(
+      available: false,
+      permissionGranted: false,
+      deviceName: null,
+      deviceId: null,
+      interfaceNumber: null,
+      alternateSetting: null,
+      endpointAddress: null,
+      maxPacketSize: null,
+      sampleRates: const [],
+      bitDepths: const [],
+      channelCounts: const [],
+      message: message,
+    );
+  }
+
+  factory UsbExclusiveCapability.fromMap(Map<String, Object?> map) {
+    return UsbExclusiveCapability(
+      available: map['available'] == true,
+      permissionGranted: map['permissionGranted'] == true,
+      deviceName: map['deviceName'] as String?,
+      deviceId: _asInt(map['deviceId']),
+      interfaceNumber: _asInt(map['interfaceNumber']),
+      alternateSetting: _asInt(map['alternateSetting']),
+      endpointAddress: _asInt(map['endpointAddress']),
+      maxPacketSize: _asInt(map['maxPacketSize']),
+      sampleRates: _asIntList(map['sampleRates']),
+      bitDepths: _asIntList(map['bitDepths']),
+      channelCounts: _asIntList(map['channelCounts']),
+      message: map['message'] as String?,
+    );
+  }
+}
+
+@immutable
+class UsbExclusivePlaybackRequest {
+  final String filePath;
+  final String? title;
+  final String? sourceFormat;
+  final int? sampleRate;
+  final int? bitDepth;
+  final int? targetBufferMs;
+  final bool startPaused;
+
+  const UsbExclusivePlaybackRequest({
+    required this.filePath,
+    required this.title,
+    required this.sourceFormat,
+    required this.sampleRate,
+    required this.bitDepth,
+    required this.targetBufferMs,
+    required this.startPaused,
+  });
+
+  Map<String, Object?> toMap() {
+    return {
+      'filePath': filePath,
+      'title': title,
+      'sourceFormat': sourceFormat,
+      'sampleRate': sampleRate,
+      'bitDepth': bitDepth,
+      'targetBufferMs': targetBufferMs,
+      'startPaused': startPaused,
+    };
+  }
+}
+
+@immutable
+class UsbExclusivePlaybackState {
+  final bool active;
+  final bool playing;
+  final Duration position;
+  final Duration? duration;
+  final int? sampleRate;
+  final int? bitDepth;
+  final String? format;
+  final String? message;
+
+  const UsbExclusivePlaybackState({
+    required this.active,
+    required this.playing,
+    required this.position,
+    required this.duration,
+    required this.sampleRate,
+    required this.bitDepth,
+    required this.format,
+    required this.message,
+  });
+
+  factory UsbExclusivePlaybackState.inactive({String? message}) {
+    return UsbExclusivePlaybackState(
+      active: false,
+      playing: false,
+      position: Duration.zero,
+      duration: null,
+      sampleRate: null,
+      bitDepth: null,
+      format: null,
+      message: message,
+    );
+  }
+
+  factory UsbExclusivePlaybackState.fromMap(Map<String, Object?> map) {
+    return UsbExclusivePlaybackState(
+      active: map['active'] == true,
+      playing: map['playing'] == true,
+      position: Duration(milliseconds: _asInt(map['positionMs']) ?? 0),
+      duration: _asInt(map['durationMs']) == null
+          ? null
+          : Duration(milliseconds: _asInt(map['durationMs'])!),
+      sampleRate: _asInt(map['sampleRate']),
+      bitDepth: _asInt(map['bitDepth']),
+      format: map['format'] as String?,
+      message: map['message'] as String?,
+    );
+  }
+}
+
+@immutable
+class UsbTransportTelemetry {
+  final bool active;
+  final Duration bufferLevel;
+  final Duration? minimumBufferLevel;
+  final Duration? targetBuffer;
+  final int isoPacketCount;
+  final int pendingUrbs;
+  final int underrunCount;
+  final int updatedAtMs;
+
+  const UsbTransportTelemetry({
+    required this.active,
+    required this.bufferLevel,
+    required this.minimumBufferLevel,
+    required this.targetBuffer,
+    required this.isoPacketCount,
+    required this.pendingUrbs,
+    required this.underrunCount,
+    required this.updatedAtMs,
+  });
+
+  factory UsbTransportTelemetry.inactive() {
+    return const UsbTransportTelemetry(
+      active: false,
+      bufferLevel: Duration.zero,
+      minimumBufferLevel: null,
+      targetBuffer: null,
+      isoPacketCount: 0,
+      pendingUrbs: 0,
+      underrunCount: 0,
+      updatedAtMs: 0,
+    );
+  }
+
+  factory UsbTransportTelemetry.fromMap(Map<String, Object?> map) {
+    return UsbTransportTelemetry(
+      active: map['active'] == true,
+      bufferLevel: Duration(
+        milliseconds: _asInt(map['bufferLevelMs'])?.clamp(0, 60000) ?? 0,
+      ),
+      minimumBufferLevel: _durationFromMs(map['minimumBufferLevelMs']),
+      targetBuffer: _durationFromMs(map['targetBufferMs']),
+      isoPacketCount: _asInt(map['isoPacketCount']) ?? 0,
+      pendingUrbs: _asInt(map['pendingUrbs']) ?? 0,
+      underrunCount: _asInt(map['underrunCount']) ?? 0,
+      updatedAtMs: _asInt(map['updatedAtMs']) ?? 0,
+    );
+  }
+}
+
+@immutable
+class UsbExclusiveProbeResult {
+  final bool supported;
+  final bool permissionGranted;
+  final String? deviceName;
+  final int? deviceId;
+  final int audioInterfaceCount;
+  final int claimedInterfaceCount;
+  final int rawDescriptorLength;
+  final String? message;
+
+  const UsbExclusiveProbeResult({
+    required this.supported,
+    required this.permissionGranted,
+    required this.deviceName,
+    required this.deviceId,
+    required this.audioInterfaceCount,
+    required this.claimedInterfaceCount,
+    required this.rawDescriptorLength,
+    required this.message,
+  });
+
+  factory UsbExclusiveProbeResult.fromMap(Map<String, Object?> map) {
+    return UsbExclusiveProbeResult(
+      supported: map['supported'] == true,
+      permissionGranted: map['permissionGranted'] == true,
+      deviceName: map['deviceName'] as String?,
+      deviceId: _asInt(map['deviceId']),
+      audioInterfaceCount: _asInt(map['audioInterfaceCount']) ?? 0,
+      claimedInterfaceCount: _asInt(map['claimedInterfaceCount']) ?? 0,
+      rawDescriptorLength: _asInt(map['rawDescriptorLength']) ?? 0,
+      message: map['message'] as String?,
+    );
+  }
+
+  bool get interfaceClaimed => claimedInterfaceCount > 0;
+}
+
+@immutable
+class UsbAudioDeviceEvent {
+  final UsbAudioDeviceEventType type;
+  final int? deviceId;
+  final UsbAudioStatus status;
+
+  const UsbAudioDeviceEvent({
+    required this.type,
+    required this.deviceId,
+    required this.status,
+  });
+
+  factory UsbAudioDeviceEvent.fromMap(Map<String, Object?> map) {
+    return UsbAudioDeviceEvent(
+      type: map['type'] == 'removed'
+          ? UsbAudioDeviceEventType.removed
+          : UsbAudioDeviceEventType.added,
+      deviceId: _asInt(map['deviceId']),
+      status: UsbAudioStatus.fromMap(
+        (map['status'] as Map?)?.cast<String, Object?>() ?? const {},
+      ),
+    );
+  }
+}
+
+@immutable
+class UsbAudioStatus {
+  final bool supported;
+  final int androidSdk;
+  final int? activeDeviceId;
+  final bool preferredApplied;
+  final int? preferredSampleRate;
+  final String? preferredEncoding;
+  final bool preferredBitPerfect;
+  final String? outputDeviceName;
+  final int? outputSampleRate;
+  final String? outputEncoding;
+  final String? message;
+  final List<UsbAudioDevice> devices;
+
+  const UsbAudioStatus({
+    required this.supported,
+    required this.androidSdk,
+    required this.activeDeviceId,
+    required this.preferredApplied,
+    required this.preferredSampleRate,
+    required this.preferredEncoding,
+    required this.preferredBitPerfect,
+    required this.outputDeviceName,
+    required this.outputSampleRate,
+    required this.outputEncoding,
+    required this.message,
+    required this.devices,
+  });
+
+  factory UsbAudioStatus.unavailable({String? message}) {
+    return UsbAudioStatus(
+      supported: false,
+      androidSdk: 0,
+      activeDeviceId: null,
+      preferredApplied: false,
+      preferredSampleRate: null,
+      preferredEncoding: null,
+      preferredBitPerfect: false,
+      outputDeviceName: null,
+      outputSampleRate: null,
+      outputEncoding: null,
+      message: message,
+      devices: const [],
+    );
+  }
+
+  factory UsbAudioStatus.fromMap(Map<String, Object?> map) {
+    final devicesRaw = map['devices'];
+    final devices = devicesRaw is List
+        ? devicesRaw
+              .whereType<Map>()
+              .map(
+                (device) =>
+                    UsbAudioDevice.fromMap(device.cast<String, Object?>()),
+              )
+              .toList(growable: false)
+        : const <UsbAudioDevice>[];
+
+    return UsbAudioStatus(
+      supported: map['supported'] == true,
+      androidSdk: _asInt(map['androidSdk']) ?? 0,
+      activeDeviceId: _asInt(map['activeDeviceId']),
+      preferredApplied: map['preferredApplied'] == true,
+      preferredSampleRate: _asInt(map['preferredSampleRate']),
+      preferredEncoding: map['preferredEncoding'] as String?,
+      preferredBitPerfect: map['preferredBitPerfect'] == true,
+      outputDeviceName: map['outputDeviceName'] as String?,
+      outputSampleRate: _asInt(map['outputSampleRate']),
+      outputEncoding: map['outputEncoding'] as String?,
+      message: map['message'] as String?,
+      devices: devices,
+    );
+  }
+
+  int? get bestAvailableDeviceId {
+    if (activeDeviceId != null) {
+      return activeDeviceId;
+    }
+    return devices.isEmpty ? null : devices.first.id;
+  }
+
+  int? get bestAvailableSampleRate {
+    final deviceId = bestAvailableDeviceId;
+    if (deviceId == null) {
+      return null;
+    }
+    for (final device in devices) {
+      if (device.id == deviceId) {
+        return device.bestSampleRate;
+      }
+    }
+    return null;
+  }
+}
+
+@immutable
+class UsbAudioDevice {
+  final int id;
+  final String name;
+  final String type;
+  final String? address;
+  final List<int> sampleRates;
+  final List<String> encodings;
+  final List<int> channelCounts;
+  final List<int> supportedMixerSampleRates;
+  final bool supportsBitPerfectMixer;
+
+  const UsbAudioDevice({
+    required this.id,
+    required this.name,
+    required this.type,
+    required this.address,
+    required this.sampleRates,
+    required this.encodings,
+    required this.channelCounts,
+    required this.supportedMixerSampleRates,
+    required this.supportsBitPerfectMixer,
+  });
+
+  factory UsbAudioDevice.fromMap(Map<String, Object?> map) {
+    return UsbAudioDevice(
+      id: _asInt(map['id']) ?? -1,
+      name: (map['name'] as String?)?.trim().isNotEmpty == true
+          ? map['name'] as String
+          : 'USB audio device',
+      type: map['type'] as String? ?? 'unknown',
+      address: map['address'] as String?,
+      sampleRates: _asIntList(map['sampleRates']),
+      encodings: _asStringList(map['encodings']),
+      channelCounts: _asIntList(map['channelCounts']),
+      supportedMixerSampleRates: _asIntList(map['supportedMixerSampleRates']),
+      supportsBitPerfectMixer: map['supportsBitPerfectMixer'] == true,
+    );
+  }
+
+  int? get bestSampleRate {
+    final candidates = supportedMixerSampleRates.isNotEmpty
+        ? supportedMixerSampleRates
+        : sampleRates;
+    if (candidates.isEmpty) {
+      return null;
+    }
+    final validRates = candidates
+        .where(UsbAudioPreferences.sampleRates.contains)
+        .toSet();
+    for (final rate in const [48000, 44100, 96000, 88200, 192000, 176400]) {
+      if (validRates.contains(rate)) {
+        return rate;
+      }
+    }
+    return null;
+  }
+}
+
+int? _asInt(Object? value) {
+  if (value is int) return value;
+  if (value is num) return value.toInt();
+  return null;
+}
+
+Duration? _durationFromMs(Object? value) {
+  final milliseconds = _asInt(value);
+  if (milliseconds == null) return null;
+  return Duration(milliseconds: milliseconds.clamp(0, 60000));
+}
+
+List<int> _asIntList(Object? value) {
+  if (value is! List) {
+    return const [];
+  }
+  return value.map(_asInt).whereType<int>().toList(growable: false);
+}
+
+List<String> _asStringList(Object? value) {
+  if (value is! List) {
+    return const [];
+  }
+  return value.whereType<String>().toList(growable: false);
+}

--- a/lib/base/utils/path.dart
+++ b/lib/base/utils/path.dart
@@ -67,7 +67,15 @@ String getPicturesPath(SourceType sourceType) {
 final _httpClient = http.Client();
 
 Future<String?> convertToRealPathIfNeed(String path) async {
-  final request = http.Request('HEAD', Uri.parse(path))
+  final uri = Uri.tryParse(path);
+  if (uri == null ||
+      !(uri.isScheme('http') || uri.isScheme('https')) ||
+      !uri.hasAuthority ||
+      uri.host.isEmpty) {
+    return null;
+  }
+
+  final request = http.Request('HEAD', uri)
     ..followRedirects = false
     ..headers.addAll(webdavClient?.headers ?? {});
 

--- a/lib/base/widgets/audio_output_panel.dart
+++ b/lib/base/widgets/audio_output_panel.dart
@@ -1,0 +1,935 @@
+import 'package:flutter/material.dart';
+import 'package:sylvakru/base/my_audio_metadata.dart';
+import 'package:sylvakru/base/services/color_manager.dart';
+import 'package:sylvakru/base/services/interaction.dart';
+import 'package:sylvakru/base/services/usb_audio_preferences.dart';
+import 'package:sylvakru/base/services/usb_audio_service.dart';
+
+String formatSampleRate(int? sampleRate) {
+  if (sampleRate == null || sampleRate <= 0) {
+    return '未知';
+  }
+
+  final khz = sampleRate / 1000.0;
+  if (khz == khz.roundToDouble()) {
+    return '${khz.round()} kHz';
+  }
+  return '${khz.toStringAsFixed(1)} kHz';
+}
+
+String formatOutputSampleRate(UsbAudioStatus status) {
+  final exclusive = usbExclusivePlaybackStateNotifier.value;
+  if (exclusive.active && exclusive.sampleRate != null) {
+    return formatSampleRate(exclusive.sampleRate);
+  }
+
+  return formatSampleRate(
+    status.preferredSampleRate ?? status.outputSampleRate,
+  );
+}
+
+String formatOutputDeviceName(UsbAudioStatus status) {
+  if (!status.supported) {
+    final name = status.outputDeviceName?.toLowerCase();
+    if (name == null || name.contains('speaker') || name.contains('扬声器')) {
+      return '扬声器';
+    }
+    return status.outputDeviceName!;
+  }
+  final device = _activeUsbDevice(status);
+  if (device != null) {
+    return device.name;
+  }
+  return status.outputDeviceName ?? 'USB DAC';
+}
+
+String formatBitrate(int? bitrate) {
+  if (bitrate == null || bitrate <= 0) {
+    return '未知';
+  }
+  final kbps = bitrate >= 100000 ? (bitrate / 1000).round() : bitrate;
+  return '$kbps kbps';
+}
+
+String formatSourceFileName(String? path) {
+  if (path == null || path.isEmpty) {
+    return '未知';
+  }
+  final normalized = path.replaceAll('\\', '/');
+  final parts = normalized.split('/');
+  return parts.isEmpty ? normalized : parts.last;
+}
+
+String formatOutputPortLabel(UsbAudioStatus status) {
+  if (!status.supported) {
+    return formatOutputDeviceName(status);
+  }
+  final exclusive = usbExclusivePlaybackStateNotifier.value;
+  if (exclusive.active) {
+    return 'USB 独占';
+  }
+  final name = _shortOutputName(status);
+  return status.preferredApplied ? '$name · 已应用偏好' : '$name · USB 输出';
+}
+
+List<int?> buildSampleRateOptions(
+  UsbAudioStatus status,
+  int? sourceSampleRate,
+) {
+  final options = <int?>[null];
+  final deviceId = status.bestAvailableDeviceId;
+  UsbAudioDevice? activeDevice;
+
+  for (final device in status.devices) {
+    if (device.id == deviceId) {
+      activeDevice = device;
+      break;
+    }
+  }
+
+  final preferredRates =
+      activeDevice?.supportedMixerSampleRates.isNotEmpty == true
+      ? activeDevice!.supportedMixerSampleRates
+      : activeDevice?.sampleRates ?? const <int>[];
+  final sortedRates = preferredRates.toSet().toList()..sort();
+
+  options.addAll(sortedRates);
+  if (sourceSampleRate != null &&
+      sourceSampleRate > 0 &&
+      UsbAudioPreferences.sampleRates.contains(sourceSampleRate) &&
+      !options.contains(sourceSampleRate)) {
+    options.add(sourceSampleRate);
+  }
+  return options;
+}
+
+int? preferredExclusiveSampleRate(
+  UsbAudioStatus status,
+  int? sourceSampleRate,
+) {
+  final fixedRate = usbAudioPreferences.preferredFixedSampleRate();
+  if (fixedRate != null) {
+    return fixedRate;
+  }
+
+  final matchedSourceRate = matchedSafeSampleRate(sourceSampleRate);
+  final deviceRates = buildSampleRateOptions(status, null).whereType<int>();
+  if (matchedSourceRate != null && deviceRates.contains(matchedSourceRate)) {
+    return matchedSourceRate;
+  }
+  return bestExclusiveDeviceSampleRate(status);
+}
+
+int? bestExclusiveDeviceSampleRate(UsbAudioStatus status) {
+  final rates = buildSampleRateOptions(status, null).whereType<int>().toList();
+  if (rates.isEmpty) {
+    return status.bestAvailableSampleRate;
+  }
+  rates.sort();
+  return rates.last;
+}
+
+int? matchedSafeSampleRate(int? sourceSampleRate) {
+  if (sourceSampleRate == null || sourceSampleRate <= 0) {
+    return null;
+  }
+
+  final supportedRates = UsbAudioPreferences.sampleRates;
+  if (supportedRates.contains(sourceSampleRate)) {
+    return sourceSampleRate;
+  }
+
+  final sameFamilyRates =
+      supportedRates.where((rate) => sourceSampleRate % rate == 0).toList()
+        ..sort();
+  if (sameFamilyRates.isNotEmpty) {
+    return sameFamilyRates.last;
+  }
+
+  return supportedRates
+      .where((rate) => rate <= sourceSampleRate)
+      .fold<int?>(
+        null,
+        (best, rate) => best == null || rate > best ? rate : best,
+      );
+}
+
+Future<UsbAudioStatus> applyExclusiveOutputForSong(
+  UsbAudioStatus status,
+  MyAudioMetadata? song,
+) {
+  return usbAudioService.applyPreferredOutput(
+    deviceId: status.bestAvailableDeviceId,
+    sampleRate: preferredExclusiveSampleRate(status, song?.samplerate),
+    encoding: usbAudioPreferences.preferredEncoding(),
+  );
+}
+
+class AudioOutputChip extends StatelessWidget {
+  final MyAudioMetadata? song;
+  final Color color;
+
+  const AudioOutputChip({super.key, required this.song, required this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder(
+      valueListenable: usbAudioStatusNotifier,
+      builder: (context, status, child) {
+        final outputRate = formatOutputSampleRate(status);
+        final outputName = _shortOutputName(status);
+        final bitDepth = _bitDepthLabel(status);
+        final chipColor = _chipColor(color);
+
+        return Center(
+          child: Material(
+            color: Colors.transparent,
+            child: InkWell(
+              borderRadius: BorderRadius.circular(999),
+              onTap: () {
+                tryVibrate();
+                showAudioOutputSheet(context, song);
+              },
+              child: Container(
+                constraints: const BoxConstraints(maxWidth: 320),
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 14,
+                  vertical: 9,
+                ),
+                decoration: BoxDecoration(
+                  color: chipColor,
+                  borderRadius: BorderRadius.circular(999),
+                  border: Border.all(color: color.withAlpha(62)),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Colors.black.withAlpha(34),
+                      blurRadius: 14,
+                      offset: const Offset(0, 6),
+                    ),
+                  ],
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    _PulseDot(active: status.supported, color: color),
+                    const SizedBox(width: 9),
+                    Flexible(
+                      child: Text(
+                        '$outputRate  |  $bitDepth  |  $outputName',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          color: color.withAlpha(232),
+                          fontSize: 13,
+                          fontWeight: FontWeight.w600,
+                          letterSpacing: 0,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 7),
+                    Icon(
+                      Icons.tune_rounded,
+                      size: 17,
+                      color: color.withAlpha(214),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+Future<void> showAudioOutputSheet(
+  BuildContext context,
+  MyAudioMetadata? song,
+) async {
+  await usbAudioService.refreshStatus();
+  if (!context.mounted) return;
+
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    useSafeArea: true,
+    barrierColor: _barrierColor(),
+    backgroundColor: Colors.transparent,
+    builder: (context) => RepaintBoundary(child: _AudioOutputSheet(song: song)),
+  );
+}
+
+Future<void> showUsbAudioDetectedSheet(
+  BuildContext context,
+  UsbAudioStatus status,
+  MyAudioMetadata? song,
+) {
+  return showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    useSafeArea: true,
+    barrierColor: _barrierColor(),
+    backgroundColor: Colors.transparent,
+    builder: (context) => RepaintBoundary(
+      child: _UsbAudioDetectedSheet(
+        parentContext: context,
+        initialStatus: status,
+        song: song,
+      ),
+    ),
+  );
+}
+
+class _UsbAudioDetectedSheet extends StatefulWidget {
+  final BuildContext parentContext;
+  final UsbAudioStatus initialStatus;
+  final MyAudioMetadata? song;
+
+  const _UsbAudioDetectedSheet({
+    required this.parentContext,
+    required this.initialStatus,
+    required this.song,
+  });
+
+  @override
+  State<_UsbAudioDetectedSheet> createState() => _UsbAudioDetectedSheetState();
+}
+
+class _UsbAudioDetectedSheetState extends State<_UsbAudioDetectedSheet> {
+  bool _applying = false;
+  late UsbAudioStatus _status = widget.initialStatus;
+
+  Future<void> _enableExclusive() async {
+    setState(() {
+      _applying = true;
+    });
+
+    final nextStatus = await applyExclusiveOutputForSong(_status, widget.song);
+    if (!mounted) return;
+
+    setState(() {
+      _status = nextStatus;
+      _applying = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final foreground = lyricsPageForegroundColor.value;
+    final highlight = lyricsPageHighlightTextColor.value;
+    final background = _panelBackgroundColor(foreground);
+    final surface = _panelSurfaceColor(background, foreground);
+    final border = foreground.withAlpha(28);
+    final muted = foreground.withAlpha(150);
+    final canRequestExclusive =
+        _status.supported &&
+        _status.androidSdk >= 34 &&
+        _activeUsbDevice(_status)?.supportsBitPerfectMixer == true;
+
+    return Padding(
+      padding: EdgeInsets.only(
+        left: 12,
+        right: 12,
+        bottom: MediaQuery.viewInsetsOf(context).bottom + 12,
+      ),
+      child: Material(
+        color: background,
+        borderRadius: BorderRadius.circular(28),
+        clipBehavior: Clip.antiAlias,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(18, 16, 18, 20),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Center(
+                child: Container(
+                  width: 44,
+                  height: 4,
+                  decoration: BoxDecoration(
+                    color: Colors.white.withAlpha(45),
+                    borderRadius: BorderRadius.circular(99),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 18),
+              Row(
+                children: [
+                  _OutputGlyph(active: true, accent: highlight),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          '检测到 USB DAC',
+                          style: TextStyle(
+                            color: foreground,
+                            fontSize: 22,
+                            fontWeight: FontWeight.w800,
+                          ),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(
+                          _exclusiveStatusLabel(_status),
+                          style: TextStyle(color: muted, fontSize: 13),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              _SignalSection(
+                title: '设备',
+                accent: highlight,
+                foreground: foreground,
+                muted: muted,
+                surface: surface,
+                border: border,
+                rows: [
+                  _InfoRow('名称', _shortOutputName(_status)),
+                  _InfoRow('输出采样率', formatOutputSampleRate(_status)),
+                  _InfoRow('支持采样率', _supportedRatesLabel(_status)),
+                  _InfoRow('当前歌曲', formatSampleRate(widget.song?.samplerate)),
+                ],
+              ),
+              const SizedBox(height: 12),
+              _SignalSection(
+                title: '独占',
+                accent: canRequestExclusive
+                    ? const Color(0xFF50D890)
+                    : const Color(0xFFFFA33A),
+                foreground: foreground,
+                muted: muted,
+                surface: surface,
+                border: border,
+                rows: [
+                  _InfoRow('Android', 'API ${_status.androidSdk}'),
+                  _InfoRow('Bit-perfect', _bitPerfectSupportLabel(_status)),
+                  _InfoRow(
+                    '请求采样率',
+                    formatSampleRate(
+                      preferredExclusiveSampleRate(
+                        _status,
+                        widget.song?.samplerate,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 18),
+              Row(
+                children: [
+                  Expanded(
+                    child: OutlinedButton(
+                      onPressed: () {
+                        Navigator.of(context).pop();
+                        WidgetsBinding.instance.addPostFrameCallback((_) {
+                          if (widget.parentContext.mounted) {
+                            showAudioOutputSheet(
+                              widget.parentContext,
+                              widget.song,
+                            );
+                          }
+                        });
+                      },
+                      child: const Text('查看链路'),
+                    ),
+                  ),
+                  const SizedBox(width: 10),
+                  Expanded(
+                    child: ElevatedButton.icon(
+                      onPressed: canRequestExclusive && !_applying
+                          ? _enableExclusive
+                          : null,
+                      icon: _applying
+                          ? SizedBox(
+                              width: 16,
+                              height: 16,
+                              child: CircularProgressIndicator(
+                                strokeWidth: 2,
+                                color: foreground,
+                              ),
+                            )
+                          : const Icon(Icons.lock_rounded, size: 18),
+                      label: Text(_applying ? '请求中' : '启用独占'),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AudioOutputSheet extends StatefulWidget {
+  final MyAudioMetadata? song;
+
+  const _AudioOutputSheet({required this.song});
+
+  @override
+  State<_AudioOutputSheet> createState() => _AudioOutputSheetState();
+}
+
+class _AudioOutputSheetState extends State<_AudioOutputSheet> {
+  @override
+  Widget build(BuildContext context) {
+    final foreground = lyricsPageForegroundColor.value;
+    final highlight = lyricsPageHighlightTextColor.value;
+    final background = _panelBackgroundColor(foreground);
+    final surface = _panelSurfaceColor(background, foreground);
+    final border = foreground.withAlpha(28);
+    final muted = foreground.withAlpha(150);
+
+    return ValueListenableBuilder(
+      valueListenable: usbAudioStatusNotifier,
+      builder: (context, status, child) {
+        return Padding(
+          padding: EdgeInsets.only(
+            left: 12,
+            right: 12,
+            bottom: MediaQuery.viewInsetsOf(context).bottom + 12,
+          ),
+          child: Material(
+            color: background,
+            borderRadius: BorderRadius.circular(28),
+            clipBehavior: Clip.antiAlias,
+            child: Container(
+              constraints: BoxConstraints(
+                maxHeight: MediaQuery.heightOf(context) * 0.82,
+              ),
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(28),
+                border: Border.all(color: border),
+              ),
+              child: ListView(
+                shrinkWrap: true,
+                padding: const EdgeInsets.fromLTRB(18, 14, 18, 22),
+                children: [
+                  Center(
+                    child: Container(
+                      width: 44,
+                      height: 4,
+                      decoration: BoxDecoration(
+                        color: Colors.white.withAlpha(45),
+                        borderRadius: BorderRadius.circular(99),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: 20),
+                  Row(
+                    children: [
+                      _OutputGlyph(active: status.supported, accent: highlight),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              '音频输出',
+                              style: TextStyle(
+                                color: foreground,
+                                fontSize: 22,
+                                fontWeight: FontWeight.w800,
+                                letterSpacing: 0,
+                              ),
+                            ),
+                            const SizedBox(height: 4),
+                            Text(
+                              formatOutputDeviceName(status),
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
+                              style: TextStyle(color: muted, fontSize: 13),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 18),
+                  _SignalSection(
+                    title: '音频源',
+                    accent: highlight,
+                    foreground: foreground,
+                    muted: muted,
+                    surface: surface,
+                    border: border,
+                    rows: [
+                      _InfoRow('文件', _sourcePathLabel(widget.song)),
+                      _InfoRow(
+                        '输入采样率',
+                        formatSampleRate(widget.song?.samplerate),
+                      ),
+                      _InfoRow(
+                        '格式',
+                        widget.song?.format?.toUpperCase() ?? '未知',
+                      ),
+                      _InfoRow('码率', formatBitrate(widget.song?.bitrate)),
+                    ],
+                  ),
+                  const SizedBox(height: 12),
+                  _SignalSection(
+                    title: '处理链',
+                    accent: muted,
+                    foreground: foreground,
+                    muted: muted,
+                    surface: surface,
+                    border: border,
+                    rows: const [
+                      _InfoRow('均衡器', '关闭'),
+                      _InfoRow('PEQ', '关闭'),
+                      _InfoRow('DSP 插件', '未接入'),
+                    ],
+                  ),
+                  const SizedBox(height: 12),
+                  _SignalSection(
+                    title: '信号输出',
+                    accent: status.supported
+                        ? const Color(0xFF50D890)
+                        : const Color(0xFFFFA33A),
+                    foreground: foreground,
+                    muted: muted,
+                    surface: surface,
+                    border: border,
+                    rows: [
+                      _InfoRow('输出端口', _outputPortLabel(status)),
+                      _InfoRow('输出采样率', formatOutputSampleRate(status)),
+                      _InfoRow('编码', _outputEncodingLabel(status)),
+                      _InfoRow(
+                        'Bit-perfect',
+                        status.preferredBitPerfect
+                            ? '已请求'
+                            : status.supported
+                            ? '未启用'
+                            : '不可用',
+                      ),
+                    ],
+                  ),
+                  if (!status.supported) ...[
+                    const SizedBox(height: 14),
+                    Text(
+                      '未检测到 USB DAC。当前显示 Android 系统输出信息。',
+                      style: TextStyle(
+                        color: muted,
+                        fontSize: 12,
+                        height: 1.45,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _SignalSection extends StatelessWidget {
+  final String title;
+  final Color accent;
+  final Color foreground;
+  final Color muted;
+  final Color surface;
+  final Color border;
+  final List<_InfoRow> rows;
+
+  const _SignalSection({
+    required this.title,
+    required this.accent,
+    required this.foreground,
+    required this.muted,
+    required this.surface,
+    required this.border,
+    required this.rows,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: surface,
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(color: border),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Column(
+            children: [
+              Container(
+                width: 12,
+                height: 12,
+                decoration: BoxDecoration(
+                  color: accent,
+                  shape: BoxShape.circle,
+                ),
+              ),
+              Container(
+                width: 2,
+                height: 78,
+                margin: const EdgeInsets.only(top: 6),
+                decoration: BoxDecoration(
+                  color: accent.withAlpha(76),
+                  borderRadius: BorderRadius.circular(99),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(width: 14),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: TextStyle(
+                    color: foreground.withAlpha(232),
+                    fontSize: 15,
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+                const SizedBox(height: 10),
+                for (final row in rows)
+                  _InfoLine(row: row, foreground: foreground, muted: muted),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _InfoLine extends StatelessWidget {
+  final _InfoRow row;
+  final Color foreground;
+  final Color muted;
+
+  const _InfoLine({
+    required this.row,
+    required this.foreground,
+    required this.muted,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 7),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 86,
+            child: Text(
+              row.label,
+              style: TextStyle(color: muted.withAlpha(150), fontSize: 13),
+            ),
+          ),
+          Expanded(
+            child: Text(
+              row.value,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                color: foreground.withAlpha(222),
+                fontSize: 13,
+                height: 1.25,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _OutputGlyph extends StatelessWidget {
+  final bool active;
+  final Color accent;
+
+  const _OutputGlyph({required this.active, required this.accent});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 46,
+      height: 46,
+      decoration: BoxDecoration(
+        color: active
+            ? accent.withAlpha(45)
+            : lyricsPageForegroundColor.value.withAlpha(18),
+        shape: BoxShape.circle,
+        border: Border.all(
+          color: active
+              ? accent
+              : lyricsPageForegroundColor.value.withAlpha(62),
+        ),
+      ),
+      child: Icon(
+        active ? Icons.usb_rounded : Icons.graphic_eq_rounded,
+        color: active ? accent : lyricsPageForegroundColor.value.withAlpha(180),
+      ),
+    );
+  }
+}
+
+class _PulseDot extends StatelessWidget {
+  final bool active;
+  final Color color;
+
+  const _PulseDot({required this.active, required this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: 8,
+      height: 8,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: active ? color : color.withAlpha(120),
+        boxShadow: active
+            ? [
+                BoxShadow(
+                  color: color.withAlpha(120),
+                  blurRadius: 12,
+                  spreadRadius: 2,
+                ),
+              ]
+            : null,
+      ),
+    );
+  }
+}
+
+class _InfoRow {
+  final String label;
+  final String value;
+
+  const _InfoRow(this.label, this.value);
+}
+
+String _shortOutputName(UsbAudioStatus status) {
+  final exclusive = usbExclusivePlaybackStateNotifier.value;
+  if (exclusive.active) {
+    return 'USB';
+  }
+
+  if (!status.supported) {
+    return formatOutputDeviceName(status);
+  }
+  final device = _activeUsbDevice(status);
+  if (device != null) return device.name;
+  return status.outputDeviceName ?? 'USB DAC';
+}
+
+UsbAudioDevice? _activeUsbDevice(UsbAudioStatus status) {
+  for (final device in status.devices) {
+    if (device.id == status.bestAvailableDeviceId) {
+      return device;
+    }
+  }
+  return null;
+}
+
+String _supportedRatesLabel(UsbAudioStatus status) {
+  final device = _activeUsbDevice(status);
+  final rates = device?.supportedMixerSampleRates.isNotEmpty == true
+      ? device!.supportedMixerSampleRates
+      : device?.sampleRates ?? const <int>[];
+  if (rates.isEmpty) return '未知';
+  return rates.map(formatSampleRate).join(' / ');
+}
+
+String _bitPerfectSupportLabel(UsbAudioStatus status) {
+  if (!status.supported) return '不可用';
+  if (status.androidSdk < 34) return '需要 Android 14+';
+  final device = _activeUsbDevice(status);
+  if (device?.supportsBitPerfectMixer == true) {
+    return status.preferredBitPerfect ? '已请求' : '可用';
+  }
+  return '设备未声明支持';
+}
+
+String _exclusiveStatusLabel(UsbAudioStatus status) {
+  if (!status.supported) return '未连接 USB 音频设备';
+  if (status.androidSdk < 34) return '当前系统不支持 USB 独占请求';
+  if (status.preferredBitPerfect && status.preferredSampleRate != null) {
+    return '已请求 USB 独占输出';
+  }
+  if (_activeUsbDevice(status)?.supportsBitPerfectMixer == true) {
+    return '可启用 USB 独占输出';
+  }
+  return '已连接 USB DAC，但未确认支持独占';
+}
+
+String _bitDepthLabel(UsbAudioStatus status) {
+  final exclusive = usbExclusivePlaybackStateNotifier.value;
+  if (exclusive.active && exclusive.bitDepth != null) {
+    return '${exclusive.bitDepth} bits';
+  }
+
+  final encoding = status.preferredEncoding ?? status.outputEncoding;
+  if (encoding == 'pcm_float') return '32 bits';
+  if (encoding == 'pcm_32bit') return '32 bits';
+  if (encoding == 'pcm_24bit_packed') return '24 bits';
+  if (encoding == 'pcm_16bit') return '16 bits';
+  return '未知';
+}
+
+String _outputEncodingLabel(UsbAudioStatus status) {
+  final encoding = status.preferredEncoding ?? status.outputEncoding;
+  if (encoding == null) return 'PCM / 系统默认';
+  final bitDepth = _bitDepthLabel(status);
+  return bitDepth == '未知' ? encoding : 'PCM / $bitDepth';
+}
+
+String _outputPortLabel(UsbAudioStatus status) {
+  return formatOutputPortLabel(status);
+}
+
+String _sourcePathLabel(MyAudioMetadata? song) {
+  return formatSourceFileName(song?.path ?? song?.cachePath);
+}
+
+Color _chipColor(Color foreground) {
+  final background = _panelBackgroundColor(foreground);
+  return Color.alphaBlend(foreground.withAlpha(18), background.withAlpha(220));
+}
+
+Color _panelBackgroundColor(Color foreground) {
+  final tint = _panelTintColor();
+  final lightForeground = foreground.computeLuminance() > 0.45;
+  final neutral = lightForeground
+      ? const Color(0xFF24252B)
+      : const Color(0xFFF0F0F2);
+  return Color.alphaBlend(tint.withAlpha(lightForeground ? 96 : 136), neutral);
+}
+
+Color _panelSurfaceColor(Color background, Color foreground) {
+  final lightForeground = foreground.computeLuminance() > 0.45;
+  return Color.alphaBlend(
+    foreground.withAlpha(lightForeground ? 18 : 14),
+    background,
+  );
+}
+
+Color _barrierColor() {
+  final tint = _panelTintColor();
+  return Color.alphaBlend(tint.withAlpha(30), Colors.black.withAlpha(70));
+}
+
+Color _panelTintColor() {
+  final pageBackground = lyricsPageBackgroundColor.value;
+  return pageBackground == Colors.transparent
+      ? currentCoverArtColor
+      : pageBackground;
+}

--- a/lib/base/widgets/settings_list.dart
+++ b/lib/base/widgets/settings_list.dart
@@ -54,7 +54,7 @@ class SettingsList extends StatelessWidget {
                   subtitle: Text(
                     l10n.settingCount(
                       Platform.isAndroid
-                          ? 14
+                          ? 15
                           : Platform.isIOS
                           ? 14
                           : 12,
@@ -116,6 +116,9 @@ class SettingsList extends StatelessWidget {
           ),
 
         sliverBox(paddingIfNeed(isLandscape, equalizerListTile(context, l10n))),
+
+        if (Platform.isAndroid)
+          sliverBox(paddingIfNeed(isLandscape, audioOutputListTile(context))),
 
         sliverBox(paddingIfNeed(isLandscape, autoPlayOnStartupListTile(l10n))),
 
@@ -481,6 +484,18 @@ class SettingsList extends StatelessWidget {
           },
         ),
       ),
+    );
+  }
+
+  Widget audioOutputListTile(BuildContext context) {
+    return ListTile(
+      leading: Icon(Icons.usb_rounded, size: iconSize),
+      title: const Text('音频输出'),
+      subtitle: const Text('USB 独占、固定采样率、DSD 与位深'),
+      trailing: const Icon(Icons.chevron_right_rounded),
+      onTap: () {
+        layersManager.pushDetail('settings', 'audio_output');
+      },
     );
   }
 

--- a/lib/base/widgets/usb_audio_event_listener.dart
+++ b/lib/base/widgets/usb_audio_event_listener.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:sylvakru/base/services/usb_audio_service.dart';
+
+class UsbAudioEventListener extends StatefulWidget {
+  final Widget child;
+
+  const UsbAudioEventListener({super.key, required this.child});
+
+  @override
+  State<UsbAudioEventListener> createState() => _UsbAudioEventListenerState();
+}
+
+class _UsbAudioEventListenerState extends State<UsbAudioEventListener> {
+  UsbAudioDeviceEvent? _lastEvent;
+
+  @override
+  void initState() {
+    super.initState();
+    usbAudioEventNotifier.addListener(_handleUsbAudioEvent);
+  }
+
+  @override
+  void dispose() {
+    usbAudioEventNotifier.removeListener(_handleUsbAudioEvent);
+    super.dispose();
+  }
+
+  void _handleUsbAudioEvent() {
+    final event = usbAudioEventNotifier.value;
+    if (event == null || identical(event, _lastEvent)) {
+      return;
+    }
+    _lastEvent = event;
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      switch (event.type) {
+        case UsbAudioDeviceEventType.added:
+          break;
+        case UsbAudioDeviceEventType.removed:
+          _showRemovedMessage();
+          break;
+      }
+    });
+  }
+
+  void _showRemovedMessage() {
+    ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+      const SnackBar(
+        content: Text('USB DAC 已断开，已恢复 Android 系统输出'),
+        behavior: SnackBarBehavior.floating,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+}

--- a/lib/layer/audio_output_settings_layer.dart
+++ b/lib/layer/audio_output_settings_layer.dart
@@ -1,0 +1,1358 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:permission_handler/permission_handler.dart';
+import 'package:sylvakru/base/app.dart';
+import 'package:sylvakru/base/audio_handler.dart';
+import 'package:sylvakru/base/data/setting.dart';
+import 'package:sylvakru/base/my_audio_metadata.dart';
+import 'package:sylvakru/base/services/color_manager.dart';
+import 'package:sylvakru/base/services/usb_audio_preferences.dart';
+import 'package:sylvakru/base/services/usb_audio_service.dart';
+import 'package:sylvakru/base/utils/media_query.dart';
+import 'package:sylvakru/base/widgets/audio_output_panel.dart';
+import 'package:sylvakru/base/widgets/my_sheet.dart';
+import 'package:sylvakru/base/widgets/my_switch.dart';
+import 'package:sylvakru/landscape_view/title_bar.dart';
+import 'package:sylvakru/layer/layers_manager.dart';
+import 'package:sylvakru/layer/settings_layer.dart';
+import 'package:sylvakru/portrait_view/custom_appbar_leading.dart';
+
+enum AudioOutputSettingsPageKind { overview, fixedSampleRate, dsdMode }
+
+enum _TransportHealth { idle, paused, stable, low, underrun }
+
+_TransportHealth _transportHealth({
+  required bool active,
+  required bool playing,
+  required int levelMs,
+  required int? minimumMs,
+  required int targetMs,
+  required int underrunCount,
+}) {
+  if (!active) {
+    return _TransportHealth.idle;
+  }
+  if (!playing) {
+    return _TransportHealth.paused;
+  }
+  if (underrunCount > 0) {
+    return _TransportHealth.underrun;
+  }
+
+  final lowWatermark = (targetMs * 0.35).round().clamp(20, 250);
+  if (levelMs < lowWatermark ||
+      (minimumMs != null && minimumMs < lowWatermark)) {
+    return _TransportHealth.low;
+  }
+  return _TransportHealth.stable;
+}
+
+String _transportHealthLabel(_TransportHealth health) {
+  return switch (health) {
+    _TransportHealth.idle => '待机',
+    _TransportHealth.paused => '暂停',
+    _TransportHealth.stable => '稳定',
+    _TransportHealth.low => '偏低',
+    _TransportHealth.underrun => '欠载',
+  };
+}
+
+Color _transportHealthAccent(_TransportHealth health) {
+  return switch (health) {
+    _TransportHealth.stable => const Color(0xFF50D890),
+    _TransportHealth.low => const Color(0xFFFFB454),
+    _TransportHealth.underrun => const Color(0xFFFF6B6B),
+    _TransportHealth.idle ||
+    _TransportHealth.paused => highlightTextColor.value,
+  };
+}
+
+class AudioOutputSettingsLayer extends StatefulWidget {
+  final AudioOutputSettingsPageKind pageKind;
+
+  const AudioOutputSettingsLayer({
+    super.key,
+    this.pageKind = AudioOutputSettingsPageKind.overview,
+  });
+
+  @override
+  State<AudioOutputSettingsLayer> createState() =>
+      _AudioOutputSettingsLayerState();
+}
+
+class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
+  UsbExclusiveProbeResult? _exclusiveProbeResult;
+  bool _probingExclusive = false;
+  bool _refreshingStatus = false;
+
+  @override
+  Widget build(BuildContext context) {
+    if (isTooNarrow(context)) {
+      return Scaffold(
+        backgroundColor: Colors.transparent,
+        appBar: AppBar(
+          automaticallyImplyLeading: false,
+          leading: customAppBarLeading(context, label: 'settings'),
+          backgroundColor: Colors.transparent,
+          systemOverlayStyle: mainPageThemeNotifier.value == .dark
+              ? .light
+              : .dark,
+          elevation: 0,
+          scrolledUnderElevation: 0,
+          title: Text(_title),
+          centerTitle: true,
+        ),
+        body: _content(),
+      );
+    }
+
+    return ValueListenableBuilder<bool>(
+      valueListenable: settingsVisibleNotifier,
+      builder: (context, visible, child) {
+        return Opacity(
+          opacity: visible ? 0 : 1,
+          child: Column(
+            children: [
+              TitleBar(backToRoot: () => layersManager.popDetail('settings')),
+              Expanded(child: _content()),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  String get _title {
+    return switch (widget.pageKind) {
+      AudioOutputSettingsPageKind.overview => 'USB 输出设置',
+      AudioOutputSettingsPageKind.fixedSampleRate => '固定采样率输出',
+      AudioOutputSettingsPageKind.dsdMode => 'DSD 模式',
+    };
+  }
+
+  Widget _content() {
+    return Center(
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 620),
+        child: ValueListenableBuilder(
+          valueListenable: mainPageThemeNotifier,
+          builder: (context, value, child) {
+            return ListView(
+              padding: const EdgeInsets.fromLTRB(16, 8, 16, 120),
+              children: [
+                switch (widget.pageKind) {
+                  AudioOutputSettingsPageKind.overview => _overview(),
+                  AudioOutputSettingsPageKind.fixedSampleRate =>
+                    _fixedSampleRate(),
+                  AudioOutputSettingsPageKind.dsdMode => _dsdMode(),
+                },
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _overview() {
+    final prefs = usbAudioPreferences;
+    return ValueListenableBuilder<UsbAudioStatus>(
+      valueListenable: usbAudioStatusNotifier,
+      builder: (context, status, _) {
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            _deviceStatusCard(status),
+            const SizedBox(height: 12),
+            _transportStatusCard(status),
+            const SizedBox(height: 18),
+            _sectionTitle('输出格式'),
+            _settingsCard(
+              children: [
+                _formatSummaryTile(status),
+                _switchTile(
+                  title: '位深兼容',
+                  subtitle: '设备不支持源位深时自动回退。',
+                  notifier: prefs.bitDepthCompatNotifier,
+                ),
+                _switchTile(
+                  title: '采样率兼容',
+                  subtitle: '设备不支持源采样率时自动回退。',
+                  notifier: prefs.sampleRateCompatNotifier,
+                ),
+                _switchTile(
+                  title: '声道兼容',
+                  subtitle: '设备不支持源声道时自动回退到可用声道。',
+                  notifier: prefs.channelCompatNotifier,
+                ),
+                _switchTile(
+                  title: 'TPDF 抖动',
+                  subtitle: '高位深转 16-bit 时加入极低电平随机噪声，降低量化失真。',
+                  notifier: prefs.tpdfDitherNotifier,
+                ),
+                _navTile(
+                  title: '固定采样率输出',
+                  value: prefs.fixedSampleRateEnabledNotifier.value
+                      ? formatSampleRate(prefs.fixedSampleRateNotifier.value)
+                      : '关闭',
+                  onTap: () {
+                    layersManager.pushDetail(
+                      'settings',
+                      'usb_fixed_sample_rate',
+                    );
+                  },
+                ),
+                _navTile(
+                  title: 'DSD 模式',
+                  value: _dsdModeLabel(prefs.dsdModeNotifier.value),
+                  onTap: () {
+                    layersManager.pushDetail('settings', 'usb_dsd_mode');
+                  },
+                ),
+                _choiceTile<UsbBitDepthMode>(
+                  title: 'PCM 位深',
+                  notifier: prefs.bitDepthModeNotifier,
+                  values: UsbBitDepthMode.values,
+                  label: _bitDepthModeLabel,
+                ),
+              ],
+            ),
+            const SizedBox(height: 18),
+            _sectionTitle('后台稳定性'),
+            _settingsCard(
+              children: [
+                _noticeTile(
+                  icon: Icons.battery_alert_rounded,
+                  title: '建议关闭电池优化',
+                  subtitle: '否则后台播放或切到大型 App 时，USB 独占链路可能被系统暂停。',
+                  actionLabel: '打开设置',
+                  onTap: openAppSettings,
+                ),
+                _switchTile(
+                  title: 'USB 独占模式',
+                  subtitle: '连接 DAC 后启用独占提示与高优先级输出策略。',
+                  notifier: prefs.performanceModeNotifier,
+                ),
+                _switchTile(
+                  title: '保持后台活动',
+                  subtitle: '减少后台播放时 USB 输出被系统中断的概率。',
+                  notifier: prefs.keepAliveInBackgroundNotifier,
+                ),
+              ],
+            ),
+            const SizedBox(height: 18),
+            _sectionTitle('传输缓冲'),
+            _settingsCard(
+              children: [
+                _bufferSlider(
+                  title: '前台缓冲区',
+                  notifier: prefs.foregroundBufferMsNotifier,
+                  min: 50,
+                  max: 1000,
+                  divisions: 19,
+                  onChanged: (value) =>
+                      _applyExclusiveBufferIfActive(foregroundBufferMs: value),
+                ),
+                _bufferSlider(
+                  title: '后台缓冲区',
+                  notifier: prefs.backgroundBufferMsNotifier,
+                  min: 500,
+                  max: 5000,
+                  divisions: 18,
+                  onChanged: (value) =>
+                      _applyExclusiveBufferIfActive(backgroundBufferMs: value),
+                ),
+                _hintTile('后台打开大型 App 出现卡顿时优先提高后台缓冲；数值越大越稳定，切歌与暂停响应可能稍慢。'),
+              ],
+            ),
+            const SizedBox(height: 18),
+            _sectionTitle('音量'),
+            _settingsCard(
+              children: [
+                _choiceTile<UsbVolumeLockMode>(
+                  title: '音量控制',
+                  notifier: prefs.volumeLockModeNotifier,
+                  values: UsbVolumeLockMode.values,
+                  label: _volumeLockLabel,
+                ),
+                _choiceTile<int>(
+                  title: 'DSD 增益补偿',
+                  notifier: prefs.dsdGainCompensationNotifier,
+                  values: const [-12, -9, -6, -3, 0, 3, 6],
+                  label: (value) => '$value dB',
+                ),
+                _mediaVolumeTile(),
+                _switchTile(
+                  title: '音量平滑交接',
+                  subtitle: '切换数字音量与 DAC 硬件音量时保持响度连续。',
+                  notifier: prefs.volumeSmoothHandoffNotifier,
+                ),
+              ],
+            ),
+            const SizedBox(height: 18),
+            _sectionTitle('兼容性'),
+            _settingsCard(
+              children: [
+                _switchTile(
+                  title: '延迟建立 USB 输出链路',
+                  subtitle: '播放开始时再建立独占会话，适合部分 DAC 卡死或控制界面异常的使用场景。',
+                  notifier: prefs.delayedUsbLinkNotifier,
+                ),
+                _choiceTile<UsbBusSpeedMode>(
+                  title: 'USB 总线速度',
+                  notifier: prefs.busSpeedModeNotifier,
+                  values: UsbBusSpeedMode.values,
+                  label: _busSpeedLabel,
+                ),
+                _switchTile(
+                  title: '播放后释放 USB 带宽',
+                  subtitle: '停止播放后允许系统回收 USB 音频资源。',
+                  notifier: prefs.releaseUsbBandwidthAfterPlaybackNotifier,
+                ),
+              ],
+            ),
+            const SizedBox(height: 18),
+            _sectionTitle('支持'),
+            _settingsCard(
+              children: [
+                _actionTile(
+                  icon: Icons.fact_check_rounded,
+                  title: 'USB 独占后台诊断',
+                  subtitle: _exclusiveProbeSummary(),
+                  actionLabel: _probingExclusive ? '检测中' : '开始检测',
+                  onTap: _probingExclusive ? null : _runExclusiveProbe,
+                ),
+                _actionTile(
+                  icon: Icons.feedback_rounded,
+                  title: 'USB 独占模式反馈',
+                  subtitle: '复制当前设备与输出链路信息，方便继续排查 DAC 兼容问题。',
+                  actionLabel: '查看状态',
+                  onTap: () => _showStatusSnack(status),
+                ),
+              ],
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _deviceStatusCard(UsbAudioStatus status) {
+    return ValueListenableBuilder<UsbExclusivePlaybackState>(
+      valueListenable: usbExclusivePlaybackStateNotifier,
+      builder: (context, exclusive, _) {
+        final device = _activeUsbDevice(status);
+        final supported = status.supported;
+        final accent = supported ? const Color(0xFF50D890) : textColor.value;
+        final foreground = textColor.value;
+        final background = Color.alphaBlend(
+          accent.withAlpha(mainPageThemeNotifier.value == .dark ? 34 : 20),
+          menuColor.value,
+        );
+        final title = supported ? device?.name ?? 'USB DAC' : '未识别 USB 设备';
+        final statusLabel = supported ? '已连接' : '未连接';
+        final linkLabel = supported
+            ? (exclusive.active ? '独占播放' : '运行中')
+            : '待连接';
+        final formatLabel = 'PCM ${formatOutputSampleRate(status)}'.replaceAll(
+          '未知',
+          '系统默认',
+        );
+
+        return DecoratedBox(
+          decoration: BoxDecoration(
+            color: background,
+            borderRadius: BorderRadius.circular(18),
+            border: Border.all(color: accent.withAlpha(70)),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 18),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Icon(Icons.usb_rounded, color: foreground.withAlpha(170)),
+                    const SizedBox(width: 10),
+                    Text(
+                      'USB EXCLUSIVE',
+                      style: TextStyle(
+                        color: foreground.withAlpha(150),
+                        fontSize: 13,
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                    const Spacer(),
+                    Container(
+                      width: 8,
+                      height: 8,
+                      decoration: BoxDecoration(
+                        color: supported ? accent : foreground.withAlpha(100),
+                        shape: BoxShape.circle,
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Text(
+                      statusLabel,
+                      style: TextStyle(
+                        color: foreground.withAlpha(165),
+                        fontSize: 13,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                    const SizedBox(width: 4),
+                    _refreshingStatus
+                        ? const SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : IconButton(
+                            tooltip: '刷新 USB 状态',
+                            onPressed: _refreshStatus,
+                            icon: const Icon(Icons.refresh_rounded),
+                          ),
+                  ],
+                ),
+                const SizedBox(height: 18),
+                Text(
+                  title,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: foreground,
+                    fontSize: 24,
+                    height: 1.05,
+                    fontWeight: FontWeight.w900,
+                  ),
+                ),
+                const SizedBox(height: 22),
+                Row(
+                  children: [
+                    Container(
+                      width: 8,
+                      height: 8,
+                      decoration: BoxDecoration(
+                        color: supported ? accent : foreground.withAlpha(100),
+                        shape: BoxShape.circle,
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Text(
+                      'OUTPUT LINK',
+                      style: TextStyle(
+                        color: foreground.withAlpha(135),
+                        fontSize: 12,
+                        fontWeight: FontWeight.w900,
+                      ),
+                    ),
+                    const SizedBox(width: 14),
+                    Text(
+                      linkLabel,
+                      style: TextStyle(
+                        color: foreground.withAlpha(190),
+                        fontSize: 14,
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 22),
+                Row(
+                  children: [
+                    Expanded(child: _metricColumn('FORMAT', formatLabel)),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: _metricColumn('DEPTH', _compactDepthLabel(status)),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: _metricColumn('USB ID', _usbIdLabel(device)),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _transportStatusCard(UsbAudioStatus status) {
+    return ValueListenableBuilder<int>(
+      valueListenable: usbAudioPreferences.foregroundBufferMsNotifier,
+      builder: (context, foregroundTargetMs, _) {
+        return ValueListenableBuilder<UsbExclusivePlaybackState>(
+          valueListenable: usbExclusivePlaybackStateNotifier,
+          builder: (context, exclusive, _) {
+            return ValueListenableBuilder<UsbTransportTelemetry>(
+              valueListenable: usbTransportTelemetryNotifier,
+              builder: (context, telemetry, _) {
+                final active = exclusive.active || telemetry.active;
+                final targetMs = _currentExclusiveTargetBufferMs(
+                  foregroundTargetMs: foregroundTargetMs,
+                  backgroundTargetMs:
+                      usbAudioPreferences.backgroundBufferMsNotifier.value,
+                );
+                final levelMs = telemetry.active
+                    ? telemetry.bufferLevel.inMilliseconds
+                    : 0;
+                final minimumMs = telemetry.minimumBufferLevel?.inMilliseconds;
+                final clampedLevel = levelMs.clamp(0, targetMs);
+                final progress = targetMs <= 0 ? 0.0 : clampedLevel / targetMs;
+                final health = _transportHealth(
+                  active: active,
+                  playing: exclusive.playing,
+                  levelMs: levelMs,
+                  minimumMs: minimumMs,
+                  targetMs: targetMs,
+                  underrunCount: telemetry.underrunCount,
+                );
+                final accent = _transportHealthAccent(health);
+                final foreground = textColor.value;
+                final background = Color.alphaBlend(
+                  accent.withAlpha(
+                    mainPageThemeNotifier.value == .dark ? 36 : 24,
+                  ),
+                  menuColor.value,
+                );
+
+                return DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: background,
+                    borderRadius: BorderRadius.circular(16),
+                    border: Border.all(color: accent.withAlpha(60)),
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(16, 14, 16, 14),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.stretch,
+                      children: [
+                        Row(
+                          children: [
+                            Expanded(
+                              child: Text(
+                                '传输状态',
+                                style: TextStyle(
+                                  color: foreground,
+                                  fontSize: 18,
+                                  fontWeight: FontWeight.w800,
+                                ),
+                              ),
+                            ),
+                            Text(
+                              _transportHealthLabel(health),
+                              style: TextStyle(
+                                color: active
+                                    ? accent
+                                    : foreground.withAlpha(170),
+                                fontWeight: FontWeight.w800,
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 18),
+                        Row(
+                          crossAxisAlignment: CrossAxisAlignment.end,
+                          children: [
+                            Flexible(
+                              flex: 4,
+                              child: FittedBox(
+                                fit: BoxFit.scaleDown,
+                                alignment: Alignment.bottomLeft,
+                                child: Text(
+                                  '$levelMs ms',
+                                  style: TextStyle(
+                                    color: foreground,
+                                    fontSize: 34,
+                                    height: 0.95,
+                                    fontWeight: FontWeight.w900,
+                                  ),
+                                ),
+                              ),
+                            ),
+                            const SizedBox(width: 10),
+                            Expanded(
+                              flex: 3,
+                              child: Padding(
+                                padding: const EdgeInsets.only(bottom: 3),
+                                child: Text(
+                                  '缓冲区水位',
+                                  maxLines: 1,
+                                  overflow: TextOverflow.ellipsis,
+                                  style: TextStyle(
+                                    color: foreground.withAlpha(145),
+                                    fontSize: 15,
+                                    fontWeight: FontWeight.w700,
+                                  ),
+                                ),
+                              ),
+                            ),
+                            Padding(
+                              padding: const EdgeInsets.only(bottom: 3),
+                              child: Text(
+                                'ISO ${telemetry.active ? telemetry.isoPacketCount : 0}',
+                                style: TextStyle(
+                                  color: foreground.withAlpha(175),
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.w800,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 12),
+                        ClipRRect(
+                          borderRadius: BorderRadius.circular(999),
+                          child: LinearProgressIndicator(
+                            value: progress,
+                            minHeight: 8,
+                            backgroundColor: foreground.withAlpha(28),
+                            valueColor: AlwaysStoppedAnimation<Color>(accent),
+                          ),
+                        ),
+                        const SizedBox(height: 10),
+                        Row(
+                          children: [
+                            Expanded(
+                              child: Text(
+                                active ? '目标 $targetMs ms' : '播放时建立目标水位',
+                                style: TextStyle(
+                                  color: foreground.withAlpha(135),
+                                  fontSize: 12,
+                                  fontWeight: FontWeight.w700,
+                                ),
+                              ),
+                            ),
+                            Text(
+                              active && minimumMs != null
+                                  ? '最低 $minimumMs ms'
+                                  : '最低 --',
+                              style: TextStyle(
+                                color: foreground.withAlpha(135),
+                                fontSize: 12,
+                                fontWeight: FontWeight.w700,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                );
+              },
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Widget _fixedSampleRate() {
+    final prefs = usbAudioPreferences;
+    return Column(
+      children: [
+        _settingsCard(
+          children: [
+            _switchTile(
+              title: '启用固定采样率',
+              subtitle: '开启后 USB 输出优先使用下方选定采样率。',
+              notifier: prefs.fixedSampleRateEnabledNotifier,
+            ),
+            for (final rate in UsbAudioPreferences.sampleRates)
+              ValueListenableBuilder<int?>(
+                valueListenable: prefs.fixedSampleRateNotifier,
+                builder: (context, selectedRate, _) {
+                  return _radioTile<int>(
+                    title: formatSampleRate(rate),
+                    value: rate,
+                    groupValue: selectedRate,
+                    onTap: () {
+                      prefs.fixedSampleRateNotifier.value = rate;
+                      setting.save();
+                    },
+                  );
+                },
+              ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _dsdMode() {
+    final prefs = usbAudioPreferences;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _sectionTitle('DSD 输出策略'),
+        _settingsCard(
+          children: [
+            for (final mode in UsbDsdMode.values)
+              ValueListenableBuilder<UsbDsdMode>(
+                valueListenable: prefs.dsdModeNotifier,
+                builder: (context, selectedMode, _) {
+                  return _radioTile<UsbDsdMode>(
+                    title: _dsdModeLabel(mode),
+                    subtitle: _dsdModeHint(mode),
+                    value: mode,
+                    groupValue: selectedMode,
+                    onTap: () {
+                      prefs.dsdModeNotifier.value = mode;
+                      setting.save();
+                    },
+                  );
+                },
+              ),
+          ],
+        ),
+        const SizedBox(height: 18),
+        _sectionTitle('DSD to PCM'),
+        _settingsCard(
+          children: [
+            _dsdPcmRateTile('DSD64', prefs.dsd64PcmRateNotifier),
+            _dsdPcmRateTile('DSD128', prefs.dsd128PcmRateNotifier),
+            _dsdPcmRateTile('DSD256', prefs.dsd256PcmRateNotifier),
+            _dsdPcmRateTile('DSD512', prefs.dsd512PcmRateNotifier),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _dsdPcmRateTile(String title, ValueNotifier<int> notifier) {
+    return _choiceTile<int>(
+      title: title,
+      notifier: notifier,
+      values: UsbAudioPreferences.sampleRates,
+      label: (value) => '${formatSampleRate(value)} PCM',
+    );
+  }
+
+  Widget _settingsCard({required List<Widget> children}) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: menuColor.value,
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Column(
+        children: [
+          for (var index = 0; index < children.length; index++) ...[
+            children[index],
+            if (index != children.length - 1) _divider(),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _sectionTitle(String title) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(6, 0, 6, 8),
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: Text(
+          title,
+          style: TextStyle(
+            color: textColor.value.withAlpha(150),
+            fontSize: 13,
+            fontWeight: FontWeight.w800,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _switchTile({
+    required String title,
+    required String subtitle,
+    required ValueNotifier<bool> notifier,
+  }) {
+    return ListTile(
+      title: Text(title),
+      subtitle: Text(subtitle),
+      trailing: SizedBox(
+        width: 52,
+        child: MySwitch(
+          valueNotifier: notifier,
+          onToggleCallBack: setting.save,
+        ),
+      ),
+    );
+  }
+
+  Widget _navTile({
+    required String title,
+    required String value,
+    required VoidCallback onTap,
+  }) {
+    return ListTile(
+      title: Text(title),
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(value, style: TextStyle(color: textColor.value.withAlpha(150))),
+          const SizedBox(width: 6),
+          const Icon(Icons.chevron_right_rounded),
+        ],
+      ),
+      onTap: onTap,
+    );
+  }
+
+  Widget _formatSummaryTile(UsbAudioStatus status) {
+    return ValueListenableBuilder<MyAudioMetadata?>(
+      valueListenable: currentSongNotifier,
+      builder: (context, song, _) {
+        final channel = _channelCountLabel(status);
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 18),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _formatMetricRow('源文件', [
+                _sourceFormatLabel(song),
+                formatSampleRate(song?.samplerate),
+                channel,
+                _compactDepthLabel(status),
+              ]),
+              const SizedBox(height: 24),
+              _formatMetricRow('DAC 端点', [
+                'PCM',
+                formatOutputSampleRate(status),
+                channel,
+                _compactDepthLabel(status),
+              ]),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _formatMetricRow(String label, List<String> values) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: TextStyle(
+            color: textColor.value.withAlpha(145),
+            fontSize: 14,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Row(
+          children: [
+            for (var index = 0; index < values.length; index++) ...[
+              Expanded(
+                child: Text(
+                  values[index],
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: textColor.value.withAlpha(220),
+                    fontSize: 22,
+                    height: 1.05,
+                    fontWeight: FontWeight.w500,
+                  ),
+                ),
+              ),
+              if (index != values.length - 1) const SizedBox(width: 12),
+            ],
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _mediaVolumeTile() {
+    return ValueListenableBuilder<double>(
+      valueListenable: volumeNotifier,
+      builder: (context, volume, _) {
+        final percent = (volume.clamp(0.0, 1.0) * 100).round();
+        final sliderValue = volume.clamp(0.0, 1.0);
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      '当前媒体音量',
+                      style: const TextStyle(fontWeight: FontWeight.w700),
+                    ),
+                  ),
+                  Text(
+                    '$percent%',
+                    style: TextStyle(
+                      color: textColor.value.withAlpha(180),
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ],
+              ),
+              Slider(
+                value: sliderValue,
+                min: 0,
+                max: 1,
+                divisions: 100,
+                label: '$percent%',
+                onChanged: (next) {
+                  volumeNotifier.value = next;
+                  _setPlayerVolumeIfReady(next);
+                },
+                onChangeEnd: (_) => setting.save(),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  void _setPlayerVolumeIfReady(double volume) {
+    try {
+      audioHandler.setVolume(volume);
+    } on Error catch (error) {
+      if (!error.toString().contains('LateInitializationError')) rethrow;
+    }
+  }
+
+  Widget _noticeTile({
+    required IconData icon,
+    required String title,
+    required String subtitle,
+    required String actionLabel,
+    required VoidCallback onTap,
+  }) {
+    return ListTile(
+      leading: _iconBox(icon, const Color(0xFFFF6868), compact: true),
+      title: Text(title),
+      subtitle: Text(subtitle),
+      trailing: TextButton(onPressed: onTap, child: Text(actionLabel)),
+    );
+  }
+
+  Widget _actionTile({
+    required IconData icon,
+    required String title,
+    required String subtitle,
+    required String actionLabel,
+    required VoidCallback? onTap,
+  }) {
+    return ListTile(
+      leading: _iconBox(icon, highlightTextColor.value, compact: true),
+      title: Text(title),
+      subtitle: Text(subtitle),
+      trailing: TextButton(onPressed: onTap, child: Text(actionLabel)),
+    );
+  }
+
+  Widget _hintTile(String text) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 8, 16, 14),
+      child: Text(
+        text,
+        style: TextStyle(color: textColor.value.withAlpha(130), fontSize: 12),
+      ),
+    );
+  }
+
+  Widget _bufferSlider({
+    required String title,
+    required ValueNotifier<int> notifier,
+    required double min,
+    required double max,
+    required int divisions,
+    ValueChanged<int>? onChanged,
+  }) {
+    return ValueListenableBuilder<int>(
+      valueListenable: notifier,
+      builder: (context, value, _) {
+        final sliderValue = value.toDouble().clamp(min, max);
+        return Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 8),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      title,
+                      style: const TextStyle(fontWeight: FontWeight.w700),
+                    ),
+                  ),
+                  Text(
+                    '${sliderValue.round()} ms',
+                    style: TextStyle(
+                      color: textColor.value.withAlpha(180),
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ],
+              ),
+              Slider(
+                value: sliderValue,
+                min: min,
+                max: max,
+                divisions: divisions,
+                label: '${sliderValue.round()} ms',
+                onChanged: (next) {
+                  final rounded = next.round();
+                  notifier.value = rounded;
+                  onChanged?.call(rounded);
+                },
+                onChangeEnd: (_) => setting.save(),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _radioTile<T>({
+    required String title,
+    String? subtitle,
+    required T value,
+    required T? groupValue,
+    required VoidCallback onTap,
+  }) {
+    return ListTile(
+      title: Text(title),
+      subtitle: subtitle == null ? null : Text(subtitle),
+      trailing: groupValue == value
+          ? Icon(Icons.check_rounded, color: highlightTextColor.value)
+          : Icon(Icons.circle_outlined, color: textColor.value.withAlpha(120)),
+      onTap: onTap,
+    );
+  }
+
+  Widget _choiceTile<T>({
+    required String title,
+    required ValueNotifier<T> notifier,
+    required List<T> values,
+    required String Function(T value) label,
+  }) {
+    return ValueListenableBuilder<T>(
+      valueListenable: notifier,
+      builder: (context, value, _) {
+        return ListTile(
+          title: Text(title),
+          trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                label(value),
+                style: TextStyle(color: textColor.value.withAlpha(150)),
+              ),
+              const SizedBox(width: 6),
+              const Icon(Icons.chevron_right_rounded),
+            ],
+          ),
+          onTap: () => _showChoiceSheet<T>(
+            title: title,
+            notifier: notifier,
+            values: values,
+            label: label,
+          ),
+        );
+      },
+    );
+  }
+
+  void _showChoiceSheet<T>({
+    required String title,
+    required ValueNotifier<T> notifier,
+    required List<T> values,
+    required String Function(T value) label,
+  }) {
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      useRootNavigator: true,
+      backgroundColor: Colors.transparent,
+      builder: (context) {
+        return MySheet(
+          ListView(
+            shrinkWrap: true,
+            padding: const EdgeInsets.fromLTRB(12, 10, 12, 18),
+            children: [
+              ListTile(
+                title: Text(
+                  title,
+                  style: const TextStyle(fontWeight: FontWeight.w800),
+                ),
+              ),
+              for (final value in values)
+                ValueListenableBuilder<T>(
+                  valueListenable: notifier,
+                  builder: (context, currentValue, _) {
+                    return ListTile(
+                      title: Text(label(value)),
+                      trailing: currentValue == value
+                          ? Icon(
+                              Icons.check_rounded,
+                              color: highlightTextColor.value,
+                            )
+                          : null,
+                      onTap: () {
+                        notifier.value = value;
+                        setting.save();
+                        Navigator.pop(context);
+                      },
+                    );
+                  },
+                ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _iconBox(IconData icon, Color color, {bool compact = false}) {
+    final size = compact ? 34.0 : 42.0;
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: color.withAlpha(30),
+        borderRadius: BorderRadius.circular(compact ? 10 : 13),
+        border: Border.all(color: color.withAlpha(90)),
+      ),
+      child: Icon(icon, color: color, size: compact ? 18 : 22),
+    );
+  }
+
+  Widget _metricColumn(String label, String value) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: TextStyle(
+            color: textColor.value.withAlpha(125),
+            fontSize: 11,
+            fontWeight: FontWeight.w900,
+          ),
+        ),
+        const SizedBox(height: 6),
+        Text(
+          value,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: TextStyle(
+            color: textColor.value.withAlpha(215),
+            fontSize: 15,
+            fontWeight: FontWeight.w800,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _divider() {
+    return Divider(
+      height: 1,
+      indent: 16,
+      endIndent: 16,
+      color: textColor.value.withAlpha(22),
+    );
+  }
+
+  void _applyExclusiveBufferIfActive({
+    int? foregroundBufferMs,
+    int? backgroundBufferMs,
+  }) {
+    final exclusive = usbExclusivePlaybackStateNotifier.value;
+    if (!exclusive.active) return;
+
+    final targetBufferMs = _currentExclusiveTargetBufferMs(
+      foregroundTargetMs:
+          foregroundBufferMs ??
+          usbAudioPreferences.foregroundBufferMsNotifier.value,
+      backgroundTargetMs:
+          backgroundBufferMs ??
+          usbAudioPreferences.backgroundBufferMsNotifier.value,
+    );
+    unawaited(usbAudioService.setExclusiveTargetBufferMs(targetBufferMs));
+  }
+
+  int _currentExclusiveTargetBufferMs({
+    required int foregroundTargetMs,
+    required int backgroundTargetMs,
+  }) {
+    if (_usesBackgroundExclusiveBuffer()) {
+      return backgroundTargetMs;
+    }
+    return foregroundTargetMs;
+  }
+
+  bool _usesBackgroundExclusiveBuffer() {
+    if (!usbAudioPreferences.keepAliveInBackgroundNotifier.value) {
+      return false;
+    }
+    return switch (WidgetsBinding.instance.lifecycleState) {
+      AppLifecycleState.resumed || null => false,
+      AppLifecycleState.inactive ||
+      AppLifecycleState.hidden ||
+      AppLifecycleState.paused ||
+      AppLifecycleState.detached => true,
+    };
+  }
+
+  Future<void> _refreshStatus() async {
+    setState(() {
+      _refreshingStatus = true;
+    });
+    await usbAudioService.refreshStatus();
+    if (!mounted) return;
+    setState(() {
+      _refreshingStatus = false;
+    });
+  }
+
+  Future<void> _runExclusiveProbe() async {
+    setState(() {
+      _probingExclusive = true;
+    });
+
+    final result = await usbAudioService.probeExclusiveAccess();
+    if (!mounted) return;
+
+    setState(() {
+      _exclusiveProbeResult = result;
+      _probingExclusive = false;
+    });
+  }
+
+  void _showStatusSnack(UsbAudioStatus status) {
+    final device = _activeUsbDevice(status);
+    final message = device == null
+        ? '当前未检测到 USB DAC。'
+        : 'USB DAC: ${device.name} · ${_supportedRatesLabel(status)} · ${_bitDepthLabel(status)}';
+    ScaffoldMessenger.maybeOf(context)?.showSnackBar(
+      SnackBar(content: Text(message), behavior: SnackBarBehavior.floating),
+    );
+  }
+
+  String _exclusiveProbeSummary() {
+    final result = _exclusiveProbeResult;
+    if (result == null) return '检查 USB 权限、Audio Class 描述符与接口 claim 能力。';
+    if (!result.permissionGranted) return '等待 USB 授权。';
+    if (result.interfaceClaimed) {
+      return '可 claim · ${result.audioInterfaceCount} 个 Audio Interface';
+    }
+    return result.message ?? '未能 claim USB Audio Interface。';
+  }
+
+  String _sourceFormatLabel(MyAudioMetadata? song) {
+    final format = song?.format;
+    if (format == null || format.isEmpty) return '未知';
+    return format.toUpperCase();
+  }
+
+  String _channelCountLabel(UsbAudioStatus status) {
+    final device = _activeUsbDevice(status);
+    final channels = device?.channelCounts.isNotEmpty == true
+        ? device!.channelCounts.first
+        : null;
+    if (channels == null || channels <= 0) return '未知';
+    return '$channels ch';
+  }
+
+  String _compactDepthLabel(UsbAudioStatus status) {
+    return _bitDepthLabel(status).replaceAll(' bits', '-bit');
+  }
+
+  String _usbIdLabel(UsbAudioDevice? device) {
+    if (device == null) return '等待连接';
+    final address = device.address;
+    if (address != null && address.isNotEmpty) return '$address · ${device.id}';
+    return '${device.type} · ${device.id}';
+  }
+
+  String _dsdModeLabel(UsbDsdMode mode) {
+    return switch (mode) {
+      UsbDsdMode.pcm => 'PCM',
+      UsbDsdMode.dop => 'DoP',
+      UsbDsdMode.native => 'Native',
+    };
+  }
+
+  String _dsdModeHint(UsbDsdMode mode) {
+    return switch (mode) {
+      UsbDsdMode.pcm => '将 DSD 转换为 PCM 输出',
+      UsbDsdMode.dop => '以 PCM 帧封装 DSD，设备支持时使用',
+      UsbDsdMode.native => '保留 Native DSD 策略，需要底层链路支持',
+    };
+  }
+
+  String _volumeLockLabel(UsbVolumeLockMode mode) {
+    return switch (mode) {
+      UsbVolumeLockMode.off => '关闭',
+      UsbVolumeLockMode.dsdOnly => '只锁 DSD 音量',
+      UsbVolumeLockMode.always => '始终锁定',
+    };
+  }
+
+  String _busSpeedLabel(UsbBusSpeedMode mode) {
+    return switch (mode) {
+      UsbBusSpeedMode.auto => '自动',
+      UsbBusSpeedMode.full => 'Full',
+      UsbBusSpeedMode.high => 'High',
+      UsbBusSpeedMode.superSpeed => 'Super',
+    };
+  }
+
+  String _bitDepthModeLabel(UsbBitDepthMode mode) {
+    return switch (mode) {
+      UsbBitDepthMode.auto => '自动',
+      UsbBitDepthMode.pcm16 => '16 bits',
+      UsbBitDepthMode.pcm24 => '24 bits',
+      UsbBitDepthMode.pcm32 => '32 bits',
+    };
+  }
+}
+
+UsbAudioDevice? _activeUsbDevice(UsbAudioStatus status) {
+  for (final device in status.devices) {
+    if (device.id == status.bestAvailableDeviceId) {
+      return device;
+    }
+  }
+  return null;
+}
+
+String _supportedRatesLabel(UsbAudioStatus status) {
+  final device = _activeUsbDevice(status);
+  final rates = device?.supportedMixerSampleRates.isNotEmpty == true
+      ? device!.supportedMixerSampleRates
+      : device?.sampleRates ?? const <int>[];
+  if (rates.isEmpty) return '未知';
+  return rates.map(formatSampleRate).join(' / ');
+}
+
+String _bitDepthLabel(UsbAudioStatus status) {
+  final exclusive = usbExclusivePlaybackStateNotifier.value;
+  if (exclusive.active && exclusive.bitDepth != null) {
+    return '${exclusive.bitDepth} bits';
+  }
+
+  final encoding = status.preferredEncoding ?? status.outputEncoding;
+  if (encoding == 'pcm_float') return '32 bits';
+  if (encoding == 'pcm_32bit') return '32 bits';
+  if (encoding == 'pcm_24bit_packed') return '24 bits';
+  if (encoding == 'pcm_16bit') return '16 bits';
+  return '未知';
+}

--- a/lib/layer/layers_manager.dart
+++ b/lib/layer/layers_manager.dart
@@ -13,6 +13,7 @@ import 'package:sylvakru/base/widgets/cover_art_widget.dart';
 import 'package:sylvakru/base/data/history.dart';
 import 'package:sylvakru/landscape_view/sidebar.dart';
 import 'package:sylvakru/layer/about_layer.dart';
+import 'package:sylvakru/layer/audio_output_settings_layer.dart';
 import 'package:sylvakru/layer/albums_layer.dart';
 import 'package:sylvakru/layer/artists_layer.dart';
 import 'package:sylvakru/layer/folders_layer.dart';
@@ -236,6 +237,16 @@ class LayersManager {
       visibleNotifier = settingsVisibleNotifier;
       if (detail == 'about') {
         detailLayer = AboutLayer();
+      } else if (detail == 'audio_output') {
+        detailLayer = AudioOutputSettingsLayer();
+      } else if (detail == 'usb_fixed_sample_rate') {
+        detailLayer = AudioOutputSettingsLayer(
+          pageKind: AudioOutputSettingsPageKind.fixedSampleRate,
+        );
+      } else if (detail == 'usb_dsd_mode') {
+        detailLayer = AudioOutputSettingsLayer(
+          pageKind: AudioOutputSettingsPageKind.dsdMode,
+        );
       } else if (detail == 'license') {
         visibleNotifier = aboutVisibleNotifier;
         detailLayer = LicenseLayer();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:sylvakru/base/services/keyboard.dart';
 import 'package:sylvakru/base/services/my_tray_listener.dart';
 import 'package:sylvakru/base/services/my_window_listener.dart';
 import 'package:sylvakru/base/services/single_instance.dart';
+import 'package:sylvakru/base/widgets/usb_audio_event_listener.dart';
 import 'package:sylvakru/l10n/generated/app_localizations.dart';
 import 'package:sylvakru/l10n/generated/app_localizations_en.dart';
 import 'package:sylvakru/base/data/loader.dart';
@@ -137,11 +138,13 @@ Future<void> main() async {
       },
       child: Builder(
         builder: (context) {
-          return MediaQuery.removePadding(
-            context: context,
-            removeLeft: true, // for mobile
-            removeRight: true,
-            child: ViewEntry(),
+          return UsbAudioEventListener(
+            child: MediaQuery.removePadding(
+              context: context,
+              removeLeft: true, // for mobile
+              removeRight: true,
+              child: ViewEntry(),
+            ),
           );
         },
       ),

--- a/test/audio_output_panel_test.dart
+++ b/test/audio_output_panel_test.dart
@@ -1,0 +1,255 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sylvakru/base/services/usb_audio_preferences.dart';
+import 'package:sylvakru/base/services/usb_audio_service.dart';
+import 'package:sylvakru/base/widgets/audio_output_panel.dart';
+
+void main() {
+  tearDown(() {
+    usbAudioPreferences.resetForTest();
+    usbAudioStatusNotifier.value = UsbAudioStatus.unavailable();
+    usbExclusivePlaybackStateNotifier.value =
+        UsbExclusivePlaybackState.inactive();
+  });
+
+  test('formatSampleRate displays source rate as kHz', () {
+    expect(formatSampleRate(44100), '44.1 kHz');
+    expect(formatSampleRate(96000), '96 kHz');
+    expect(formatSampleRate(null), '未知');
+  });
+
+  test('formatOutputSampleRate falls back to Android system output rate', () {
+    const status = UsbAudioStatus(
+      supported: false,
+      androidSdk: 35,
+      activeDeviceId: null,
+      preferredApplied: false,
+      preferredSampleRate: null,
+      preferredEncoding: null,
+      preferredBitPerfect: false,
+      outputDeviceName: '内置扬声器',
+      outputSampleRate: 48000,
+      outputEncoding: 'pcm_16bit',
+      message: null,
+      devices: [],
+    );
+
+    expect(formatOutputSampleRate(status), '48 kHz');
+  });
+
+  test('formatOutputDeviceName shows speaker for system speaker output', () {
+    const status = UsbAudioStatus(
+      supported: false,
+      androidSdk: 35,
+      activeDeviceId: null,
+      preferredApplied: false,
+      preferredSampleRate: null,
+      preferredEncoding: null,
+      preferredBitPerfect: false,
+      outputDeviceName: '内置扬声器',
+      outputSampleRate: 48000,
+      outputEncoding: 'pcm_16bit',
+      message: null,
+      devices: [],
+    );
+
+    expect(formatOutputDeviceName(status), '扬声器');
+  });
+
+  test('formatOutputDeviceName prefers connected USB device name', () {
+    const status = UsbAudioStatus(
+      supported: true,
+      androidSdk: 35,
+      activeDeviceId: 7,
+      preferredApplied: true,
+      preferredSampleRate: 96000,
+      preferredEncoding: 'pcm_24bit_packed',
+      preferredBitPerfect: true,
+      outputDeviceName: 'Android USB output',
+      outputSampleRate: 96000,
+      outputEncoding: 'pcm_24bit_packed',
+      message: 'USB audio device detected.',
+      devices: [
+        UsbAudioDevice(
+          id: 7,
+          name: 'iBasso Macaron',
+          type: 'usb_device',
+          address: 'dac',
+          sampleRates: [44100, 48000, 96000],
+          encodings: ['pcm_16bit', 'pcm_24bit_packed'],
+          channelCounts: [2],
+          supportedMixerSampleRates: [48000, 96000],
+          supportsBitPerfectMixer: true,
+        ),
+      ],
+    );
+
+    expect(formatOutputDeviceName(status), 'iBasso Macaron');
+  });
+
+  test(
+    'formatBitrate displays concrete value without source metadata note',
+    () {
+      expect(formatBitrate(3489), '3489 kbps');
+      expect(formatBitrate(822000), '822 kbps');
+      expect(formatBitrate(null), '未知');
+    },
+  );
+
+  test('formatSourceFileName strips directory and keeps only file name', () {
+    expect(
+      formatSourceFileName('/storage/emulated/0/Music/TOMOO - LUCKY.flac'),
+      'TOMOO - LUCKY.flac',
+    );
+    expect(formatSourceFileName(r'D:\Music\demo.wav'), 'demo.wav');
+    expect(formatSourceFileName(null), '未知');
+  });
+
+  test('formatOutputPortLabel removes true exclusive wording', () {
+    usbExclusivePlaybackStateNotifier.value = const UsbExclusivePlaybackState(
+      active: true,
+      playing: true,
+      position: Duration.zero,
+      duration: null,
+      sampleRate: 48000,
+      bitDepth: 24,
+      format: 'flac',
+      message: null,
+    );
+
+    const status = UsbAudioStatus(
+      supported: true,
+      androidSdk: 35,
+      activeDeviceId: 7,
+      preferredApplied: false,
+      preferredSampleRate: null,
+      preferredEncoding: null,
+      preferredBitPerfect: false,
+      outputDeviceName: 'USB-Audio - Macaron',
+      outputSampleRate: 48000,
+      outputEncoding: 'pcm_24bit_packed',
+      message: null,
+      devices: [
+        UsbAudioDevice(
+          id: 7,
+          name: 'USB-Audio - Macaron',
+          type: 'usb_device',
+          address: 'dac',
+          sampleRates: [48000],
+          encodings: ['pcm_24bit_packed'],
+          channelCounts: [2],
+          supportedMixerSampleRates: [48000],
+          supportsBitPerfectMixer: true,
+        ),
+      ],
+    );
+
+    expect(formatOutputPortLabel(status), 'USB 独占');
+    expect(formatOutputPortLabel(status), isNot(contains('真独占')));
+    expect(formatOutputPortLabel(status), isNot(contains('系统输出')));
+  });
+
+  test('buildSampleRateOptions prefers USB supported mixer rates', () {
+    const status = UsbAudioStatus(
+      supported: true,
+      androidSdk: 35,
+      activeDeviceId: 7,
+      preferredApplied: true,
+      preferredSampleRate: 96000,
+      preferredEncoding: 'pcm_24bit_packed',
+      preferredBitPerfect: true,
+      outputDeviceName: 'USB DAC',
+      outputSampleRate: 96000,
+      outputEncoding: 'pcm_24bit_packed',
+      message: null,
+      devices: [
+        UsbAudioDevice(
+          id: 7,
+          name: 'USB DAC',
+          type: 'usb_device',
+          address: 'dac',
+          sampleRates: [44100, 48000],
+          encodings: ['pcm_16bit'],
+          channelCounts: [2],
+          supportedMixerSampleRates: [48000, 96000, 192000],
+          supportsBitPerfectMixer: true,
+        ),
+      ],
+    );
+
+    expect(buildSampleRateOptions(status, 44100), [
+      null,
+      48000,
+      96000,
+      192000,
+      44100,
+    ]);
+  });
+
+  test('exclusive sample rate prefers current song rate when supported', () {
+    const status = UsbAudioStatus(
+      supported: true,
+      androidSdk: 35,
+      activeDeviceId: 7,
+      preferredApplied: false,
+      preferredSampleRate: null,
+      preferredEncoding: null,
+      preferredBitPerfect: false,
+      outputDeviceName: 'USB DAC',
+      outputSampleRate: 48000,
+      outputEncoding: 'pcm_16bit',
+      message: null,
+      devices: [
+        UsbAudioDevice(
+          id: 7,
+          name: 'USB DAC',
+          type: 'usb_device',
+          address: 'dac',
+          sampleRates: [48000, 96000],
+          encodings: ['pcm_16bit'],
+          channelCounts: [2],
+          supportedMixerSampleRates: [44100, 48000, 96000],
+          supportsBitPerfectMixer: true,
+        ),
+      ],
+    );
+
+    expect(preferredExclusiveSampleRate(status, 44100), 44100);
+    expect(preferredExclusiveSampleRate(status, 88200), 96000);
+  });
+
+  test('exclusive sample rate prefers configured fixed rate', () {
+    usbAudioPreferences.load({
+      'usbFixedSampleRateEnabled': true,
+      'usbFixedSampleRate': 192000,
+    });
+
+    const status = UsbAudioStatus(
+      supported: true,
+      androidSdk: 35,
+      activeDeviceId: 7,
+      preferredApplied: false,
+      preferredSampleRate: null,
+      preferredEncoding: null,
+      preferredBitPerfect: false,
+      outputDeviceName: 'USB DAC',
+      outputSampleRate: 48000,
+      outputEncoding: 'pcm_16bit',
+      message: null,
+      devices: [
+        UsbAudioDevice(
+          id: 7,
+          name: 'USB DAC',
+          type: 'usb_device',
+          address: 'dac',
+          sampleRates: [44100, 48000, 96000],
+          encodings: ['pcm_16bit'],
+          channelCounts: [2],
+          supportedMixerSampleRates: [44100, 48000, 96000, 192000],
+          supportsBitPerfectMixer: true,
+        ),
+      ],
+    );
+
+    expect(preferredExclusiveSampleRate(status, 44100), 192000);
+  });
+}

--- a/test/audio_output_settings_layer_test.dart
+++ b/test/audio_output_settings_layer_test.dart
@@ -1,0 +1,419 @@
+import 'dart:io';
+
+import 'package:audio_tags_lofty/audio_tags_lofty.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sylvakru/base/app.dart' as app;
+import 'package:sylvakru/base/audio_handler.dart';
+import 'package:sylvakru/base/my_audio_metadata.dart';
+import 'package:sylvakru/base/services/usb_audio_preferences.dart';
+import 'package:sylvakru/base/services/usb_audio_service.dart';
+import 'package:sylvakru/layer/audio_output_settings_layer.dart';
+
+void main() {
+  setUpAll(() {
+    app.appSupportDir = Directory.systemTemp.createTempSync(
+      'sylvakru_audio_settings_test_',
+    );
+  });
+
+  tearDown(() {
+    usbAudioPreferences.resetForTest();
+    usbAudioStatusNotifier.value = UsbAudioStatus.unavailable();
+    usbExclusivePlaybackStateNotifier.value =
+        UsbExclusivePlaybackState.inactive();
+    usbTransportTelemetryNotifier.value = UsbTransportTelemetry.inactive();
+    currentSongNotifier.value = null;
+  });
+
+  testWidgets('传输状态卡使用 telemetry 水位而不是播放进度', (tester) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    usbAudioPreferences.load(const {});
+    usbAudioStatusNotifier.value = const UsbAudioStatus(
+      supported: true,
+      androidSdk: 35,
+      activeDeviceId: 7,
+      preferredApplied: true,
+      preferredSampleRate: 96000,
+      preferredEncoding: 'pcm_24bit_packed',
+      preferredBitPerfect: true,
+      outputDeviceName: 'Macaron',
+      outputSampleRate: 96000,
+      outputEncoding: 'pcm_24bit_packed',
+      message: null,
+      devices: [
+        UsbAudioDevice(
+          id: 7,
+          name: 'Macaron',
+          type: 'usb_headset',
+          address: '/dev/bus/usb/001/002',
+          sampleRates: [48000, 96000],
+          encodings: ['pcm_16bit', 'pcm_24bit_packed'],
+          channelCounts: [2],
+          supportedMixerSampleRates: [48000, 96000],
+          supportsBitPerfectMixer: true,
+        ),
+      ],
+    );
+    usbExclusivePlaybackStateNotifier.value = const UsbExclusivePlaybackState(
+      active: true,
+      playing: true,
+      position: Duration(milliseconds: 248424),
+      duration: Duration(minutes: 3),
+      sampleRate: 96000,
+      bitDepth: 24,
+      format: 'PCM',
+      message: null,
+    );
+    usbTransportTelemetryNotifier.value = const UsbTransportTelemetry(
+      active: true,
+      bufferLevel: Duration(milliseconds: 184),
+      minimumBufferLevel: Duration(milliseconds: 120),
+      targetBuffer: Duration(milliseconds: 200),
+      isoPacketCount: 4096,
+      pendingUrbs: 7,
+      underrunCount: 0,
+      updatedAtMs: 123456,
+    );
+
+    await tester.pumpWidget(
+      const MaterialApp(home: AudioOutputSettingsLayer()),
+    );
+
+    expect(find.text('传输状态'), findsOneWidget);
+    expect(find.text('184 ms'), findsOneWidget);
+    expect(find.text('248424 ms'), findsNothing);
+    expect(find.text('缓冲区水位'), findsOneWidget);
+    expect(find.text('ISO 4096'), findsOneWidget);
+    expect(find.text('目标 200 ms'), findsOneWidget);
+    expect(find.text('最低 120 ms'), findsOneWidget);
+    expect(find.text('采样率'), findsNothing);
+    expect(find.text('缓冲'), findsNothing);
+  });
+
+  testWidgets('传输状态卡低水位时不显示稳定', (tester) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    usbAudioPreferences.load(const {});
+    usbAudioStatusNotifier.value = const UsbAudioStatus(
+      supported: true,
+      androidSdk: 35,
+      activeDeviceId: 7,
+      preferredApplied: true,
+      preferredSampleRate: 96000,
+      preferredEncoding: 'pcm_24bit_packed',
+      preferredBitPerfect: true,
+      outputDeviceName: 'Macaron',
+      outputSampleRate: 96000,
+      outputEncoding: 'pcm_24bit_packed',
+      message: null,
+      devices: [
+        UsbAudioDevice(
+          id: 7,
+          name: 'Macaron',
+          type: 'usb_headset',
+          address: '/dev/bus/usb/001/002',
+          sampleRates: [48000, 96000],
+          encodings: ['pcm_16bit', 'pcm_24bit_packed'],
+          channelCounts: [2],
+          supportedMixerSampleRates: [48000, 96000],
+          supportsBitPerfectMixer: true,
+        ),
+      ],
+    );
+    usbExclusivePlaybackStateNotifier.value = const UsbExclusivePlaybackState(
+      active: true,
+      playing: true,
+      position: Duration(milliseconds: 1000),
+      duration: Duration(minutes: 3),
+      sampleRate: 96000,
+      bitDepth: 24,
+      format: 'PCM',
+      message: null,
+    );
+    usbTransportTelemetryNotifier.value = const UsbTransportTelemetry(
+      active: true,
+      bufferLevel: Duration(milliseconds: 52),
+      minimumBufferLevel: Duration(milliseconds: 2),
+      targetBuffer: Duration(milliseconds: 300),
+      isoPacketCount: 4096,
+      pendingUrbs: 2,
+      underrunCount: 0,
+      updatedAtMs: 123456,
+    );
+
+    await tester.pumpWidget(
+      const MaterialApp(home: AudioOutputSettingsLayer()),
+    );
+
+    expect(find.text('偏低'), findsOneWidget);
+    expect(find.text('稳定'), findsNothing);
+  });
+
+  testWidgets('传输状态卡出现欠载时显示欠载', (tester) async {
+    tester.view.physicalSize = const Size(390, 844);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    usbAudioPreferences.load(const {});
+    usbAudioStatusNotifier.value = const UsbAudioStatus(
+      supported: true,
+      androidSdk: 35,
+      activeDeviceId: 7,
+      preferredApplied: true,
+      preferredSampleRate: 96000,
+      preferredEncoding: 'pcm_24bit_packed',
+      preferredBitPerfect: true,
+      outputDeviceName: 'Macaron',
+      outputSampleRate: 96000,
+      outputEncoding: 'pcm_24bit_packed',
+      message: null,
+      devices: [
+        UsbAudioDevice(
+          id: 7,
+          name: 'Macaron',
+          type: 'usb_headset',
+          address: '/dev/bus/usb/001/002',
+          sampleRates: [48000, 96000],
+          encodings: ['pcm_16bit', 'pcm_24bit_packed'],
+          channelCounts: [2],
+          supportedMixerSampleRates: [48000, 96000],
+          supportsBitPerfectMixer: true,
+        ),
+      ],
+    );
+    usbExclusivePlaybackStateNotifier.value = const UsbExclusivePlaybackState(
+      active: true,
+      playing: true,
+      position: Duration(milliseconds: 1000),
+      duration: Duration(minutes: 3),
+      sampleRate: 96000,
+      bitDepth: 24,
+      format: 'PCM',
+      message: null,
+    );
+    usbTransportTelemetryNotifier.value = const UsbTransportTelemetry(
+      active: true,
+      bufferLevel: Duration(milliseconds: 320),
+      minimumBufferLevel: Duration(milliseconds: 280),
+      targetBuffer: Duration(milliseconds: 300),
+      isoPacketCount: 4096,
+      pendingUrbs: 12,
+      underrunCount: 1,
+      updatedAtMs: 123456,
+    );
+
+    await tester.pumpWidget(
+      const MaterialApp(home: AudioOutputSettingsLayer()),
+    );
+
+    expect(find.text('欠载'), findsOneWidget);
+    expect(find.text('稳定'), findsNothing);
+  });
+
+  testWidgets('输出格式显示当前歌曲源文件信息', (tester) async {
+    tester.view.physicalSize = const Size(390, 1200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    usbAudioPreferences.load(const {});
+    usbAudioStatusNotifier.value = const UsbAudioStatus(
+      supported: true,
+      androidSdk: 35,
+      activeDeviceId: 7,
+      preferredApplied: false,
+      preferredSampleRate: null,
+      preferredEncoding: 'pcm_24bit_packed',
+      preferredBitPerfect: false,
+      outputDeviceName: 'USB-Audio - Macaron',
+      outputSampleRate: 44100,
+      outputEncoding: 'pcm_24bit_packed',
+      message: null,
+      devices: [
+        UsbAudioDevice(
+          id: 7,
+          name: 'USB-Audio - Macaron',
+          type: 'usb_headset',
+          address: 'usb_headset',
+          sampleRates: [44100, 48000],
+          encodings: ['pcm_16bit', 'pcm_24bit_packed'],
+          channelCounts: [2],
+          supportedMixerSampleRates: [44100, 48000],
+          supportsBitPerfectMixer: false,
+        ),
+      ],
+    );
+    usbExclusivePlaybackStateNotifier.value = const UsbExclusivePlaybackState(
+      active: true,
+      playing: true,
+      position: Duration.zero,
+      duration: Duration(minutes: 3),
+      sampleRate: 44100,
+      bitDepth: 24,
+      format: 'FLAC',
+      message: null,
+    );
+    currentSongNotifier.value = MyAudioMetadata(
+      AudioMetadata(
+        format: 'FLAC',
+        title: 'LUCKY',
+        bitrate: 822000,
+        samplerate: 44100,
+      ),
+      id: 'lucky',
+      path: '/storage/emulated/0/Music/TOMOO - LUCKY.flac',
+    );
+
+    await tester.pumpWidget(
+      const MaterialApp(home: AudioOutputSettingsLayer()),
+    );
+
+    expect(find.text('源文件'), findsOneWidget);
+    expect(find.text('TOMOO - LUCKY.flac'), findsNothing);
+    expect(find.text('FLAC'), findsOneWidget);
+    expect(find.text('44.1 kHz'), findsWidgets);
+    expect(find.text('2 ch'), findsWidgets);
+    expect(find.text('24-bit'), findsWidgets);
+    expect(find.text('PCM'), findsOneWidget);
+    expect(find.text('44.1 kHz · FLAC · 822 kbps'), findsNothing);
+    expect(find.text('等待播放'), findsNothing);
+  });
+
+  testWidgets('设备状态卡使用样板式状态字段', (tester) async {
+    tester.view.physicalSize = const Size(390, 1200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    usbAudioPreferences.load(const {});
+    usbAudioStatusNotifier.value = const UsbAudioStatus(
+      supported: true,
+      androidSdk: 35,
+      activeDeviceId: 7,
+      preferredApplied: false,
+      preferredSampleRate: null,
+      preferredEncoding: 'pcm_24bit_packed',
+      preferredBitPerfect: false,
+      outputDeviceName: 'USB-Audio - Macaron',
+      outputSampleRate: 44100,
+      outputEncoding: 'pcm_24bit_packed',
+      message: null,
+      devices: [
+        UsbAudioDevice(
+          id: 7,
+          name: 'USB-Audio - Macaron',
+          type: 'usb_headset',
+          address: 'usb_headset',
+          sampleRates: [44100, 48000],
+          encodings: ['pcm_16bit', 'pcm_24bit_packed'],
+          channelCounts: [2],
+          supportedMixerSampleRates: [44100, 48000],
+          supportsBitPerfectMixer: false,
+        ),
+      ],
+    );
+
+    await tester.pumpWidget(
+      const MaterialApp(home: AudioOutputSettingsLayer()),
+    );
+
+    expect(find.text('USB EXCLUSIVE'), findsOneWidget);
+    expect(find.text('已连接'), findsOneWidget);
+    expect(find.text('OUTPUT LINK'), findsOneWidget);
+    expect(find.text('运行中'), findsOneWidget);
+    expect(find.text('FORMAT'), findsOneWidget);
+    expect(find.text('DEPTH'), findsOneWidget);
+    expect(find.text('USB ID'), findsOneWidget);
+    expect(find.text('已连接 USB DAC，但未确认支持独占'), findsNothing);
+  });
+
+  testWidgets('后台稳定性移动到输出格式之后', (tester) async {
+    tester.view.physicalSize = const Size(390, 1600);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    usbAudioPreferences.load(const {});
+
+    await tester.pumpWidget(
+      const MaterialApp(home: AudioOutputSettingsLayer()),
+    );
+
+    final outputTop = tester.getTopLeft(find.text('输出格式')).dy;
+    final stabilityTop = tester.getTopLeft(find.text('后台稳定性')).dy;
+
+    expect(stabilityTop, greaterThan(outputTop));
+  });
+
+  testWidgets('媒体音量显示真实播放器音量', (tester) async {
+    tester.view.physicalSize = const Size(390, 1200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    usbAudioPreferences.load(const {});
+    volumeNotifier.value = 0.42;
+
+    await tester.pumpWidget(
+      const MaterialApp(home: AudioOutputSettingsLayer()),
+    );
+
+    expect(find.text('42%'), findsOneWidget);
+    expect(find.text('播放开始后检测'), findsNothing);
+  });
+
+  testWidgets('调整前台缓冲区后传输目标实时刷新', (tester) async {
+    tester.view.physicalSize = const Size(390, 1200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(() {
+      tester.view.resetPhysicalSize();
+      tester.view.resetDevicePixelRatio();
+    });
+
+    usbAudioPreferences.load(const {});
+    usbExclusivePlaybackStateNotifier.value = const UsbExclusivePlaybackState(
+      active: true,
+      playing: true,
+      position: Duration.zero,
+      duration: Duration(minutes: 3),
+      sampleRate: 96000,
+      bitDepth: 24,
+      format: 'PCM',
+      message: null,
+    );
+    usbTransportTelemetryNotifier.value = UsbTransportTelemetry.inactive();
+
+    await tester.pumpWidget(
+      const MaterialApp(home: AudioOutputSettingsLayer()),
+    );
+
+    usbAudioPreferences.foregroundBufferMsNotifier.value = 350;
+    await tester.pump();
+
+    expect(find.text('350 ms'), findsWidgets);
+    expect(find.text('目标 350 ms'), findsOneWidget);
+  });
+}

--- a/test/path_utils_test.dart
+++ b/test/path_utils_test.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sylvakru/base/utils/path.dart';
+
+void main() {
+  test('convertToRealPathIfNeed ignores Android local file paths', () async {
+    final result = await convertToRealPathIfNeed(
+      '/storage/emulated/0/TRIM/Download/01.%20test.flac',
+    );
+
+    expect(result, isNull);
+  });
+}

--- a/test/playback_position_bridge_test.dart
+++ b/test/playback_position_bridge_test.dart
@@ -1,0 +1,52 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sylvakru/base/services/playback_position_bridge.dart';
+import 'package:sylvakru/base/services/usb_audio_service.dart';
+
+void main() {
+  test('USB 真独占 active 时位置流使用独占播放位置', () async {
+    final playerPositions = StreamController<Duration>.broadcast();
+    var playerPosition = Duration.zero;
+    final exclusiveState = ValueNotifier(UsbExclusivePlaybackState.inactive());
+    final bridge = PlaybackPositionBridge(
+      playerPositionStream: playerPositions.stream,
+      playerPosition: () => playerPosition,
+      exclusiveStateListenable: exclusiveState,
+    );
+
+    addTearDown(() async {
+      bridge.dispose();
+      exclusiveState.dispose();
+      await playerPositions.close();
+    });
+
+    final emitted = <Duration>[];
+    final subscription = bridge.stream.listen(emitted.add);
+    addTearDown(subscription.cancel);
+
+    playerPosition = const Duration(seconds: 2);
+    playerPositions.add(playerPosition);
+    await pumpEventQueue();
+
+    exclusiveState.value = const UsbExclusivePlaybackState(
+      active: true,
+      playing: true,
+      position: Duration(seconds: 42),
+      duration: Duration(minutes: 3),
+      sampleRate: 96000,
+      bitDepth: 24,
+      format: 'flac',
+      message: 'Playing.',
+    );
+    await pumpEventQueue();
+
+    playerPosition = const Duration(seconds: 3);
+    playerPositions.add(playerPosition);
+    await pumpEventQueue();
+
+    expect(emitted, [const Duration(seconds: 2), const Duration(seconds: 42)]);
+    expect(bridge.position, const Duration(seconds: 42));
+  });
+}

--- a/test/super_lyric_bridge_test.dart
+++ b/test/super_lyric_bridge_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sylvakru/base/services/lyric.dart';
+import 'package:sylvakru/base/services/super_lyric_bridge.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('com.afalphy.sylvakru/super_lyric');
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  tearDown(() {
+    messenger.setMockMethodCallHandler(channel, null);
+    SuperLyricBridge.resetForTest();
+  });
+
+  test('sendLyric sends non-empty lyric and skips duplicates', () async {
+    final calls = <MethodCall>[];
+    SuperLyricBridge.configureForTest(channel: channel, isAndroid: true);
+
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      calls.add(call);
+      return null;
+    });
+
+    await SuperLyricBridge.sendLyric('first line');
+    await SuperLyricBridge.sendLyric('first line');
+    await SuperLyricBridge.sendLyric('second line');
+
+    expect(calls, hasLength(2));
+    expect(calls[0].method, 'sendLyric');
+    expect(calls[0].arguments, {'lyric': 'first line'});
+    expect(calls[1].arguments, {'lyric': 'second line'});
+  });
+
+  test('sendLyricLine sends line timing and word timing tokens', () async {
+    final calls = <MethodCall>[];
+    SuperLyricBridge.configureForTest(channel: channel, isAndroid: true);
+
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      calls.add(call);
+      return null;
+    });
+
+    await SuperLyricBridge.sendLyricLine(
+      LyricLine(const Duration(seconds: 10), 'hello world', [
+        LyricToken(
+          const Duration(seconds: 10),
+          'hello ',
+          const Duration(milliseconds: 10400),
+        ),
+        LyricToken(
+          const Duration(milliseconds: 10400),
+          'world',
+          const Duration(seconds: 11),
+        ),
+      ]),
+    );
+
+    expect(calls, hasLength(1));
+    expect(calls.single.method, 'sendLyric');
+    expect(calls.single.arguments, {
+      'lyric': 'hello world',
+      'startTime': 10000,
+      'endTime': 11000,
+      'tokens': [
+        {'text': 'hello ', 'startTime': 10000, 'endTime': 10400},
+        {'text': 'world', 'startTime': 10400, 'endTime': 11000},
+      ],
+    });
+  });
+
+  test('sendLyric sends stop for blank or placeholder lyrics', () async {
+    final calls = <MethodCall>[];
+    SuperLyricBridge.configureForTest(channel: channel, isAndroid: true);
+
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      calls.add(call);
+      return null;
+    });
+
+    await SuperLyricBridge.sendLyric('   ');
+    await SuperLyricBridge.sendLyric('There are no lyrics');
+    await SuperLyricBridge.sendLyric('Lyrics parsing failed');
+
+    expect(calls.map((call) => call.method), ['sendStop']);
+  });
+
+  test('sendStop clears last sent lyric and skips duplicate stop', () async {
+    final calls = <MethodCall>[];
+    SuperLyricBridge.configureForTest(channel: channel, isAndroid: true);
+
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      calls.add(call);
+      return null;
+    });
+
+    await SuperLyricBridge.sendLyric('one line');
+    await SuperLyricBridge.sendStop();
+    await SuperLyricBridge.sendStop();
+    await SuperLyricBridge.sendLyric('one line');
+
+    expect(calls.map((call) => call.method), [
+      'sendLyric',
+      'sendStop',
+      'sendLyric',
+    ]);
+  });
+}

--- a/test/super_lyric_position_publisher_test.dart
+++ b/test/super_lyric_position_publisher_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sylvakru/base/services/lyric.dart';
+import 'package:sylvakru/base/services/super_lyric_position_publisher.dart';
+
+void main() {
+  test('publishes lyric lines as playback position advances', () async {
+    final events = <String>[];
+    final publisher = SuperLyricPositionPublisher(
+      sendLyricLine: (line) async => events.add('lyric:${line.text}'),
+      sendStop: () async => events.add('stop'),
+    );
+
+    publisher.updateLines([
+      LyricLine(const Duration(seconds: 1), 'first', const []),
+      LyricLine(const Duration(seconds: 3), 'second', const []),
+    ]);
+
+    await publisher.publishAt(const Duration(milliseconds: 500));
+    await publisher.publishAt(const Duration(seconds: 1));
+    await publisher.publishAt(const Duration(seconds: 2));
+    await publisher.publishAt(const Duration(seconds: 3));
+
+    expect(events, ['stop', 'lyric:first', 'lyric:second']);
+  });
+
+  test(
+    'reset makes the current lyric publish again after a song change',
+    () async {
+      final events = <String>[];
+      final publisher = SuperLyricPositionPublisher(
+        sendLyricLine: (line) async => events.add(line.text),
+        sendStop: () async {},
+      );
+
+      publisher.updateLines([
+        LyricLine(Duration.zero, 'same visible text', const []),
+      ]);
+      await publisher.publishAt(Duration.zero);
+
+      publisher.updateLines([
+        LyricLine(Duration.zero, 'same visible text', const []),
+      ]);
+      await publisher.publishAt(Duration.zero);
+
+      expect(events, ['same visible text', 'same visible text']);
+    },
+  );
+
+  test(
+    'reset makes the current lyric publish again after pause stop',
+    () async {
+      final events = <String>[];
+      final publisher = SuperLyricPositionPublisher(
+        sendLyricLine: (line) async => events.add(line.text),
+        sendStop: () async {},
+      );
+
+      publisher.updateLines([
+        LyricLine(Duration.zero, 'current line', const []),
+      ]);
+      await publisher.publishAt(Duration.zero);
+
+      publisher.reset();
+      await publisher.publishAt(Duration.zero);
+
+      expect(events, ['current line', 'current line']);
+    },
+  );
+}

--- a/test/usb_audio_preferences_test.dart
+++ b/test/usb_audio_preferences_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sylvakru/base/services/usb_audio_preferences.dart';
+
+void main() {
+  tearDown(() {
+    usbAudioPreferences.resetForTest();
+  });
+
+  test('loads and serializes USB audio preferences', () {
+    usbAudioPreferences.load({
+      'usbFixedSampleRateEnabled': true,
+      'usbFixedSampleRate': 96000,
+      'usbDsdMode': 'native',
+      'usbDsd64PcmRate': 176400,
+      'usbPerformanceMode': false,
+      'usbVolumeLockMode': 'always',
+      'usbDsdGainCompensation': -6,
+      'usbBusSpeedMode': 'high',
+      'usbBitDepthMode': 'pcm32',
+      'usbReleaseBandwidthAfterPlayback': true,
+      'usbKeepAliveInBackground': false,
+      'usbBitDepthCompat': false,
+      'usbSampleRateCompat': false,
+      'usbChannelCompat': false,
+      'usbTpdfDither': true,
+      'usbForegroundBufferMs': 320,
+      'usbBackgroundBufferMs': 2400,
+      'usbVolumeSmoothHandoff': false,
+      'usbDelayedUsbLink': true,
+    });
+
+    expect(usbAudioPreferences.preferredFixedSampleRate(), 96000);
+    expect(usbAudioPreferences.dsdModeNotifier.value, UsbDsdMode.native);
+    expect(usbAudioPreferences.dsd64PcmRateNotifier.value, 176400);
+    expect(usbAudioPreferences.performanceModeNotifier.value, isFalse);
+    expect(
+      usbAudioPreferences.volumeLockModeNotifier.value,
+      UsbVolumeLockMode.always,
+    );
+    expect(usbAudioPreferences.dsdGainCompensationNotifier.value, -6);
+    expect(
+      usbAudioPreferences.busSpeedModeNotifier.value,
+      UsbBusSpeedMode.high,
+    );
+    expect(usbAudioPreferences.preferredEncoding(), 'pcm_32bit');
+    expect(
+      usbAudioPreferences.releaseUsbBandwidthAfterPlaybackNotifier.value,
+      isTrue,
+    );
+    expect(usbAudioPreferences.keepAliveInBackgroundNotifier.value, isFalse);
+    expect(usbAudioPreferences.bitDepthCompatNotifier.value, isFalse);
+    expect(usbAudioPreferences.sampleRateCompatNotifier.value, isFalse);
+    expect(usbAudioPreferences.channelCompatNotifier.value, isFalse);
+    expect(usbAudioPreferences.tpdfDitherNotifier.value, isTrue);
+    expect(usbAudioPreferences.foregroundBufferMsNotifier.value, 320);
+    expect(usbAudioPreferences.backgroundBufferMsNotifier.value, 2400);
+    expect(usbAudioPreferences.volumeSmoothHandoffNotifier.value, isFalse);
+    expect(usbAudioPreferences.delayedUsbLinkNotifier.value, isTrue);
+    expect(usbAudioPreferences.toMap()['usbDsdMode'], 'native');
+    expect(usbAudioPreferences.toMap()['usbBitDepthCompat'], isFalse);
+    expect(usbAudioPreferences.toMap()['usbTpdfDither'], isTrue);
+    expect(usbAudioPreferences.toMap()['usbForegroundBufferMs'], 320);
+  });
+
+  test('uses practical defaults for USB compatibility options', () {
+    usbAudioPreferences.load(const {});
+
+    expect(usbAudioPreferences.bitDepthCompatNotifier.value, isTrue);
+    expect(usbAudioPreferences.sampleRateCompatNotifier.value, isTrue);
+    expect(usbAudioPreferences.channelCompatNotifier.value, isTrue);
+    expect(usbAudioPreferences.tpdfDitherNotifier.value, isFalse);
+    expect(usbAudioPreferences.foregroundBufferMsNotifier.value, 200);
+    expect(usbAudioPreferences.backgroundBufferMsNotifier.value, 1500);
+    expect(usbAudioPreferences.volumeSmoothHandoffNotifier.value, isTrue);
+    expect(usbAudioPreferences.delayedUsbLinkNotifier.value, isFalse);
+  });
+
+  test('selects exclusive target buffer for foreground and background', () {
+    usbAudioPreferences.load({
+      'usbForegroundBufferMs': 320,
+      'usbBackgroundBufferMs': 2400,
+      'usbKeepAliveInBackground': true,
+    });
+
+    expect(preferredUsbExclusiveTargetBufferMs(background: false), 320);
+    expect(preferredUsbExclusiveTargetBufferMs(background: true), 2400);
+
+    usbAudioPreferences.keepAliveInBackgroundNotifier.value = false;
+    expect(preferredUsbExclusiveTargetBufferMs(background: true), 320);
+  });
+
+  test('selects exclusive PCM bit depth from user preference', () {
+    usbAudioPreferences.bitDepthModeNotifier.value = UsbBitDepthMode.auto;
+    expect(preferredUsbExclusiveBitDepth(), isNull);
+
+    usbAudioPreferences.bitDepthModeNotifier.value = UsbBitDepthMode.pcm16;
+    expect(preferredUsbExclusiveBitDepth(), 16);
+
+    usbAudioPreferences.bitDepthModeNotifier.value = UsbBitDepthMode.pcm24;
+    expect(preferredUsbExclusiveBitDepth(), 24);
+
+    usbAudioPreferences.bitDepthModeNotifier.value = UsbBitDepthMode.pcm32;
+    expect(preferredUsbExclusiveBitDepth(), 32);
+  });
+
+  test('ignores unsupported fixed sample rate', () {
+    usbAudioPreferences.load({
+      'usbFixedSampleRateEnabled': true,
+      'usbFixedSampleRate': 12345,
+    });
+
+    expect(usbAudioPreferences.preferredFixedSampleRate(), isNull);
+  });
+}

--- a/test/usb_audio_service_test.dart
+++ b/test/usb_audio_service_test.dart
@@ -1,0 +1,365 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sylvakru/base/services/usb_audio_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const channel = MethodChannel('com.afalphy.sylvakru/usb_audio');
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+
+  tearDown(() {
+    messenger.setMockMethodCallHandler(channel, null);
+    usbTransportTelemetryNotifier.value = UsbTransportTelemetry.inactive();
+  });
+
+  test(
+    'refreshStatus maps USB device capabilities from platform channel',
+    () async {
+      final service = UsbAudioService(channel: channel, isAndroid: true);
+
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        if (call.method == 'getStatus') {
+          return {
+            'supported': true,
+            'androidSdk': 35,
+            'activeDeviceId': 10,
+            'preferredApplied': false,
+            'preferredSampleRate': 96000,
+            'preferredEncoding': 'pcm_24bit_packed',
+            'preferredBitPerfect': true,
+            'outputDeviceName': 'USB DAC',
+            'outputSampleRate': 96000,
+            'outputEncoding': 'pcm_24bit_packed',
+            'message': 'USB audio device detected',
+            'devices': [
+              {
+                'id': 10,
+                'name': 'USB DAC',
+                'type': 'usb_device',
+                'address': 'bus-001',
+                'sampleRates': [44100, 48000, 96000],
+                'encodings': ['pcm_16bit', 'pcm_24bit_packed'],
+                'channelCounts': [2],
+                'supportedMixerSampleRates': [48000, 96000],
+                'supportsBitPerfectMixer': true,
+              },
+            ],
+          };
+        }
+        throw PlatformException(code: 'unexpected_method');
+      });
+
+      final status = await service.refreshStatus();
+
+      expect(status.supported, isTrue);
+      expect(status.androidSdk, 35);
+      expect(status.activeDeviceId, 10);
+      expect(status.preferredSampleRate, 96000);
+      expect(status.preferredEncoding, 'pcm_24bit_packed');
+      expect(status.preferredBitPerfect, isTrue);
+      expect(status.outputDeviceName, 'USB DAC');
+      expect(status.outputSampleRate, 96000);
+      expect(status.outputEncoding, 'pcm_24bit_packed');
+      expect(status.devices, hasLength(1));
+      expect(status.devices.single.name, 'USB DAC');
+      expect(status.devices.single.sampleRates, [44100, 48000, 96000]);
+      expect(status.devices.single.supportsBitPerfectMixer, isTrue);
+      expect(usbAudioStatusNotifier.value, status);
+    },
+  );
+
+  test(
+    'applyPreferredOutput requests requested sample rate and device id',
+    () async {
+      final service = UsbAudioService(channel: channel, isAndroid: true);
+      Object? receivedArguments;
+
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        if (call.method == 'applyPreferredOutput') {
+          receivedArguments = call.arguments;
+          return {
+            'supported': true,
+            'androidSdk': 35,
+            'activeDeviceId': 10,
+            'preferredApplied': true,
+            'outputSampleRate': 96000,
+            'message': 'Applied preferred USB mixer attributes',
+            'devices': const [],
+          };
+        }
+        throw PlatformException(code: 'unexpected_method');
+      });
+
+      final status = await service.applyPreferredOutput(
+        deviceId: 10,
+        sampleRate: 96000,
+      );
+
+      expect(receivedArguments, {
+        'deviceId': 10,
+        'sampleRate': 96000,
+        'encoding': 'pcm_24bit_packed',
+        'bitPerfect': true,
+      });
+      expect(status.preferredApplied, isTrue);
+      expect(status.message, 'Applied preferred USB mixer attributes');
+    },
+  );
+
+  test('native USB added event updates status and event notifier', () async {
+    UsbAudioService(channel: channel, isAndroid: true);
+
+    final eventStatus = {
+      'supported': true,
+      'androidSdk': 35,
+      'activeDeviceId': 18,
+      'preferredApplied': false,
+      'preferredSampleRate': null,
+      'preferredEncoding': null,
+      'preferredBitPerfect': false,
+      'outputDeviceName': 'USB DAC',
+      'outputSampleRate': 48000,
+      'outputEncoding': 'pcm_16bit',
+      'message': 'USB audio device detected.',
+      'devices': [
+        {
+          'id': 18,
+          'name': 'USB DAC',
+          'type': 'usb_device',
+          'address': 'dac-18',
+          'sampleRates': [44100, 48000, 96000],
+          'encodings': ['pcm_16bit', 'pcm_24bit_packed'],
+          'channelCounts': [2],
+          'supportedMixerSampleRates': [44100, 48000, 96000],
+          'supportsBitPerfectMixer': true,
+        },
+      ],
+    };
+
+    await messenger.handlePlatformMessage(
+      channel.name,
+      const StandardMethodCodec().encodeMethodCall(
+        MethodCall('onUsbAudioDeviceEvent', {
+          'type': 'added',
+          'deviceId': 18,
+          'status': eventStatus,
+        }),
+      ),
+      (_) {},
+    );
+
+    final event = usbAudioEventNotifier.value;
+    expect(event, isNotNull);
+    expect(event!.type, UsbAudioDeviceEventType.added);
+    expect(event.deviceId, 18);
+    expect(event.status.supported, isTrue);
+    expect(event.status.devices.single.name, 'USB DAC');
+    expect(usbAudioStatusNotifier.value.activeDeviceId, 18);
+  });
+
+  test('probeExclusiveAccess maps native USB claim result', () async {
+    final service = UsbAudioService(channel: channel, isAndroid: true);
+
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      if (call.method == 'probeExclusiveAccess') {
+        return {
+          'supported': true,
+          'permissionGranted': true,
+          'deviceName': 'USB DAC',
+          'deviceId': 21,
+          'audioInterfaceCount': 2,
+          'claimedInterfaceCount': 1,
+          'rawDescriptorLength': 257,
+          'message': 'USB Audio interface can be claimed.',
+        };
+      }
+      throw PlatformException(code: 'unexpected_method');
+    });
+
+    final result = await service.probeExclusiveAccess();
+
+    expect(result.supported, isTrue);
+    expect(result.permissionGranted, isTrue);
+    expect(result.deviceName, 'USB DAC');
+    expect(result.deviceId, 21);
+    expect(result.audioInterfaceCount, 2);
+    expect(result.claimedInterfaceCount, 1);
+    expect(result.interfaceClaimed, isTrue);
+    expect(result.rawDescriptorLength, 257);
+  });
+
+  test(
+    'getExclusiveCapabilities maps native exclusive USB capabilities',
+    () async {
+      final service = UsbAudioService(channel: channel, isAndroid: true);
+
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        if (call.method == 'getExclusiveCapabilities') {
+          return {
+            'available': true,
+            'permissionGranted': true,
+            'deviceName': 'iBasso Macaron',
+            'deviceId': 31,
+            'interfaceNumber': 1,
+            'alternateSetting': 1,
+            'endpointAddress': 1,
+            'maxPacketSize': 196,
+            'sampleRates': [44100, 48000, 96000],
+            'bitDepths': [16, 24, 32],
+            'channelCounts': [2],
+            'message': 'USB exclusive endpoint is available.',
+          };
+        }
+        throw PlatformException(code: 'unexpected_method');
+      });
+
+      final capability = await service.getExclusiveCapabilities();
+
+      expect(capability.available, isTrue);
+      expect(capability.permissionGranted, isTrue);
+      expect(capability.deviceName, 'iBasso Macaron');
+      expect(capability.deviceId, 31);
+      expect(capability.interfaceNumber, 1);
+      expect(capability.alternateSetting, 1);
+      expect(capability.endpointAddress, 1);
+      expect(capability.maxPacketSize, 196);
+      expect(capability.sampleRates, [44100, 48000, 96000]);
+      expect(capability.bitDepths, [16, 24, 32]);
+      expect(capability.channelCounts, [2]);
+    },
+  );
+
+  test(
+    'startExclusivePlayback sends playback request to native layer',
+    () async {
+      final service = UsbAudioService(channel: channel, isAndroid: true);
+      Object? receivedArguments;
+
+      messenger.setMockMethodCallHandler(channel, (call) async {
+        if (call.method == 'startExclusivePlayback') {
+          receivedArguments = call.arguments;
+          return {
+            'active': true,
+            'playing': true,
+            'positionMs': 0,
+            'durationMs': 180000,
+            'sampleRate': 44100,
+            'bitDepth': 24,
+            'format': 'flac',
+            'message': 'USB exclusive playback started.',
+          };
+        }
+        throw PlatformException(code: 'unexpected_method');
+      });
+
+      final state = await service.startExclusivePlayback(
+        const UsbExclusivePlaybackRequest(
+          filePath: '/music/test.flac',
+          title: 'Test',
+          sourceFormat: 'flac',
+          sampleRate: 44100,
+          bitDepth: 24,
+          targetBufferMs: 320,
+          startPaused: false,
+        ),
+      );
+
+      expect(receivedArguments, {
+        'filePath': '/music/test.flac',
+        'title': 'Test',
+        'sourceFormat': 'flac',
+        'sampleRate': 44100,
+        'bitDepth': 24,
+        'targetBufferMs': 320,
+        'startPaused': false,
+      });
+      expect(state.active, isTrue);
+      expect(state.playing, isTrue);
+      expect(state.position, Duration.zero);
+      expect(state.duration, const Duration(minutes: 3));
+      expect(state.sampleRate, 44100);
+      expect(state.bitDepth, 24);
+      expect(state.format, 'flac');
+      expect(usbExclusivePlaybackStateNotifier.value, state);
+    },
+  );
+
+  test('setExclusiveTargetBufferMs updates native exclusive buffer', () async {
+    final service = UsbAudioService(channel: channel, isAndroid: true);
+    Object? receivedArguments;
+
+    messenger.setMockMethodCallHandler(channel, (call) async {
+      if (call.method == 'setExclusiveTargetBufferMs') {
+        receivedArguments = call.arguments;
+        return null;
+      }
+      throw PlatformException(code: 'unexpected_method');
+    });
+
+    await service.setExclusiveTargetBufferMs(2400);
+
+    expect(receivedArguments, {'targetBufferMs': 2400});
+  });
+
+  test('native exclusive state event updates playback notifier', () async {
+    UsbAudioService(channel: channel, isAndroid: true);
+
+    await messenger.handlePlatformMessage(
+      channel.name,
+      const StandardMethodCodec().encodeMethodCall(
+        MethodCall('onUsbExclusiveStateChanged', {
+          'active': true,
+          'playing': false,
+          'positionMs': 42000,
+          'durationMs': 240000,
+          'sampleRate': 48000,
+          'bitDepth': 24,
+          'format': 'flac',
+          'message': 'Paused.',
+        }),
+      ),
+      (_) {},
+    );
+
+    final state = usbExclusivePlaybackStateNotifier.value;
+    expect(state.active, isTrue);
+    expect(state.playing, isFalse);
+    expect(state.position, const Duration(seconds: 42));
+    expect(state.duration, const Duration(minutes: 4));
+    expect(state.sampleRate, 48000);
+    expect(state.bitDepth, 24);
+  });
+
+  test('native transport telemetry event updates transport notifier', () async {
+    UsbAudioService(channel: channel, isAndroid: true);
+
+    await messenger.handlePlatformMessage(
+      channel.name,
+      const StandardMethodCodec().encodeMethodCall(
+        MethodCall('onUsbTransportTelemetryChanged', {
+          'active': true,
+          'bufferLevelMs': 184,
+          'minimumBufferLevelMs': 120,
+          'targetBufferMs': 200,
+          'isoPacketCount': 4096,
+          'pendingUrbs': 7,
+          'underrunCount': 1,
+          'updatedAtMs': 123456,
+        }),
+      ),
+      (_) {},
+    );
+
+    final telemetry = usbTransportTelemetryNotifier.value;
+    expect(telemetry.active, isTrue);
+    expect(telemetry.bufferLevel, const Duration(milliseconds: 184));
+    expect(telemetry.minimumBufferLevel, const Duration(milliseconds: 120));
+    expect(telemetry.targetBuffer, const Duration(milliseconds: 200));
+    expect(telemetry.isoPacketCount, 4096);
+    expect(telemetry.pendingUrbs, 7);
+    expect(telemetry.underrunCount, 1);
+    expect(telemetry.updatedAtMs, 123456);
+  });
+}


### PR DESCRIPTION
## 说明

这个 PR 基于当前最新 `master` 重新整理，只包含 USB 独占播放相关改动。旧分支里页面掉帧、`BackdropFilter`、`CoverArtWidget`、歌词页/横屏页视觉相关改动没有带入，本 PR 以主仓库现有页面修复为准。

## 主要改动

- 新增 Android USB Audio 设备识别、权限、能力探测与事件回传。
- 新增 native USB exclusive playback engine，包括 PCM 写入、ISO 传输、feedback 与 telemetry。
- 新增 Dart 侧 `UsbAudioService`、USB 偏好、播放位置桥接和 super lyric 位置发布。
- 在设置页加入 Android USB 音频输出设置入口和详细设置页。
- 播放链路接入 USB 独占播放状态、进度同步、暂停/恢复/seek/stop 处理。
- 增加 USB 输出面板、设置页和 service/preference 相关测试。

## 验证

使用 Flutter 3.44：

```bash
F:\software\flutter_3.44.0\bin\flutter.bat analyze
```

结果：`No issues found`

```bash
F:\software\flutter_3.44.0\bin\flutter.bat test test/usb_audio_service_test.dart test/usb_audio_preferences_test.dart test/audio_output_panel_test.dart test/audio_output_settings_layer_test.dart test/playback_position_bridge_test.dart test/super_lyric_bridge_test.dart test/super_lyric_position_publisher_test.dart test/path_utils_test.dart
```

结果：`All tests passed!`，共 41 个测试。