### PR TITLE
@修复音频输出设置卡片 ListTile 水波纹被 DecoratedBox 遮挡的断言

### DIFF
--- a/lib/layer/audio_output_settings_layer.dart
+++ b/lib/layer/audio_output_settings_layer.dart
@@ -759,11 +759,12 @@ class _AudioOutputSettingsLayerState extends State<AudioOutputSettingsLayer> {
   }
 
   Widget _settingsCard({required List<Widget> children}) {
-    return DecoratedBox(
-      decoration: BoxDecoration(
-        color: menuColor.value,
-        borderRadius: BorderRadius.circular(16),
-      ),
+    // 用同色同圆角的 Material 承载，让内部 ListTile 的水波纹画在卡片本身上，
+    // 避免带色 DecoratedBox 盖住 ink 触发框架断言。
+    return Material(
+      color: menuColor.value,
+      borderRadius: BorderRadius.circular(16),
+      clipBehavior: Clip.antiAlias,
       child: Column(
         children: [
           for (var index = 0; index < children.length; index++) ...[


### PR DESCRIPTION
fix(usb): 修复音频输出设置卡片 ListTile 水波纹被 DecoratedBox 遮挡的断言

_settingsCard 用带背景色的 DecoratedBox 包 ListTile，导致 ink/背景画在被遮挡的 Material 上触发框架断言。改用同色同圆角的 Material 承载并裁剪水波纹，视觉不变。
@