### PR TITLE
feat: restore desktop lyrics with transparency fix and custom style

### DIFF
--- a/lib/base/audio_handler.dart
+++ b/lib/base/audio_handler.dart
@@ -164,6 +164,7 @@ class MyAudioHandler extends BaseAudioHandler {
     final tmpLyricLine = currentLyricLine;
 
     currentLyricLine = lines[current];
+    nextLyricLine = current + 1 < lines.length ? lines[current + 1] : null;
     currentLyricLineIsKaraoke = parsedLyrics.isKaraoke;
 
     if (lyricsWindowVisible && currentLyricLine != tmpLyricLine) {
@@ -459,6 +460,7 @@ class MyAudioHandler extends BaseAudioHandler {
     playQueue = [];
     _playQueueTmp = [];
     currentLyricLine = null;
+    nextLyricLine = null;
     if (!isMobile) {
       await updateDesktopLyrics();
     }
@@ -500,6 +502,7 @@ class MyAudioHandler extends BaseAudioHandler {
         } else {
           await stop();
           currentLyricLine = null;
+          nextLyricLine = null;
           if (!isMobile) {
             await updateDesktopLyrics();
           }

--- a/lib/base/audio_handler.dart
+++ b/lib/base/audio_handler.dart
@@ -17,6 +17,8 @@ import 'package:sylvakru/base/utils/path.dart';
 import 'package:sylvakru/base/widgets/equalizer.dart';
 import 'package:sylvakru/base/widgets/lyric_list_view.dart';
 import 'package:sylvakru/base/data/history.dart';
+import 'package:sylvakru/landscape_view/desktop_lyrics.dart';
+import 'package:sylvakru/base/extensions/window_controller_extension.dart';
 import 'package:sylvakru/layer/layers_manager.dart';
 import 'package:sylvakru/base/utils/contrast_color_generator.dart';
 import 'package:sylvakru/base/data/library.dart';
@@ -130,7 +132,43 @@ class MyAudioHandler extends BaseAudioHandler {
       if (isLoading || isSyncing) {
         return;
       }
+      _tryUpdateDesktopLyrics(position);
     });
+  }
+
+  /// Recomputes which lyric line is current for [position] and, only when
+  /// it actually changed, pushes it to the desktop lyrics window. Cheap to
+  /// call on every position tick since it's a no-op when nothing changed
+  /// or the desktop lyrics window isn't running.
+  void _tryUpdateDesktopLyrics(Duration position) {
+    final currentSong = currentSongNotifier.value;
+    if (currentSong == null || currentSong.parsedLyrics == null) {
+      return;
+    }
+    ParsedLyrics parsedLyrics = currentSong.parsedLyrics!;
+
+    List<LyricLine> lines = parsedLyrics.lines;
+
+    int current = 0;
+
+    for (int i = 0; i < lines.length; i++) {
+      final line = lines[i];
+      if (position < line.start) {
+        break;
+      }
+      if (line.start > lines[current].start) {
+        current = i;
+      }
+    }
+
+    final tmpLyricLine = currentLyricLine;
+
+    currentLyricLine = lines[current];
+    currentLyricLineIsKaraoke = parsedLyrics.isKaraoke;
+
+    if (lyricsWindowVisible && currentLyricLine != tmpLyricLine) {
+      updateDesktopLyrics();
+    }
   }
 
   void updateIsPlaying(bool isPlaying) {
@@ -142,6 +180,8 @@ class MyAudioHandler extends BaseAudioHandler {
     }
     needPause = false;
     isPlayingNotifier.value = isPlaying;
+
+    lyricsWindowController?.sendPlaying(isPlaying);
   }
 
   void updatePlaybackState({Duration? postion, bool stop = false}) {
@@ -418,6 +458,10 @@ class MyAudioHandler extends BaseAudioHandler {
     stop();
     playQueue = [];
     _playQueueTmp = [];
+    currentLyricLine = null;
+    if (!isMobile) {
+      await updateDesktopLyrics();
+    }
     currentIndex = -1;
     currentSongNotifier.value = null;
     currentCoverArtColor = Colors.grey;
@@ -455,6 +499,10 @@ class MyAudioHandler extends BaseAudioHandler {
           await skipToNext();
         } else {
           await stop();
+          currentLyricLine = null;
+          if (!isMobile) {
+            await updateDesktopLyrics();
+          }
         }
       }
     }
@@ -558,6 +606,7 @@ class MyAudioHandler extends BaseAudioHandler {
     updateServiceMediaItem(currentSong);
 
     updatePlaybackState(postion: Duration.zero);
+    _tryUpdateDesktopLyrics(Duration.zero);
   }
 
   void updateServiceMediaItem(MyAudioMetadata currentSong) {

--- a/lib/base/data/setting.dart
+++ b/lib/base/data/setting.dart
@@ -9,6 +9,7 @@ import 'package:sylvakru/base/widgets/lyric_list_view.dart';
 import 'package:sylvakru/base/data/artist_album.dart';
 import 'package:sylvakru/base/app.dart';
 import 'package:sylvakru/base/widgets/manage_music_folders.dart';
+import 'package:sylvakru/landscape_view/desktop_lyrics.dart';
 
 final exitOnCloseNotifier = ValueNotifier(false);
 
@@ -70,6 +71,12 @@ class Setting {
         json['exitOnClose'] as bool? ?? exitOnCloseNotifier.value;
 
     recursiveScanNotifier.value = json['recursiveScan'] as bool? ?? false;
+
+    final desktopLyricsStyle =
+        json['desktopLyricsStyle'] as Map<String, dynamic>?;
+    if (desktopLyricsStyle != null) {
+      applyDesktopLyricsStyleFromMap(desktopLyricsStyle);
+    }
   }
 
   void save() {
@@ -94,6 +101,8 @@ class Setting {
         'exitOnClose': exitOnCloseNotifier.value,
 
         'recursiveScan': recursiveScanNotifier.value,
+
+        'desktopLyricsStyle': desktopLyricsStyleToMap(),
       }),
     );
   }

--- a/lib/base/extensions/window_controller_extension.dart
+++ b/lib/base/extensions/window_controller_extension.dart
@@ -1,0 +1,96 @@
+import 'package:desktop_multi_window/desktop_multi_window.dart';
+import 'package:flutter/services.dart';
+import 'package:sylvakru/base/audio_handler.dart';
+import 'package:sylvakru/base/services/logger.dart';
+import 'package:sylvakru/base/services/lyric.dart';
+import 'package:sylvakru/landscape_view/desktop_lyrics.dart';
+import 'package:window_manager/window_manager.dart';
+
+/// The desktop lyrics window runs in its own isolate with its own Flutter
+/// engine, so it cannot see the main isolate's globals (currentSongNotifier,
+/// isPlayingNotifier, etc.). Everything they need to agree on - the current
+/// lyric line, play/pause state, playback controls - has to be pushed
+/// explicitly across this platform channel.
+extension WindowControllerExtension on WindowController {
+  Future<void> desktopLyricsCustomInitialize() async {
+    return await setWindowMethodHandler((call) async {
+      switch (call.method) {
+        case 'window_center':
+          return await windowManager.center();
+        case 'window_close':
+          return await windowManager.close();
+        case 'update_lyric':
+          getDesktopLyricFromMap(call.arguments);
+          break;
+        case 'set_playing':
+          isPlayingNotifier.value = call.arguments as bool;
+          break;
+        case 'unlock':
+          await windowManager.setIgnoreMouseEvents(false);
+          break;
+        default:
+          throw MissingPluginException('Not implemented: ${call.method}');
+      }
+    });
+  }
+
+  Future<void> mainCustomInitialize() async {
+    return await setWindowMethodHandler((call) async {
+      switch (call.method) {
+        case 'hide_desktop_lyrics':
+          lyricsWindowVisible = false;
+          break;
+        case 'skip_to_previous':
+          audioHandler.skipToPrevious();
+          break;
+        case 'toggle_play':
+          audioHandler.togglePlay();
+          break;
+        case 'skip_to_next':
+          audioHandler.skipToNext();
+          break;
+        default:
+          throw MissingPluginException('Not implemented: ${call.method}');
+      }
+    });
+  }
+
+  Future<void> center() => _safeInvoke('window_center');
+
+  Future<void> close() => _safeInvoke('window_close');
+
+  Future<void> updateLyric(
+    Duration postion,
+    LyricLine? lyricline,
+    bool isKaraoke,
+  ) => _safeInvoke('update_lyric', {
+    'position': postion.inMicroseconds,
+    'lyric_line': lyricline?.toMap(),
+    'isKaraoke': isKaraoke,
+  });
+
+  Future<void> sendPlaying(bool playing) => _safeInvoke('set_playing', playing);
+
+  Future<void> hideDesktopLyrics() => _safeInvoke('hide_desktop_lyrics');
+
+  Future<void> skipToPrevious() => _safeInvoke('skip_to_previous');
+
+  Future<void> togglePlay() => _safeInvoke('toggle_play');
+
+  Future<void> skipToNext() => _safeInvoke('skip_to_next');
+
+  Future<void> unlock() => _safeInvoke('unlock');
+
+  /// The two windows are only loosely coupled: the lyrics window can be
+  /// closed, still starting up, or briefly unresponsive, and none of that
+  /// should ever be able to crash the caller (e.g. the position stream in
+  /// audio_handler.dart fires many times per second). Swallow and log
+  /// instead of letting a transient channel error propagate.
+  Future<void> _safeInvoke(String method, [dynamic arguments]) async {
+    try {
+      await invokeMethod(method, arguments);
+    } catch (e) {
+      logger.output('desktop lyrics IPC "$method" failed: $e');
+    }
+  }
+}

--- a/lib/base/extensions/window_controller_extension.dart
+++ b/lib/base/extensions/window_controller_extension.dart
@@ -22,6 +22,9 @@ extension WindowControllerExtension on WindowController {
         case 'update_lyric':
           getDesktopLyricFromMap(call.arguments);
           break;
+        case 'update_style':
+          applyDesktopLyricsStyleFromMap(call.arguments);
+          break;
         case 'set_playing':
           isPlayingNotifier.value = call.arguments as bool;
           break;
@@ -62,14 +65,19 @@ extension WindowControllerExtension on WindowController {
   Future<void> updateLyric(
     Duration postion,
     LyricLine? lyricline,
+    LyricLine? nextLyricline,
     bool isKaraoke,
   ) => _safeInvoke('update_lyric', {
     'position': postion.inMicroseconds,
     'lyric_line': lyricline?.toMap(),
+    'next_lyric_line': nextLyricline?.toMap(),
     'isKaraoke': isKaraoke,
   });
 
   Future<void> sendPlaying(bool playing) => _safeInvoke('set_playing', playing);
+
+  Future<void> updateStyle(Map<String, dynamic> style) =>
+      _safeInvoke('update_style', style);
 
   Future<void> hideDesktopLyrics() => _safeInvoke('hide_desktop_lyrics');
 

--- a/lib/base/services/exit.dart
+++ b/lib/base/services/exit.dart
@@ -1,6 +1,8 @@
 import 'dart:io';
 
+import 'package:sylvakru/base/extensions/window_controller_extension.dart';
 import 'package:sylvakru/base/services/single_instance.dart';
+import 'package:sylvakru/landscape_view/desktop_lyrics.dart';
 import 'package:window_manager/window_manager.dart';
 
 bool _exited = false;
@@ -9,6 +11,11 @@ void exitApp() async {
   if (_exited) {
     return;
   }
+
+  // Fire-and-forget: initDesktopLyrics() may have failed to create this
+  // window (controller null) and the call is best-effort anyway, so it
+  // must never block or fail the actual app shutdown below.
+  lyricsWindowController?.close();
 
   await SingleInstance.end();
   // only this allows quick exit on Windows

--- a/lib/base/services/lyric.dart
+++ b/lib/base/services/lyric.dart
@@ -213,6 +213,7 @@ Future<void> updateDesktopLyrics() async {
   await lyricsWindowController?.updateLyric(
     audioHandler.getPosition(),
     currentLyricLine,
+    nextLyricLine,
     currentLyricLineIsKaraoke,
   );
 }
@@ -227,6 +228,11 @@ void getDesktopLyricFromMap(dynamic data) {
   final lyricLineMap = map['lyric_line'] as Map?;
   currentLyricLine = lyricLineMap != null
       ? LyricLine.fromMap(lyricLineMap)
+      : null;
+
+  final nextLyricLineMap = map['next_lyric_line'] as Map?;
+  nextLyricLine = nextLyricLineMap != null
+      ? LyricLine.fromMap(nextLyricLineMap)
       : null;
 
   currentLyricLineIsKaraoke = map['isKaraoke'] as bool;

--- a/lib/base/services/lyric.dart
+++ b/lib/base/services/lyric.dart
@@ -3,6 +3,7 @@ import 'dart:ui';
 
 import 'package:charset/charset.dart';
 import 'package:sylvakru/base/app.dart';
+import 'package:sylvakru/base/audio_handler.dart';
 import 'package:sylvakru/base/my_audio_metadata.dart';
 import 'package:sylvakru/base/services/subsonic_client.dart';
 import 'package:sylvakru/base/services/webdav_client.dart';
@@ -10,6 +11,8 @@ import 'package:sylvakru/base/services/logger.dart';
 import 'package:sylvakru/base/services/navidrome_client.dart';
 import 'package:sylvakru/l10n/generated/app_localizations.dart';
 import 'package:sylvakru/l10n/generated/app_localizations_en.dart';
+import 'package:sylvakru/landscape_view/desktop_lyrics.dart';
+import 'package:sylvakru/base/extensions/window_controller_extension.dart';
 
 class LyricToken {
   final Duration start;
@@ -201,4 +204,31 @@ Future<void> setParsedLyrics(MyAudioMetadata song) async {
       result.lines.last.tokens.last.end = song.duration;
     }
   }
+}
+
+/// Pushes the current lyric line to the desktop lyrics window, if it's
+/// running. No-op (and never throws) when the window hasn't been created,
+/// e.g. on mobile or if [initDesktopLyrics] failed.
+Future<void> updateDesktopLyrics() async {
+  await lyricsWindowController?.updateLyric(
+    audioHandler.getPosition(),
+    currentLyricLine,
+    currentLyricLineIsKaraoke,
+  );
+}
+
+/// Handles the 'update_lyric' message received on the desktop lyrics
+/// window's side of the channel; mirrors [LyricLine.toMap] in reverse.
+void getDesktopLyricFromMap(dynamic data) {
+  final raw = data as Map;
+  final map = Map<String, dynamic>.from(raw);
+
+  desktopLyricsCurrentPosition = Duration(microseconds: map['position'] as int);
+  final lyricLineMap = map['lyric_line'] as Map?;
+  currentLyricLine = lyricLineMap != null
+      ? LyricLine.fromMap(lyricLineMap)
+      : null;
+
+  currentLyricLineIsKaraoke = map['isKaraoke'] as bool;
+  updateDesktopLyricsNotifier.value++;
 }

--- a/lib/base/services/my_tray_listener.dart
+++ b/lib/base/services/my_tray_listener.dart
@@ -1,5 +1,7 @@
 import 'package:sylvakru/base/audio_handler.dart';
+import 'package:sylvakru/base/extensions/window_controller_extension.dart';
 import 'package:sylvakru/base/services/exit.dart';
+import 'package:sylvakru/landscape_view/desktop_lyrics.dart';
 import 'package:tray_manager/tray_manager.dart';
 import 'package:window_manager/window_manager.dart';
 
@@ -27,6 +29,10 @@ class MyTrayListener extends TrayListener {
       audioHandler.togglePlay();
     } else if (menuItem.key == 'skipToNext') {
       audioHandler.skipToNext();
+    } else if (menuItem.key == 'unlock') {
+      // Escape hatch for when the lyrics window is click-through locked:
+      // its own unlock button is unreachable in that state.
+      lyricsWindowController?.unlock();
     }
   }
 }

--- a/lib/base/widgets/desktop_lyrics_style_panel.dart
+++ b/lib/base/widgets/desktop_lyrics_style_panel.dart
@@ -1,0 +1,158 @@
+import 'dart:io';
+
+import 'package:flex_color_picker/flex_color_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:just_font_scan/just_font_scan.dart';
+import 'package:sylvakru/base/app.dart';
+import 'package:sylvakru/base/data/setting.dart';
+import 'package:sylvakru/base/services/interaction.dart';
+import 'package:sylvakru/l10n/generated/app_localizations.dart';
+import 'package:sylvakru/landscape_view/desktop_lyrics.dart';
+
+/// Settings panel for the floating desktop lyrics window's appearance.
+/// Every change here is pushed live to the (separate-isolate) lyrics window
+/// via [pushDesktopLyricsStyle] and persisted through [setting.save], so the
+/// lyrics window picks it up immediately if it's currently visible.
+class DesktopLyricsStylePanel extends StatefulWidget {
+  const DesktopLyricsStylePanel({super.key});
+
+  @override
+  State<DesktopLyricsStylePanel> createState() =>
+      _DesktopLyricsStylePanelState();
+}
+
+class _DesktopLyricsStylePanelState extends State<DesktopLyricsStylePanel> {
+  void _applyAndPersist() {
+    setting.save();
+    pushDesktopLyricsStyle();
+    setState(() {});
+  }
+
+  Future<void> _pickColor(ValueNotifier<Color> notifier) async {
+    final picked = await showColorPickerDialog(
+      context,
+      notifier.value,
+      enableOpacity: true,
+      pickersEnabled: const <ColorPickerType, bool>{
+        ColorPickerType.primary: false,
+        ColorPickerType.accent: false,
+        ColorPickerType.wheel: true,
+      },
+    );
+    notifier.value = picked;
+    _applyAndPersist();
+  }
+
+  Widget _colorTile(String label, ValueNotifier<Color> notifier) {
+    return ListTile(
+      title: Text(label),
+      onTap: () => _pickColor(notifier),
+      trailing: Container(
+        width: 28,
+        height: 28,
+        decoration: BoxDecoration(
+          color: notifier.value,
+          shape: BoxShape.circle,
+          border: Border.all(color: Colors.grey),
+        ),
+      ),
+    );
+  }
+
+  Future<void> _pickFont() async {
+    final l10n = AppLocalizations.of(context);
+    final fonts = <String>[...importedFonts];
+    if (Platform.isWindows || Platform.isMacOS) {
+      fonts.addAll(JustFontScan.scan().map((e) => e.name));
+    }
+
+    await showAnimationDialog(
+      context: context,
+      child: SizedBox(
+        width: 300,
+        height: 400,
+        child: Padding(
+          padding: const EdgeInsets.all(15),
+          child: ListView(
+            children: [
+              ListTile(
+                title: Text(l10n.followSystem),
+                trailing: desktopLyricsFontFamilyNotifier.value == null
+                    ? Icon(Icons.check)
+                    : null,
+                onTap: () {
+                  desktopLyricsFontFamilyNotifier.value = null;
+                  Navigator.pop(context);
+                  _applyAndPersist();
+                },
+              ),
+              for (final font in fonts)
+                ListTile(
+                  title: Text(font),
+                  trailing: desktopLyricsFontFamilyNotifier.value == font
+                      ? Icon(Icons.check)
+                      : null,
+                  onTap: () {
+                    desktopLyricsFontFamilyNotifier.value = font;
+                    Navigator.pop(context);
+                    _applyAndPersist();
+                  },
+                ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context);
+
+    return ListView(
+      children: [
+        ListTile(
+          title: Text(l10n.lineMode),
+          trailing: SegmentedButton<DesktopLyricsLineMode>(
+            segments: [
+              ButtonSegment(value: .single, label: Text(l10n.singleLine)),
+              ButtonSegment(value: .double, label: Text(l10n.doubleLine)),
+            ],
+            selected: {desktopLyricsLineModeNotifier.value},
+            onSelectionChanged: (selection) {
+              desktopLyricsLineModeNotifier.value = selection.first;
+              _applyAndPersist();
+            },
+          ),
+        ),
+        ListTile(
+          title: Text(l10n.fonts),
+          trailing: Text(
+            desktopLyricsFontFamilyNotifier.value ?? l10n.followSystem,
+          ),
+          onTap: _pickFont,
+        ),
+        ListTile(
+          title: Text(
+            '${l10n.fontSize}: ${desktopLyricsFontSizeNotifier.value.round()}',
+          ),
+          subtitle: Slider(
+            min: 16,
+            max: 60,
+            divisions: 44,
+            value: desktopLyricsFontSizeNotifier.value,
+            onChanged: (v) {
+              desktopLyricsFontSizeNotifier.value = v;
+              setState(() {});
+            },
+            onChangeEnd: (v) => _applyAndPersist(),
+          ),
+        ),
+        _colorTile(l10n.lyricColor, desktopLyricsColorNotifier),
+        _colorTile(l10n.sungLyricColor, desktopLyricsSungColorNotifier),
+        _colorTile(l10n.outlineColor, desktopLyricsOutlineColorNotifier),
+        _colorTile(l10n.nextLineColor, desktopLyricsNextLineColorNotifier),
+      ],
+    );
+  }
+}

--- a/lib/base/widgets/lyric_list_view.dart
+++ b/lib/base/widgets/lyric_list_view.dart
@@ -319,6 +319,10 @@ class KaraokeText extends StatefulWidget {
   final double fontSize;
   final bool expanded;
   final bool isDesktopLyrics;
+  final String? fontFamily;
+  final Color? sungColor;
+  final Color? unsungColor;
+  final Color? outlineColor;
 
   const KaraokeText({
     super.key,
@@ -327,6 +331,10 @@ class KaraokeText extends StatefulWidget {
     required this.fontSize,
     required this.expanded,
     this.isDesktopLyrics = false,
+    this.fontFamily,
+    this.sungColor,
+    this.unsungColor,
+    this.outlineColor,
   });
 
   @override
@@ -340,7 +348,8 @@ class KaraokeTextState extends State<KaraokeText>
   Duration displayPosition = Duration.zero;
   DateTime lastSyncTime = DateTime.now();
 
-  late Color textColor;
+  late Color sungColor;
+  late Color unsungColor;
 
   void _playStateListener() {
     if (isPlayingNotifier.value) {
@@ -375,11 +384,14 @@ class KaraokeTextState extends State<KaraokeText>
       ticker.start();
     }
 
-    textColor = widget.isDesktopLyrics
-        ? Colors.white
-        : miniModeNotifier.value
-        ? miniViewHighlightTextColor.value
-        : lyricsPageHighlightTextColor.value;
+    sungColor =
+        widget.sungColor ??
+        (widget.isDesktopLyrics
+            ? Colors.white
+            : miniModeNotifier.value
+            ? miniViewHighlightTextColor.value
+            : lyricsPageHighlightTextColor.value);
+    unsungColor = widget.unsungColor ?? sungColor.withAlpha(128);
   }
 
   @override
@@ -414,8 +426,9 @@ class KaraokeTextState extends State<KaraokeText>
 
     final style = TextStyle(
       fontSize: widget.fontSize,
+      fontFamily: widget.fontFamily,
       fontWeight: FontWeight.bold,
-      color: textColor,
+      color: sungColor,
     );
 
     return WidgetSpan(
@@ -427,13 +440,16 @@ class KaraokeTextState extends State<KaraokeText>
             token.text,
             style: TextStyle(
               fontSize: widget.fontSize,
+              fontFamily: widget.fontFamily,
               color: Colors.transparent,
               shadows: widget.isDesktopLyrics
                   ? [
                       Shadow(
                         offset: Offset(2, 2),
                         blurRadius: isMobile ? 5 : 1,
-                        color: isMobile ? Colors.black87 : Colors.black54,
+                        color:
+                            widget.outlineColor ??
+                            (isMobile ? Colors.black87 : Colors.black54),
                       ),
                     ]
                   : null,
@@ -444,7 +460,7 @@ class KaraokeTextState extends State<KaraokeText>
             shaderCallback: (bounds) {
               final p = progress.clamp(0.0, 1.0);
               return LinearGradient(
-                colors: [textColor, textColor.withAlpha(128)],
+                colors: [sungColor, unsungColor],
                 stops: [p, p],
               ).createShader(Rect.fromLTWH(0, 0, bounds.width, bounds.height));
             },

--- a/lib/base/widgets/settings_list.dart
+++ b/lib/base/widgets/settings_list.dart
@@ -16,6 +16,7 @@ import 'package:sylvakru/base/services/webdav_client.dart';
 import 'package:sylvakru/base/utils/media_query.dart';
 import 'package:sylvakru/base/utils/source_type.dart';
 import 'package:sylvakru/base/widgets/connect_client_widget.dart';
+import 'package:sylvakru/base/widgets/desktop_lyrics_style_panel.dart';
 import 'package:sylvakru/base/widgets/equalizer.dart';
 import 'package:sylvakru/base/widgets/my_divider.dart';
 import 'package:sylvakru/base/data/setting.dart';
@@ -117,6 +118,14 @@ class SettingsList extends StatelessWidget {
           ),
 
         sliverBox(paddingIfNeed(isLandscape, equalizerListTile(context, l10n))),
+
+        if (!isMobile)
+          sliverBox(
+            paddingIfNeed(
+              isLandscape,
+              desktopLyricsStyleListTile(context, l10n),
+            ),
+          ),
 
         sliverBox(paddingIfNeed(isLandscape, autoPlayOnStartupListTile(l10n))),
 
@@ -721,6 +730,29 @@ class SettingsList extends StatelessWidget {
           return Icon(Icons.lock);
         },
       ),
+    );
+  }
+
+  Widget desktopLyricsStyleListTile(
+    BuildContext context,
+    AppLocalizations l10n,
+  ) {
+    return ListTile(
+      leading: ImageIcon(desktopLyricsImage, size: iconSize),
+      title: Text(l10n.desktopLyricsStyle),
+      onTap: () {
+        showAnimationDialog(
+          context: context,
+          child: SizedBox(
+            width: 320,
+            height: 480,
+            child: Padding(
+              padding: const EdgeInsets.all(15.0),
+              child: const DesktopLyricsStylePanel(),
+            ),
+          ),
+        );
+      },
     );
   }
 

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -243,5 +243,14 @@
   "connectingToAppStore": "Connecting to the App Store...",
   "checkingPurchase": "Checking purchase history...",
   "noLyrics": "There are no lyrics",
-  "lyricsParseFailed": "Lyrics parsing failed"
+  "lyricsParseFailed": "Lyrics parsing failed",
+  "desktopLyricsStyle": "Desktop Lyrics Style",
+  "lineMode": "Line Mode",
+  "singleLine": "Single Line",
+  "doubleLine": "Double Line (with next line)",
+  "fontSize": "Font Size",
+  "lyricColor": "Lyric Color",
+  "sungLyricColor": "Sung Lyric Color",
+  "outlineColor": "Outline Color",
+  "nextLineColor": "Next Line Color"
 }

--- a/lib/l10n/app_zh.arb
+++ b/lib/l10n/app_zh.arb
@@ -194,5 +194,14 @@
   "connectingToAppStore": "正在连接 App Store...",
   "checkingPurchase": "正在检查购买记录...",
   "noLyrics": "暂无歌词",
-  "lyricsParseFailed": "歌词解析失败"
+  "lyricsParseFailed": "歌词解析失败",
+  "desktopLyricsStyle": "桌面歌词样式",
+  "lineMode": "显示行数",
+  "singleLine": "单行",
+  "doubleLine": "双行（含下一句）",
+  "fontSize": "字号",
+  "lyricColor": "歌词颜色",
+  "sungLyricColor": "已唱歌词颜色",
+  "outlineColor": "描边颜色",
+  "nextLineColor": "下一句颜色"
 }

--- a/lib/l10n/generated/app_localizations.dart
+++ b/lib/l10n/generated/app_localizations.dart
@@ -1273,6 +1273,60 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Lyrics parsing failed'**
   String get lyricsParseFailed;
+
+  /// No description provided for @desktopLyricsStyle.
+  ///
+  /// In en, this message translates to:
+  /// **'Desktop Lyrics Style'**
+  String get desktopLyricsStyle;
+
+  /// No description provided for @lineMode.
+  ///
+  /// In en, this message translates to:
+  /// **'Line Mode'**
+  String get lineMode;
+
+  /// No description provided for @singleLine.
+  ///
+  /// In en, this message translates to:
+  /// **'Single Line'**
+  String get singleLine;
+
+  /// No description provided for @doubleLine.
+  ///
+  /// In en, this message translates to:
+  /// **'Double Line (with next line)'**
+  String get doubleLine;
+
+  /// No description provided for @fontSize.
+  ///
+  /// In en, this message translates to:
+  /// **'Font Size'**
+  String get fontSize;
+
+  /// No description provided for @lyricColor.
+  ///
+  /// In en, this message translates to:
+  /// **'Lyric Color'**
+  String get lyricColor;
+
+  /// No description provided for @sungLyricColor.
+  ///
+  /// In en, this message translates to:
+  /// **'Sung Lyric Color'**
+  String get sungLyricColor;
+
+  /// No description provided for @outlineColor.
+  ///
+  /// In en, this message translates to:
+  /// **'Outline Color'**
+  String get outlineColor;
+
+  /// No description provided for @nextLineColor.
+  ///
+  /// In en, this message translates to:
+  /// **'Next Line Color'**
+  String get nextLineColor;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/generated/app_localizations_en.dart
+++ b/lib/l10n/generated/app_localizations_en.dart
@@ -616,4 +616,31 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get lyricsParseFailed => 'Lyrics parsing failed';
+
+  @override
+  String get desktopLyricsStyle => 'Desktop Lyrics Style';
+
+  @override
+  String get lineMode => 'Line Mode';
+
+  @override
+  String get singleLine => 'Single Line';
+
+  @override
+  String get doubleLine => 'Double Line (with next line)';
+
+  @override
+  String get fontSize => 'Font Size';
+
+  @override
+  String get lyricColor => 'Lyric Color';
+
+  @override
+  String get sungLyricColor => 'Sung Lyric Color';
+
+  @override
+  String get outlineColor => 'Outline Color';
+
+  @override
+  String get nextLineColor => 'Next Line Color';
 }

--- a/lib/l10n/generated/app_localizations_zh.dart
+++ b/lib/l10n/generated/app_localizations_zh.dart
@@ -609,4 +609,31 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get lyricsParseFailed => '歌词解析失败';
+
+  @override
+  String get desktopLyricsStyle => '桌面歌词样式';
+
+  @override
+  String get lineMode => '显示行数';
+
+  @override
+  String get singleLine => '单行';
+
+  @override
+  String get doubleLine => '双行（含下一句）';
+
+  @override
+  String get fontSize => '字号';
+
+  @override
+  String get lyricColor => '歌词颜色';
+
+  @override
+  String get sungLyricColor => '已唱歌词颜色';
+
+  @override
+  String get outlineColor => '描边颜色';
+
+  @override
+  String get nextLineColor => '下一句颜色';
 }

--- a/lib/landscape_view/bottom_control.dart
+++ b/lib/landscape_view/bottom_control.dart
@@ -174,6 +174,7 @@ class BottomControl extends StatelessWidget {
             if (lyricsWindowVisible) {
               await controller.hide();
             } else {
+              await pushDesktopLyricsStyle();
               await updateDesktopLyrics();
               await controller.show();
             }

--- a/lib/landscape_view/bottom_control.dart
+++ b/lib/landscape_view/bottom_control.dart
@@ -3,10 +3,11 @@ import 'package:sylvakru/base/audio_handler.dart';
 import 'package:sylvakru/base/services/color_manager.dart';
 import 'package:sylvakru/base/app.dart';
 import 'package:sylvakru/base/asset_images.dart';
-import 'package:sylvakru/base/services/interaction.dart';
+import 'package:sylvakru/base/services/lyric.dart';
 import 'package:sylvakru/base/widgets/buttons.dart';
 import 'package:sylvakru/base/widgets/cover_art_widget.dart';
 import 'package:sylvakru/base/utils/dynamic_lyrics_page_route.dart';
+import 'package:sylvakru/landscape_view/desktop_lyrics.dart';
 import 'package:sylvakru/landscape_view/speaker.dart';
 import 'package:sylvakru/landscape_view/volume_bar.dart';
 import 'package:sylvakru/base/widgets/seekbar.dart';
@@ -55,7 +56,7 @@ class BottomControl extends StatelessWidget {
                       ],
                     ),
                   ),
-                  Expanded(flex: 2, child: otherControls(context)),
+                  Expanded(flex: 2, child: otherControls()),
                 ],
               ],
             ),
@@ -162,13 +163,21 @@ class BottomControl extends StatelessWidget {
     ];
   }
 
-  Widget otherControls(BuildContext context) {
+  Widget otherControls() {
     return Row(
       children: [
         Spacer(),
         IconButton(
-          onPressed: () {
-            showCenterMessage(context, 'Desktop lyrics has been removed');
+          onPressed: () async {
+            final controller = lyricsWindowController;
+            if (controller == null) return;
+            if (lyricsWindowVisible) {
+              await controller.hide();
+            } else {
+              await updateDesktopLyrics();
+              await controller.show();
+            }
+            lyricsWindowVisible = !lyricsWindowVisible;
           },
           icon: const ImageIcon(desktopLyricsImage, size: 25),
         ),

--- a/lib/landscape_view/desktop_lyrics.dart
+++ b/lib/landscape_view/desktop_lyrics.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 
 import 'package:desktop_multi_window/desktop_multi_window.dart';
 import 'package:flutter/material.dart';
-import 'package:sylvakru/base/app.dart';
 import 'package:sylvakru/base/audio_handler.dart';
 
 import 'package:sylvakru/base/asset_images.dart';
@@ -24,8 +23,70 @@ bool lyricsWindowVisible = false;
 Duration desktopLyricsCurrentPosition = Duration.zero;
 
 LyricLine? currentLyricLine;
+LyricLine? nextLyricLine;
 bool currentLyricLineIsKaraoke = false;
 final updateDesktopLyricsNotifier = ValueNotifier(0);
+
+enum DesktopLyricsLineMode { single, double }
+
+// Style is edited from the main window's settings UI but rendered in the
+// lyrics window's own isolate/engine, which shares no memory with the main
+// one - these notifiers only hold the locally-applicable value in whichever
+// isolate they're read in, and are kept in sync across that boundary via
+// desktopLyricsStyleToMap()/applyDesktopLyricsStyleFromMap() over the
+// platform channel (see WindowControllerExtension.updateStyle).
+final desktopLyricsLineModeNotifier = ValueNotifier(
+  DesktopLyricsLineMode.single,
+);
+final desktopLyricsFontSizeNotifier = ValueNotifier(30.0);
+final desktopLyricsFontFamilyNotifier = ValueNotifier<String?>(null);
+final desktopLyricsColorNotifier = ValueNotifier<Color>(
+  const Color(0x80FFFFFF),
+);
+final desktopLyricsSungColorNotifier = ValueNotifier<Color>(
+  const Color(0xFFFFFFFF),
+);
+final desktopLyricsOutlineColorNotifier = ValueNotifier<Color>(
+  const Color(0x8A000000),
+);
+final desktopLyricsNextLineColorNotifier = ValueNotifier<Color>(
+  const Color(0x80FFFFFF),
+);
+
+Map<String, dynamic> desktopLyricsStyleToMap() {
+  return {
+    'lineMode': desktopLyricsLineModeNotifier.value.name,
+    'fontSize': desktopLyricsFontSizeNotifier.value,
+    'fontFamily': desktopLyricsFontFamilyNotifier.value,
+    'color': desktopLyricsColorNotifier.value.toARGB32(),
+    'sungColor': desktopLyricsSungColorNotifier.value.toARGB32(),
+    'outlineColor': desktopLyricsOutlineColorNotifier.value.toARGB32(),
+    'nextLineColor': desktopLyricsNextLineColorNotifier.value.toARGB32(),
+  };
+}
+
+void applyDesktopLyricsStyleFromMap(dynamic data) {
+  final raw = data as Map;
+  final map = Map<String, dynamic>.from(raw);
+
+  desktopLyricsLineModeNotifier.value = DesktopLyricsLineMode.values.firstWhere(
+    (e) => e.name == map['lineMode'],
+    orElse: () => DesktopLyricsLineMode.single,
+  );
+  desktopLyricsFontSizeNotifier.value = (map['fontSize'] as num).toDouble();
+  desktopLyricsFontFamilyNotifier.value = map['fontFamily'] as String?;
+  desktopLyricsColorNotifier.value = Color(map['color'] as int);
+  desktopLyricsSungColorNotifier.value = Color(map['sungColor'] as int);
+  desktopLyricsOutlineColorNotifier.value = Color(map['outlineColor'] as int);
+  desktopLyricsNextLineColorNotifier.value = Color(map['nextLineColor'] as int);
+}
+
+/// Pushes the current style config to the lyrics window, if it's running.
+/// Call this whenever a style setting changes, and once before showing the
+/// window in case it missed earlier updates while hidden.
+Future<void> pushDesktopLyricsStyle() async {
+  await lyricsWindowController?.updateStyle(desktopLyricsStyleToMap());
+}
 
 Future<void> initDesktopLyrics() async {
   try {
@@ -101,22 +162,39 @@ class DesktopLyrics extends StatelessWidget {
   }
 
   Widget content() {
-    return ValueListenableBuilder(
-      valueListenable: updateDesktopLyricsNotifier,
-      builder: (context, value, child) {
+    return AnimatedBuilder(
+      animation: Listenable.merge([
+        updateDesktopLyricsNotifier,
+        desktopLyricsLineModeNotifier,
+        desktopLyricsFontSizeNotifier,
+        desktopLyricsFontFamilyNotifier,
+        desktopLyricsColorNotifier,
+        desktopLyricsSungColorNotifier,
+        desktopLyricsOutlineColorNotifier,
+        desktopLyricsNextLineColorNotifier,
+      ]),
+      builder: (context, child) {
+        final fontSize = desktopLyricsFontSizeNotifier.value;
+        final fontFamily = desktopLyricsFontFamilyNotifier.value;
+        final color = desktopLyricsColorNotifier.value;
+        final sungColor = desktopLyricsSungColorNotifier.value;
+        final outlineColor = desktopLyricsOutlineColorNotifier.value;
+        final nextLineColor = desktopLyricsNextLineColorNotifier.value;
+        final isDoubleLine =
+            desktopLyricsLineModeNotifier.value == DesktopLyricsLineMode.double;
+
+        List<Shadow> shadows(Color shadowColor) => [
+          Shadow(offset: Offset(0, 1), blurRadius: 1, color: shadowColor),
+        ];
+
         if (currentLyricLine == null) {
           return Text(
             'Sylvakru',
             style: TextStyle(
-              fontSize: isMobile ? 20 : 30,
-              color: Colors.white,
-              shadows: [
-                Shadow(
-                  offset: Offset(0, 1),
-                  blurRadius: 1,
-                  color: Colors.black87,
-                ),
-              ],
+              fontSize: fontSize,
+              fontFamily: fontFamily,
+              color: sungColor,
+              shadows: shadows(outlineColor),
             ),
           );
         }
@@ -132,42 +210,47 @@ class DesktopLyrics extends StatelessWidget {
                     key: UniqueKey(),
                     line: currentLyricLine!,
                     position: desktopLyricsCurrentPosition,
-                    fontSize: isMobile ? 20 : 30,
+                    fontSize: fontSize,
                     expanded: false,
                     isDesktopLyrics: true,
+                    fontFamily: fontFamily,
+                    unsungColor: color,
+                    sungColor: sungColor,
+                    outlineColor: outlineColor,
                   );
                 },
               )
             else
               Text(
                 currentLyricLine!.text,
-
                 style: TextStyle(
-                  fontSize: isMobile ? 20 : 30,
-                  color: Colors.white,
-                  shadows: [
-                    Shadow(
-                      offset: Offset(0, 1),
-                      blurRadius: 1,
-                      color: Colors.black87,
-                    ),
-                  ],
+                  fontSize: fontSize,
+                  fontFamily: fontFamily,
+                  color: sungColor,
+                  shadows: shadows(outlineColor),
                 ),
               ),
             for (final translate in currentLyricLine!.translates)
               Text(
                 translate,
-
                 style: TextStyle(
-                  fontSize: isMobile ? 14 : 24,
-                  color: Colors.white.withAlpha(128),
-                  shadows: [
-                    Shadow(
-                      offset: Offset(0, 1),
-                      blurRadius: 1,
-                      color: Colors.black87,
-                    ),
-                  ],
+                  fontSize: fontSize - 6,
+                  fontFamily: fontFamily,
+                  color: color,
+                  shadows: shadows(outlineColor),
+                ),
+              ),
+            if (isDoubleLine && nextLyricLine != null)
+              Padding(
+                padding: const EdgeInsets.only(top: 4),
+                child: Text(
+                  nextLyricLine!.text,
+                  style: TextStyle(
+                    fontSize: fontSize - 6,
+                    fontFamily: fontFamily,
+                    color: nextLineColor,
+                    shadows: shadows(outlineColor),
+                  ),
                 ),
               ),
           ],

--- a/lib/landscape_view/desktop_lyrics.dart
+++ b/lib/landscape_view/desktop_lyrics.dart
@@ -1,0 +1,260 @@
+import 'dart:io';
+
+import 'package:desktop_multi_window/desktop_multi_window.dart';
+import 'package:flutter/material.dart';
+import 'package:sylvakru/base/app.dart';
+import 'package:sylvakru/base/audio_handler.dart';
+
+import 'package:sylvakru/base/asset_images.dart';
+import 'package:sylvakru/base/services/logger.dart';
+import 'package:sylvakru/base/services/lyric.dart';
+import 'package:sylvakru/base/widgets/lyric_list_view.dart';
+import 'package:sylvakru/base/extensions/window_controller_extension.dart';
+import 'package:smooth_corner/smooth_corner.dart';
+import 'package:window_manager/window_manager.dart';
+
+// Null until [initDesktopLyrics] has successfully created the secondary
+// window. Kept nullable rather than late so a failed/unsupported
+// creation (e.g. sandboxed Linux environments without multi-window
+// support) degrades to "feature silently unavailable" instead of a
+// startup crash.
+WindowController? lyricsWindowController;
+bool lyricsWindowVisible = false;
+
+Duration desktopLyricsCurrentPosition = Duration.zero;
+
+LyricLine? currentLyricLine;
+bool currentLyricLineIsKaraoke = false;
+final updateDesktopLyricsNotifier = ValueNotifier(0);
+
+Future<void> initDesktopLyrics() async {
+  try {
+    lyricsWindowController = await WindowController.create(
+      WindowConfiguration(hiddenAtLaunch: true, arguments: 'desktop_lyrics'),
+    );
+  } catch (e) {
+    // Desktop lyrics is a nice-to-have, not core playback: never let its
+    // setup take the whole app down with it.
+    logger.output('failed to create desktop lyrics window: $e');
+    lyricsWindowController = null;
+  }
+}
+
+class DesktopLyrics extends StatelessWidget {
+  final ValueNotifier<bool> _isTransparentNotifier = ValueNotifier(false);
+
+  DesktopLyrics({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      theme: Platform.isWindows
+          ? ThemeData(fontFamily: 'Microsoft YaHei')
+          : null,
+
+      home: ValueListenableBuilder(
+        valueListenable: _isTransparentNotifier,
+        builder: (context, isTransparent, child) {
+          bool isDragging = false;
+          return GestureDetector(
+            behavior: HitTestBehavior.translucent,
+            onPanStart: (details) async {
+              isDragging = true;
+              await windowManager.startDragging();
+              isDragging = false;
+            },
+            child: MouseRegion(
+              onEnter: (_) {
+                _isTransparentNotifier.value = false;
+              },
+              onExit: (_) {
+                if (isDragging) {
+                  return;
+                }
+                _isTransparentNotifier.value = true;
+              },
+              child: Material(
+                color: isTransparent ? Colors.transparent : Colors.black45,
+                shape: SmoothRectangleBorder(
+                  smoothness: 1,
+                  borderRadius: BorderRadius.circular(5),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Column(
+                    children: [
+                      SizedBox(
+                        height: 50,
+                        child: isTransparent ? null : controlsRow(),
+                      ),
+                      content(),
+                      Spacer(),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget content() {
+    return ValueListenableBuilder(
+      valueListenable: updateDesktopLyricsNotifier,
+      builder: (context, value, child) {
+        if (currentLyricLine == null) {
+          return Text(
+            'Sylvakru',
+            style: TextStyle(
+              fontSize: isMobile ? 20 : 30,
+              color: Colors.white,
+              shadows: [
+                Shadow(
+                  offset: Offset(0, 1),
+                  blurRadius: 1,
+                  color: Colors.black87,
+                ),
+              ],
+            ),
+          );
+        }
+
+        return Column(
+          crossAxisAlignment: .center,
+          children: [
+            if (currentLyricLineIsKaraoke)
+              ValueListenableBuilder(
+                valueListenable: updateLyricsNotifier,
+                builder: (context, value, child) {
+                  return KaraokeText(
+                    key: UniqueKey(),
+                    line: currentLyricLine!,
+                    position: desktopLyricsCurrentPosition,
+                    fontSize: isMobile ? 20 : 30,
+                    expanded: false,
+                    isDesktopLyrics: true,
+                  );
+                },
+              )
+            else
+              Text(
+                currentLyricLine!.text,
+
+                style: TextStyle(
+                  fontSize: isMobile ? 20 : 30,
+                  color: Colors.white,
+                  shadows: [
+                    Shadow(
+                      offset: Offset(0, 1),
+                      blurRadius: 1,
+                      color: Colors.black87,
+                    ),
+                  ],
+                ),
+              ),
+            for (final translate in currentLyricLine!.translates)
+              Text(
+                translate,
+
+                style: TextStyle(
+                  fontSize: isMobile ? 14 : 24,
+                  color: Colors.white.withAlpha(128),
+                  shadows: [
+                    Shadow(
+                      offset: Offset(0, 1),
+                      blurRadius: 1,
+                      color: Colors.black87,
+                    ),
+                  ],
+                ),
+              ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget controlsRow() {
+    return Row(
+      children: [
+        Spacer(),
+        IconButton(
+          color: Colors.grey.shade50,
+
+          // Click-through is deliberately not persisted across restarts:
+          // this window's isolate can't safely touch the main window's
+          // config file (see the multi-isolate note above), and locking
+          // silently on launch with no visible unlock affordance would be
+          // an easy way for a user to strand themselves. The tray menu's
+          // "Unlock Desktop Lyrics" item is the escape hatch if this button
+          // becomes unreachable after locking.
+          onPressed: () async {
+            await windowManager.setIgnoreMouseEvents(true);
+          },
+          icon: Icon(Icons.lock_rounded, size: 20),
+        ),
+        IconButton(
+          color: Colors.grey.shade50,
+          icon: const ImageIcon(previousButtonImage, size: 25),
+          onPressed: () async {
+            final controllers = await WindowController.getAll();
+            for (final controller in controllers) {
+              if (controller.arguments.isEmpty) {
+                controller.skipToPrevious();
+              }
+            }
+          },
+        ),
+        IconButton(
+          color: Colors.grey.shade50,
+          icon: ValueListenableBuilder(
+            valueListenable: isPlayingNotifier,
+            builder: (_, isPlaying, _) {
+              return Icon(
+                isPlaying ? Icons.pause_rounded : Icons.play_arrow_rounded,
+                size: 30,
+              );
+            },
+          ),
+          onPressed: () async {
+            final controllers = await WindowController.getAll();
+            for (final controller in controllers) {
+              if (controller.arguments.isEmpty) {
+                controller.togglePlay();
+              }
+            }
+          },
+        ),
+        IconButton(
+          color: Colors.grey.shade50,
+          icon: const ImageIcon(nextButtonImage, size: 25),
+          onPressed: () async {
+            final controllers = await WindowController.getAll();
+            for (final controller in controllers) {
+              if (controller.arguments.isEmpty) {
+                controller.skipToNext();
+              }
+            }
+          },
+        ),
+        IconButton(
+          color: Colors.grey.shade50,
+
+          onPressed: () async {
+            final controllers = await WindowController.getAll();
+            for (final controller in controllers) {
+              if (controller.arguments.isEmpty) {
+                controller.hideDesktopLyrics();
+              }
+            }
+            windowManager.hide();
+          },
+          icon: Icon(Icons.close),
+        ),
+        Spacer(),
+      ],
+    );
+  }
+}

--- a/lib/landscape_view/pages/landscape_lyrics_page.dart
+++ b/lib/landscape_view/pages/landscape_lyrics_page.dart
@@ -378,6 +378,7 @@ class _LandscapeLyricsPageState extends State<LandscapeLyricsPage> {
                           if (lyricsWindowVisible) {
                             await controller.hide();
                           } else {
+                            await pushDesktopLyricsStyle();
                             await updateDesktopLyrics();
                             await controller.show();
                           }

--- a/lib/landscape_view/pages/landscape_lyrics_page.dart
+++ b/lib/landscape_view/pages/landscape_lyrics_page.dart
@@ -7,10 +7,11 @@ import 'package:sylvakru/base/audio_handler.dart';
 import 'package:sylvakru/base/services/color_manager.dart';
 import 'package:sylvakru/base/app.dart';
 import 'package:sylvakru/base/asset_images.dart';
-import 'package:sylvakru/base/services/interaction.dart';
+import 'package:sylvakru/base/services/lyric.dart';
 import 'package:sylvakru/base/widgets/buttons.dart';
 import 'package:sylvakru/base/widgets/cover_art_widget.dart';
 import 'package:sylvakru/base/data/setting.dart';
+import 'package:sylvakru/landscape_view/desktop_lyrics.dart';
 import 'package:sylvakru/landscape_view/speaker.dart';
 import 'package:sylvakru/landscape_view/title_bar.dart';
 import 'package:sylvakru/landscape_view/volume_bar.dart';
@@ -372,10 +373,15 @@ class _LandscapeLyricsPageState extends State<LandscapeLyricsPage> {
                       width: 40,
                       child: IconButton(
                         onPressed: () async {
-                          showCenterMessage(
-                            context,
-                            'Desktop lyrics has been removed',
-                          );
+                          final controller = lyricsWindowController;
+                          if (controller == null) return;
+                          if (lyricsWindowVisible) {
+                            await controller.hide();
+                          } else {
+                            await updateDesktopLyrics();
+                            await controller.show();
+                          }
+                          lyricsWindowVisible = !lyricsWindowVisible;
                         },
                         icon: const ImageIcon(desktopLyricsImage, size: 25),
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,11 +1,14 @@
 import 'dart:io';
+import 'package:desktop_multi_window/desktop_multi_window.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:sylvakru/base/extensions/window_controller_extension.dart';
 import 'package:sylvakru/base/services/color_manager.dart';
 import 'package:sylvakru/base/app.dart';
 import 'package:sylvakru/base/services/logger.dart';
+import 'package:sylvakru/landscape_view/desktop_lyrics.dart';
 import 'package:sylvakru/base/services/keyboard.dart';
 import 'package:sylvakru/base/services/my_tray_listener.dart';
 import 'package:sylvakru/base/services/my_window_listener.dart';
@@ -34,13 +37,29 @@ Future<void> main() async {
   if (isMobile) {
     screenRadius = await ScreenCornerRadius.get();
   } else {
+    await windowManager.ensureInitialized();
+
+    // desktop_multi_window re-runs this whole main() for every window it
+    // creates, in a separate engine/isolate that shares no Dart state with
+    // this one. The 'desktop_lyrics' argument (set in initDesktopLyrics())
+    // is the only way this invocation knows whether it's the main window
+    // or the floating lyrics window - it must be checked before any of the
+    // main-window-only setup below (single-instance lock, tray icon, etc.)
+    // runs, or the lyrics window would end up doing it too.
+    final windowController = await WindowController.fromCurrentEngine();
+    if (windowController.arguments == 'desktop_lyrics') {
+      await _setupDesktopLyricsWindow(windowController);
+      runApp(DesktopLyrics());
+      return;
+    }
+
     if (kReleaseMode) {
       await SingleInstance.start();
     }
 
     keyboardInit();
 
-    await _setupMainWindow();
+    await _setupMainWindow(windowController);
     await _setupTray();
   }
 
@@ -149,10 +168,14 @@ Future<void> main() async {
   );
 
   logger.output('App start');
+  if (!isMobile) {
+    await initDesktopLyrics();
+  }
 }
 
-Future<void> _setupMainWindow() async {
+Future<void> _setupMainWindow(WindowController windowController) async {
   myWindowListener = MyWindowListener();
+  await windowController.mainCustomInitialize();
   WindowOptions windowOptions = WindowOptions(
     size: mainSize,
     center: true,
@@ -160,7 +183,6 @@ Future<void> _setupMainWindow() async {
     titleBarStyle: TitleBarStyle.hidden,
     windowButtonVisibility: false,
   );
-  await windowManager.ensureInitialized();
   await windowManager.waitUntilReadyToShow(windowOptions, () async {
     await windowManager.setPreventClose(true);
     await windowManager.show();
@@ -192,6 +214,27 @@ Future<void> _setupMainWindow() async {
   windowManager.addListener(myWindowListener);
 }
 
+Future<void> _setupDesktopLyricsWindow(
+  WindowController windowController,
+) async {
+  await windowController.desktopLyricsCustomInitialize();
+  WindowOptions windowOptions = WindowOptions(
+    title: "Desktop Lyrics",
+    size: Platform.isLinux ? Size(1000, 250) : Size(1000, 200),
+    center: true,
+    backgroundColor: Colors.transparent,
+    titleBarStyle: TitleBarStyle.hidden,
+    // Keeping it in the taskbar/dock list on macOS is intentional: hiding
+    // it there (as done on Windows/Linux) hides the Dock icon too, since
+    // this is a second top-level window of the same app.
+    skipTaskbar: Platform.isMacOS ? false : true,
+    alwaysOnTop: true,
+  );
+  await windowManager.waitUntilReadyToShow(windowOptions, () async {
+    await windowManager.setAsFrameless();
+  });
+}
+
 Future<void> _setTrayMemu(Locale locale) async {
   late AppLocalizations l10n;
   try {
@@ -208,6 +251,9 @@ Future<void> _setTrayMemu(Locale locale) async {
         MenuItem(key: 'skipToPrevious', label: l10n.skip2Previous),
         MenuItem(key: 'togglePlay', label: l10n.playOrPause),
         MenuItem(key: 'skipToNext', label: l10n.skip2Next),
+
+        MenuItem.separator(),
+        MenuItem(key: 'unlock', label: l10n.unlockDeskLrc),
 
         MenuItem.separator(),
         MenuItem(key: 'exit', label: l10n.exit),

--- a/lib/mini_view/mini_view.dart
+++ b/lib/mini_view/mini_view.dart
@@ -6,11 +6,12 @@ import 'package:flutter/material.dart';
 import 'package:sylvakru/base/audio_handler.dart';
 import 'package:sylvakru/base/asset_images.dart';
 import 'package:sylvakru/base/services/color_manager.dart';
-import 'package:sylvakru/base/services/interaction.dart';
 import 'package:sylvakru/base/services/my_window_listener.dart';
+import 'package:sylvakru/base/services/lyric.dart';
 import 'package:sylvakru/base/widgets/buttons.dart';
 import 'package:sylvakru/base/widgets/cover_art_widget.dart';
 import 'package:sylvakru/base/widgets/seekbar.dart';
+import 'package:sylvakru/landscape_view/desktop_lyrics.dart';
 import 'package:sylvakru/landscape_view/pages/play_queue_page.dart';
 import 'package:sylvakru/landscape_view/speaker.dart';
 import 'package:sylvakru/landscape_view/volume_bar.dart';
@@ -533,7 +534,18 @@ class _MiniViewState extends State<MiniView> {
 
               IconButton(
                 onPressed: () async {
-                  showCenterMessage(context, 'Desktop lyrics has been removed');
+                  // null if initDesktopLyrics() failed at startup (e.g. no
+                  // multi-window support in this environment) - fail silently
+                  // rather than crashing the button's tap handler.
+                  final controller = lyricsWindowController;
+                  if (controller == null) return;
+                  if (lyricsWindowVisible) {
+                    await controller.hide();
+                  } else {
+                    await updateDesktopLyrics();
+                    await controller.show();
+                  }
+                  lyricsWindowVisible = !lyricsWindowVisible;
                 },
                 icon: const ImageIcon(desktopLyricsImage, size: 25),
 

--- a/lib/mini_view/mini_view.dart
+++ b/lib/mini_view/mini_view.dart
@@ -542,6 +542,7 @@ class _MiniViewState extends State<MiniView> {
                   if (lyricsWindowVisible) {
                     await controller.hide();
                   } else {
+                    await pushDesktopLyricsStyle();
                     await updateDesktopLyrics();
                     await controller.show();
                   }

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,6 +6,7 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <desktop_multi_window/desktop_multi_window_plugin.h>
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 #include <media_kit_libs_linux/media_kit_libs_linux_plugin.h>
 #include <screen_retriever_linux/screen_retriever_linux_plugin.h>
@@ -14,6 +15,9 @@
 #include <window_manager/window_manager_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) desktop_multi_window_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "DesktopMultiWindowPlugin");
+  desktop_multi_window_plugin_register_with_registrar(desktop_multi_window_registrar);
   g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
   flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  desktop_multi_window
   flutter_secure_storage_linux
   media_kit_libs_linux
   screen_retriever_linux

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -7,6 +7,8 @@
 
 #include "flutter/generated_plugin_registrant.h"
 
+#include "desktop_multi_window/desktop_multi_window_plugin.h"
+
 struct _MyApplication {
   GtkApplication parent_instance;
   char** dart_entrypoint_arguments;
@@ -72,6 +74,14 @@ static void my_application_activate(GApplication* application) {
   gtk_widget_realize(GTK_WIDGET(view));
 
   fl_register_plugins(FL_PLUGIN_REGISTRY(view));
+
+  // Every window desktop_multi_window creates (e.g. the desktop lyrics
+  // window) gets its own FlPluginRegistry that plugins must be registered
+  // into separately; without this callback that second window's engine
+  // has no working plugins at all (window_manager included).
+  desktop_multi_window_plugin_set_window_created_callback([](FlPluginRegistry* registry){
+    fl_register_plugins(registry);
+  });
 
   gtk_widget_grab_focus(GTK_WIDGET(view));
 }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,6 +7,7 @@ import Foundation
 
 import audio_service
 import audio_session
+import desktop_multi_window
 import file_picker
 import flutter_secure_storage_darwin
 import in_app_purchase_storekit
@@ -20,6 +21,7 @@ import window_manager
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AudioServicePlugin.register(with: registry.registrar(forPlugin: "AudioServicePlugin"))
   AudioSessionPlugin.register(with: registry.registrar(forPlugin: "AudioSessionPlugin"))
+  FlutterMultiWindowPlugin.register(with: registry.registrar(forPlugin: "FlutterMultiWindowPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
   FlutterSecureStorageDarwinPlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStorageDarwinPlugin"))
   InAppPurchasePlugin.register(with: registry.registrar(forPlugin: "InAppPurchasePlugin"))

--- a/macos/Runner/MainFlutterWindow.swift
+++ b/macos/Runner/MainFlutterWindow.swift
@@ -1,5 +1,6 @@
 import Cocoa
 import FlutterMacOS
+import desktop_multi_window
 
 class MainFlutterWindow: NSWindow {
   override func awakeFromNib() {
@@ -9,6 +10,13 @@ class MainFlutterWindow: NSWindow {
     self.setFrame(windowFrame, display: true)
 
     RegisterGeneratedPlugins(registry: flutterViewController)
+
+    // Each window desktop_multi_window creates (e.g. the desktop lyrics
+    // window) runs its own FlutterViewController with its own plugin
+    // registry, so plugins have to be registered into it separately too.
+    FlutterMultiWindowPlugin.setOnWindowCreatedCallback { controller in
+      RegisterGeneratedPlugins(registry: controller)
+    }
 
     super.awakeFromNib()
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -269,11 +269,12 @@ packages:
   desktop_multi_window:
     dependency: "direct main"
     description:
-      name: desktop_multi_window
-      sha256: "60ba38725b8887b60e44d15afdcf0c3813568b5da2ccaf1e7f6fd09a380a6e24"
-      url: "https://pub.flutter-io.cn"
-    source: hosted
-    version: "0.3.0"
+      path: "packages/desktop_multi_window"
+      ref: main
+      resolved-ref: "4118d4c0ff41f6bacd1d9b7c0ad09baa9fd2bf49"
+      url: "https://github.com/lpifx/flutter-plugins"
+    source: git
+    version: "0.3.1"
   dio:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -6,7 +6,7 @@ packages:
     description:
       name: _fe_analyzer_shared
       sha256: cd6add6f846f35fb79f3c315296703c1a24f3cfd7f4739d91a74961c1c7e9f1b
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "100.0.0"
   analyzer:
@@ -14,7 +14,7 @@ packages:
     description:
       name: analyzer
       sha256: "6ba98576948803398b69e3a444df24eacdbe12ed699c7014e120ea38552debbf"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "13.0.0"
   archive:
@@ -22,7 +22,7 @@ packages:
     description:
       name: archive
       sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "4.0.9"
   args:
@@ -30,7 +30,7 @@ packages:
     description:
       name: args
       sha256: d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.7.0"
   async:
@@ -38,23 +38,23 @@ packages:
     description:
       name: async
       sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.13.1"
   audio_service:
     dependency: "direct main"
     description:
       name: audio_service
-      sha256: cb122c7c2639d2a992421ef96b67948ad88c5221da3365ccef1031393a76e044
-      url: "https://pub.dev"
+      sha256: "95f3267f3449eb5cf71c8fcf1d556f57af1e898e2dc5815fb168d1843653edb7"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.18.18"
+    version: "0.18.19"
   audio_service_mpris:
     dependency: "direct main"
     description:
       name: audio_service_mpris
       sha256: "8cb2ff2237f4cd2fd27f16451ed35b3aedc12df8a384435327c67a9f4d557ef4"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.2.1"
   audio_service_platform_interface:
@@ -62,7 +62,7 @@ packages:
     description:
       name: audio_service_platform_interface
       sha256: "6283782851f6c8b501b60904a32fc7199dc631172da0629d7301e66f672ab777"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.1.3"
   audio_service_web:
@@ -70,7 +70,7 @@ packages:
     description:
       name: audio_service_web
       sha256: b8ea9243201ee53383157fbccf13d5d2a866b5dda922ec19d866d1d5d70424df
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.1.4"
   audio_service_win:
@@ -86,16 +86,16 @@ packages:
     dependency: "direct main"
     description:
       name: audio_session
-      sha256: "7217b229db57cc4dc577a8abb56b7429a5a212b978517a5be578704bfe5e568b"
-      url: "https://pub.dev"
+      sha256: f9e7711a0e24ca8b40f5d7ac374c3c6e55016f3157912badd18199cdbbca5c4d
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.2.3"
+    version: "0.2.4"
   audio_tags_lofty:
     dependency: "direct main"
     description:
       name: audio_tags_lofty
       sha256: a4f8309d362c448f12b07b52102eaf3678b51b8b40204e4d04ebdff3649d58b1
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.0.6"
   auto_size_text:
@@ -103,7 +103,7 @@ packages:
     description:
       name: auto_size_text
       sha256: "3f5261cd3fb5f2a9ab4e2fc3fba84fd9fcaac8821f20a1d4e71f557521b22599"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.0.0"
   boolean_selector:
@@ -111,47 +111,47 @@ packages:
     description:
       name: boolean_selector
       sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.1.2"
   build:
     dependency: transitive
     description:
       name: build
-      sha256: a156715e7cd728130c592f30552575908aae5b100005fbc1f0fb16b3c03a3d10
-      url: "https://pub.dev"
+      sha256: "45d14a0fb23e018d8287c32fc98d726ce466b231928ed9b9200f29bd3ccd39ae"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "4.0.6"
+    version: "4.0.7"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      sha256: "4070d2a59f8eec34c97c86ceb44403834899075f66e8a9d59706f8e7834f6f71"
-      url: "https://pub.dev"
+      sha256: f2c223156a26eea323e6244b85141d76413a80aeee9fe0b380773789fabaf8ae
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: bf05f6e12cfea92d3c09308d7bcdab1906cd8a179b023269eed00c071004b957
-      url: "https://pub.dev"
+      sha256: fd754058c342243718d5171a95f352cfc9fcf0cba8cfa26df67cb13a5836db78
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "4.1.1"
+    version: "4.1.2"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "1523ce62448ebac2c15a8ba5fbad8acac169788658a7dd2a1c2d9c2a9318b9a6"
-      url: "https://pub.dev"
+      sha256: "5367e521935b102bdf1e735d2aab461e36b2edca6517662d088dd04cc39f8d16"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.15.0"
+    version: "2.15.1"
   built_collection:
     dependency: transitive
     description:
       name: built_collection
       sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "5.1.1"
   built_value:
@@ -159,7 +159,7 @@ packages:
     description:
       name: built_value
       sha256: "34e4067d30ce212937df995f03b69992eea683539ceeac7f679a1f1eba055b56"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "8.12.6"
   characters:
@@ -167,7 +167,7 @@ packages:
     description:
       name: characters
       sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.4.1"
   charcode:
@@ -175,7 +175,7 @@ packages:
     description:
       name: charcode
       sha256: fb0f1107cac15a5ea6ef0a6ef71a807b9e4267c713bb93e00e92d737cc8dbd8a
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.4.0"
   charset:
@@ -183,7 +183,7 @@ packages:
     description:
       name: charset
       sha256: "27802032a581e01ac565904ece8c8962564b1070690794f0072f6865958ce8b9"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.0.1"
   checked_yaml:
@@ -191,7 +191,7 @@ packages:
     description:
       name: checked_yaml
       sha256: "959525d3162f249993882720d52b7e0c833978df229be20702b33d48d91de70f"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.0.4"
   cli_util:
@@ -199,7 +199,7 @@ packages:
     description:
       name: cli_util
       sha256: "5909d2c6b66817222779e1eedc19e0e28b76d1df7bd9856a4792ccb9881df358"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.5.1"
   clock:
@@ -207,7 +207,7 @@ packages:
     description:
       name: clock
       sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.1.2"
   code_assets:
@@ -215,7 +215,7 @@ packages:
     description:
       name: code_assets
       sha256: bf394f466ba9205f1812a0433b392d6af280f155f56651eda7c18cc32ed493b8
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.2.1"
   collection:
@@ -223,7 +223,7 @@ packages:
     description:
       name: collection
       sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.19.1"
   convert:
@@ -231,23 +231,23 @@ packages:
     description:
       name: convert
       sha256: b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.1.2"
   cross_file:
     dependency: transitive
     description:
       name: cross_file
-      sha256: "28bb3ae56f117b5aec029d702a90f57d285cd975c3c5c281eaca38dbc47c5937"
-      url: "https://pub.dev"
+      sha256: "92c9c43c383bfa1c32079d3bc492d55d6d4318044b7b47edaff8971cbb555c51"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.3.5+2"
+    version: "0.3.5+4"
   crypto:
     dependency: "direct main"
     description:
       name: crypto
       sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.0.7"
   dart_style:
@@ -255,7 +255,7 @@ packages:
     description:
       name: dart_style
       sha256: "59d53ef8eaed9d288ed9767618e2b31c4fa0383a127db59d5eb2e737a7638a60"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.1.9"
   dbus:
@@ -263,47 +263,55 @@ packages:
     description:
       name: dbus
       sha256: "0ce9b0a839e6dee59a37a623d2fc26a35bbbe6404213e419b0d6411023d62645"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.7.14"
+  desktop_multi_window:
+    dependency: "direct main"
+    description:
+      name: desktop_multi_window
+      sha256: "60ba38725b8887b60e44d15afdcf0c3813568b5da2ccaf1e7f6fd09a380a6e24"
+      url: "https://pub.flutter-io.cn"
+    source: hosted
+    version: "0.3.0"
   dio:
     dependency: "direct main"
     description:
       name: dio
-      sha256: aff32c08f92787a557dd5c0145ac91536481831a01b4648136373cddb0e64f8c
-      url: "https://pub.dev"
+      sha256: ea2bad3c89a27635ce2d85cce4d6b199da49a5a48ec77b03e45b65a3b90922b0
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "5.9.2"
+    version: "5.10.0"
   dio_web_adapter:
     dependency: transitive
     description:
       name: dio_web_adapter
-      sha256: "2f9e64323a7c3c7ef69567d5c800424a11f8337b8b228bad02524c9fb3c1f340"
-      url: "https://pub.dev"
+      sha256: dd58dc3861eb36edb13b217efc006a1c21e5bbc341de8c229b85634fa5e362e4
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.1.2"
+    version: "2.2.0"
   drift:
     dependency: "direct main"
     description:
       name: drift
-      sha256: "6cc0b623c0e83f7080524d8396e9301b1d78b9c66a4fdceeb0f798211303254c"
-      url: "https://pub.dev"
+      sha256: c21b9af62e78f86837638dda6c33506bd9444ca8a32cad2b99c07369cf9e2462
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.34.0"
+    version: "2.34.1"
   drift_dev:
     dependency: "direct dev"
     description:
       name: drift_dev
-      sha256: "042a5fb507ab5697f67eb55b75cfff2f665701f6606926136d6d4e85f81ff837"
-      url: "https://pub.dev"
+      sha256: c563e0ea24a1b4ad316f860a206220a74dd9c6324f0e7e02a961dd4808dba942
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.34.1+1"
+    version: "2.34.2+1"
   drift_flutter:
     dependency: "direct main"
     description:
       name: drift_flutter
       sha256: "887fdec622174dc7eaefd0048403e34ee07cc18626ac8a7544cc3b8a4a172166"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.3.0"
   fake_async:
@@ -311,7 +319,7 @@ packages:
     description:
       name: fake_async
       sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.3.3"
   ffi:
@@ -319,7 +327,7 @@ packages:
     description:
       name: ffi
       sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.2.0"
   ffi_leak_tracker:
@@ -327,7 +335,7 @@ packages:
     description:
       name: ffi_leak_tracker
       sha256: "4093d4ef9ca06ffe2786e73bfb25e22aa92112b9bb4ec941f11e3e6b61489a97"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.1.2"
   file:
@@ -335,7 +343,7 @@ packages:
     description:
       name: file
       sha256: a3b4f84adafef897088c160faf7dfffb7696046cb13ae90b508c2cbc95d3b8d4
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "7.0.1"
   file_picker:
@@ -352,7 +360,7 @@ packages:
     description:
       name: fixnum
       sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.1.1"
   flex_color_picker:
@@ -360,7 +368,7 @@ packages:
     description:
       name: flex_color_picker
       sha256: a0979dd61f21b634717b98eb4ceaed2bfe009fe020ce8597aaf164b9eeb57aaa
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.8.0"
   flex_seed_scheme:
@@ -368,7 +376,7 @@ packages:
     description:
       name: flex_seed_scheme
       sha256: a3183753bbcfc3af106224bff3ab3e1844b73f58062136b7499919f49f3667e7
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "4.0.1"
   flutter:
@@ -381,7 +389,7 @@ packages:
     description:
       name: flutter_cache_manager
       sha256: "400b6592f16a4409a7f2bb929a9a7e38c72cceb8ffb99ee57bbf2cb2cecf8386"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.4.1"
   flutter_lints:
@@ -389,7 +397,7 @@ packages:
     description:
       name: flutter_lints
       sha256: "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "6.0.0"
   flutter_localizations:
@@ -402,7 +410,7 @@ packages:
     description:
       name: flutter_plugin_android_lifecycle
       sha256: "3854fe5e3bff0b113c658f260b90c95dea17c92db0f2addeac2e343dd9969785"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.0.35"
   flutter_secure_storage:
@@ -410,7 +418,7 @@ packages:
     description:
       name: flutter_secure_storage
       sha256: "7686b1d6a29985dcbb808c59518226e603e3bfa7c0ddfd1a0d00e4cda77c868e"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "10.3.1"
   flutter_secure_storage_darwin:
@@ -418,7 +426,7 @@ packages:
     description:
       name: flutter_secure_storage_darwin
       sha256: "82329fa5cdf343773b1b6897dea959105a29f092454259edff92f9f6637e8149"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.3.2"
   flutter_secure_storage_linux:
@@ -426,7 +434,7 @@ packages:
     description:
       name: flutter_secure_storage_linux
       sha256: a5f35ddab43cf5c8215d2feb4ce1957851f28c5c37e6f04335066a0602087bf5
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.0.1"
   flutter_secure_storage_platform_interface:
@@ -434,7 +442,7 @@ packages:
     description:
       name: flutter_secure_storage_platform_interface
       sha256: "8ceea1223bee3c6ac1a22dabd8feefc550e4729b3675de4b5900f55afcb435d6"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.0.1"
   flutter_secure_storage_web:
@@ -442,7 +450,7 @@ packages:
     description:
       name: flutter_secure_storage_web
       sha256: "073a62b3aeb866ab4ce795f960413948e51e5a42a9b0c8333b6daf5bb3208a1c"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.1.1"
   flutter_secure_storage_windows:
@@ -450,7 +458,7 @@ packages:
     description:
       name: flutter_secure_storage_windows
       sha256: "471951813a97006d899db4948acc654a4f28c440083ea08178935ce20b173ec1"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "4.2.2"
   flutter_switch:
@@ -458,7 +466,7 @@ packages:
     description:
       name: flutter_switch
       sha256: b91477f926bba135d2d203d7b24367492662d8d9c3aa6adb960b14c1087d3c41
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.3.2"
   flutter_test:
@@ -476,7 +484,7 @@ packages:
     description:
       name: glob
       sha256: c3f1ee72c96f8f78935e18aa8cecced9ab132419e8625dc187e1c2408efc20de
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.1.3"
   google_fonts:
@@ -484,7 +492,7 @@ packages:
     description:
       name: google_fonts
       sha256: "4e9391085e524954a51e3625b7c9c7e9851dc3f376603208bb45c24b9a66255d"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "8.1.0"
   graphs:
@@ -492,7 +500,7 @@ packages:
     description:
       name: graphs
       sha256: "741bbf84165310a68ff28fe9e727332eef1407342fca52759cb21ad8177bb8d0"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.3.2"
   hooks:
@@ -500,7 +508,7 @@ packages:
     description:
       name: hooks
       sha256: "9a62a50b50b769a737bc0a8ff381f333529df3ab746b2f6b02e83760231455ba"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.0.2"
   http:
@@ -508,7 +516,7 @@ packages:
     description:
       name: http
       sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.6.0"
   http_multi_server:
@@ -516,7 +524,7 @@ packages:
     description:
       name: http_multi_server
       sha256: aa6199f908078bb1c5efb8d8638d4ae191aac11b311132c3ef48ce352fb52ef8
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.2.2"
   http_parser:
@@ -524,7 +532,7 @@ packages:
     description:
       name: http_parser
       sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "4.1.2"
   icons_launcher:
@@ -532,7 +540,7 @@ packages:
     description:
       name: icons_launcher
       sha256: b42b2f9b10e58d6a973f71293f00a1f0572595e5e50d676c53048e464f78cb7d
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.1.0"
   image:
@@ -540,7 +548,7 @@ packages:
     description:
       name: image
       sha256: f9881ff4998044947ec38d098bc7c8316ae1186fa786eddffdb867b9bc94dfce
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "4.8.0"
   in_app_purchase:
@@ -548,7 +556,7 @@ packages:
     description:
       name: in_app_purchase
       sha256: "0e9510b80b0074e89ab0a8e0fc901439b779dc9ae575ab8d419253c6e1627716"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.3.0"
   in_app_purchase_android:
@@ -556,7 +564,7 @@ packages:
     description:
       name: in_app_purchase_android
       sha256: eb8f551039481d1b265f12fa54f5ab5dd4f13ec5444a468b85a3793517a37fda
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.5.1"
   in_app_purchase_platform_interface:
@@ -564,23 +572,23 @@ packages:
     description:
       name: in_app_purchase_platform_interface
       sha256: "0b0076cac8ce4fa7048f01e76af8b123aeb6a7c4e0dea2a5206d6664454f3e36"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.4.1"
   in_app_purchase_storekit:
     dependency: transitive
     description:
       name: in_app_purchase_storekit
-      sha256: "5f9d59c86c15f56429a4fdf09097c99d5b412510e1fcf80cf874fc9638fab369"
-      url: "https://pub.dev"
+      sha256: "47d63717270133fcfa1ff8e144f6aaf9d498fa3884de43e24909737da55aedd8"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.4.10"
+    version: "0.4.10+1"
   intl:
     dependency: transitive
     description:
       name: intl
       sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.20.2"
   io:
@@ -588,7 +596,7 @@ packages:
     description:
       name: io
       sha256: dfd5a80599cf0165756e3181807ed3e77daf6dd4137caaad72d0b7931597650b
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.0.5"
   jni:
@@ -596,7 +604,7 @@ packages:
     description:
       name: jni
       sha256: c2230682d5bc2362c1c9e8d3c7f406d9cbba23ab3f2e203a025dd47e0fb2e68f
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.0.0"
   jni_flutter:
@@ -604,7 +612,7 @@ packages:
     description:
       name: jni_flutter
       sha256: "8b59e590786050b1cd866677dddaf76b1ade5e7bc751abe04b86e84d379d3ba6"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.0.1"
   js:
@@ -612,7 +620,7 @@ packages:
     description:
       name: js
       sha256: "53385261521cc4a0c4658fd0ad07a7d14591cf8fc33abbceae306ddb974888dc"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.7.2"
   json_annotation:
@@ -620,7 +628,7 @@ packages:
     description:
       name: json_annotation
       sha256: "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "4.12.0"
   just_font_scan:
@@ -628,7 +636,7 @@ packages:
     description:
       name: just_font_scan
       sha256: a8206db7a5402315592447c2188a4a0205c4256422d859001ba59f2d433801ba
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.3.0"
   leak_tracker:
@@ -636,7 +644,7 @@ packages:
     description:
       name: leak_tracker
       sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "11.0.2"
   leak_tracker_flutter_testing:
@@ -644,7 +652,7 @@ packages:
     description:
       name: leak_tracker_flutter_testing
       sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.0.10"
   leak_tracker_testing:
@@ -652,7 +660,7 @@ packages:
     description:
       name: leak_tracker_testing
       sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.0.2"
   lints:
@@ -660,7 +668,7 @@ packages:
     description:
       name: lints
       sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "6.1.0"
   logging:
@@ -668,7 +676,7 @@ packages:
     description:
       name: logging
       sha256: c8245ada5f1717ed44271ed1c26b8ce85ca3228fd2ffdb75468ab01979309d61
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.3.0"
   lpinyin:
@@ -676,7 +684,7 @@ packages:
     description:
       name: lpinyin
       sha256: "0bb843363f1f65170efd09fbdfc760c7ec34fc6354f9fcb2f89e74866a0d814a"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.0.3"
   matcher:
@@ -684,7 +692,7 @@ packages:
     description:
       name: matcher
       sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.12.19"
   material_color_utilities:
@@ -692,7 +700,7 @@ packages:
     description:
       name: material_color_utilities
       sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.13.0"
   media_kit:
@@ -718,7 +726,7 @@ packages:
     description:
       name: media_kit_libs_audio
       sha256: "81bf506c234e81e3ec536ba72f8f700a928543c14c345220210cae0411636316"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.0.7"
   media_kit_libs_ios_audio:
@@ -735,7 +743,7 @@ packages:
     description:
       name: media_kit_libs_linux
       sha256: "2b473399a49ec94452c4d4ae51cfc0f6585074398d74216092bf3d54aac37ecf"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.2.1"
   media_kit_libs_macos_audio:
@@ -761,7 +769,7 @@ packages:
     description:
       name: menu_base
       sha256: "820368014a171bd1241030278e6c2617354f492f5c703d7b7d4570a6b8b84405"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.1.1"
   meta:
@@ -769,7 +777,7 @@ packages:
     description:
       name: meta
       sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.18.0"
   mime:
@@ -777,23 +785,23 @@ packages:
     description:
       name: mime
       sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.0.0"
   native_toolchain_c:
     dependency: transitive
     description:
       name: native_toolchain_c
-      sha256: f59351d28f49520cd3a74eb1f41c5f19ae15e53c65a3231d14af672e46510a96
-      url: "https://pub.dev"
+      sha256: f9c168717100ae6d9fee9ffb0be379bf1f8b26b0f6bcbd4fdddcd931993a6a72
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.19.1"
+    version: "0.19.2"
   nested:
     dependency: transitive
     description:
       name: nested
       sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.0.0"
   objective_c:
@@ -801,7 +809,7 @@ packages:
     description:
       name: objective_c
       sha256: "6cb691c686fa2838c6deb34980d426145c2a5d537491cb83d463c33cdbc726ed"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "9.4.1"
   package_config:
@@ -809,7 +817,7 @@ packages:
     description:
       name: package_config
       sha256: f096c55ebb7deb7e384101542bfba8c52696c1b56fca2eb62827989ef2353bbc
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.2.0"
   path:
@@ -817,7 +825,7 @@ packages:
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.9.1"
   path_provider:
@@ -825,7 +833,7 @@ packages:
     description:
       name: path_provider
       sha256: a7f4874f987173da295a61c181b8ee71dab59b332a486b391babf26a1b884825
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.1.6"
   path_provider_android:
@@ -833,7 +841,7 @@ packages:
     description:
       name: path_provider_android
       sha256: "69cbd515a62b94d32a7944f086b2f82b4ac40a1d45bebfc00813a430ab2dabcd"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.3.1"
   path_provider_foundation:
@@ -841,7 +849,7 @@ packages:
     description:
       name: path_provider_foundation
       sha256: "2a376b7d6392d80cd3705782d2caa734ca4727776db0b6ec36ef3f1855197699"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.6.0"
   path_provider_linux:
@@ -849,7 +857,7 @@ packages:
     description:
       name: path_provider_linux
       sha256: "58c2005f147315b11e9b4a7bc889cd5203e250cba8e3f012dae259b4972b5c16"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.2.2"
   path_provider_platform_interface:
@@ -857,7 +865,7 @@ packages:
     description:
       name: path_provider_platform_interface
       sha256: "484838772624c3a4b94f1e44a3e19897fee738f2d5c4ce448443b0417f7c9dda"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.1.3"
   path_provider_windows:
@@ -865,7 +873,7 @@ packages:
     description:
       name: path_provider_windows
       sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.3.0"
   permission_handler:
@@ -873,7 +881,7 @@ packages:
     description:
       name: permission_handler
       sha256: fe54465bcc62a4564c6e4db337bbaded6c0c0fa6e10487414436d163114784f6
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "12.0.3"
   permission_handler_android:
@@ -881,7 +889,7 @@ packages:
     description:
       name: permission_handler_android
       sha256: "1e3bc410ca1bf84662104b100eb126e066cb55791b7451307f9708d4007350e6"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "13.0.1"
   permission_handler_apple:
@@ -889,7 +897,7 @@ packages:
     description:
       name: permission_handler_apple
       sha256: "79dfa1df734798aa3cfdad166d3a3698c206d8813de13516ea1071b5d7e2f420"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "9.4.10"
   permission_handler_html:
@@ -897,7 +905,7 @@ packages:
     description:
       name: permission_handler_html
       sha256: "38f000e83355abb3392140f6bc3030660cfaef189e1f87824facb76300b4ff24"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.1.3+5"
   permission_handler_platform_interface:
@@ -905,7 +913,7 @@ packages:
     description:
       name: permission_handler_platform_interface
       sha256: eb99b295153abce5d683cac8c02e22faab63e50679b937fa1bf67d58bb282878
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "4.3.0"
   permission_handler_windows:
@@ -913,7 +921,7 @@ packages:
     description:
       name: permission_handler_windows
       sha256: "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.2.1"
   petitparser:
@@ -921,7 +929,7 @@ packages:
     description:
       name: petitparser
       sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "7.0.2"
   platform:
@@ -929,7 +937,7 @@ packages:
     description:
       name: platform
       sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.1.6"
   plugin_platform_interface:
@@ -937,7 +945,7 @@ packages:
     description:
       name: plugin_platform_interface
       sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.1.8"
   pool:
@@ -945,7 +953,7 @@ packages:
     description:
       name: pool
       sha256: "978783255c543aa3586a1b3c21f6e9d720eb315376a915872c61ef8b5c20177d"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.5.2"
   posix:
@@ -953,7 +961,7 @@ packages:
     description:
       name: posix
       sha256: "185ef7606574f789b40f289c233efa52e96dead518aed988e040a10737febb07"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "6.5.0"
   provider:
@@ -961,7 +969,7 @@ packages:
     description:
       name: provider
       sha256: "4e82183fa20e5ca25703ead7e05de9e4cceed1fbd1eadc1ac3cb6f565a09f272"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "6.1.5+1"
   pub_semver:
@@ -969,7 +977,7 @@ packages:
     description:
       name: pub_semver
       sha256: "5bfcf68ca79ef689f8990d1160781b4bad40a3bd5e5218ad4076ddb7f4081585"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.2.0"
   pubspec_parse:
@@ -977,7 +985,7 @@ packages:
     description:
       name: pubspec_parse
       sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.5.0"
   recase:
@@ -985,7 +993,7 @@ packages:
     description:
       name: recase
       sha256: e4eb4ec2dcdee52dcf99cb4ceabaffc631d7424ee55e56f280bc039737f89213
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "4.1.0"
   record_use:
@@ -993,7 +1001,7 @@ packages:
     description:
       name: record_use
       sha256: "2551bd8eecfe95d14ae75f6021ad0248be5c27f138c2ec12fcb52b500b3ba1ed"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.6.0"
   rxdart:
@@ -1001,7 +1009,7 @@ packages:
     description:
       name: rxdart
       sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.28.0"
   safe_local_storage:
@@ -1009,7 +1017,7 @@ packages:
     description:
       name: safe_local_storage
       sha256: "7483b3d5e8976f0bd263647c03b96131ee8e43f48b56fa8a8ec459e8515d74b0"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.0.4"
   screen_corner_radius:
@@ -1017,55 +1025,55 @@ packages:
     description:
       name: screen_corner_radius
       sha256: "3e6465e9a0373852eb8af80bab2e972667b0302ed5b864366e5308158282e6f7"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.0.0"
   screen_retriever:
     dependency: transitive
     description:
       name: screen_retriever
-      sha256: "42cc3b402a0f67d2455a0d067553d0f13453f6a008d98eababf8b63958d506bd"
-      url: "https://pub.dev"
+      sha256: ace919117a7520c13a50a6259e60c4a0d4cbe98809468792a91b5c5adada2aa6
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.2"
   screen_retriever_linux:
     dependency: transitive
     description:
       name: screen_retriever_linux
-      sha256: "2a476f1a5538065bc5badf376cfdc83d6ecf07d77eb2391b9c2bff5a76970048"
-      url: "https://pub.dev"
+      sha256: "7b52006a5ceae1f3d5af7f77188c3290d6e7d8ded16d99809bea84967c65c257"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.2"
   screen_retriever_macos:
     dependency: transitive
     description:
       name: screen_retriever_macos
-      sha256: b5abb900fcb86614ff10b738b34e37b9e1d03b0447280668e2bc8a98bdc7bd59
-      url: "https://pub.dev"
+      sha256: a1489b99cce597c45a54b9aae1cd94c8d4705353b7e0bb2457a6e4de44e0ad8a
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.2"
   screen_retriever_platform_interface:
     dependency: transitive
     description:
       name: screen_retriever_platform_interface
-      sha256: "3af22d926bedf20c2caa308eea376776451a3af125919ce072e56525fded8901"
-      url: "https://pub.dev"
+      sha256: "94a5535277510a63184ca178ce12a1449bc0b38618879aa1c18bf57369c5064a"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.2"
   screen_retriever_windows:
     dependency: transitive
     description:
       name: screen_retriever_windows
-      sha256: c44b38a4c4bab34af259180a70a4eee1e29384e7b82e627c9faa68afcdab2e73
-      url: "https://pub.dev"
+      sha256: dafc6922b0bfbf1d48cf3ccbf519b4fff47bdcb820da1728ea6db675fecc9324
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.2"
   scrollable_positioned_list:
     dependency: "direct main"
     description:
       name: scrollable_positioned_list
       sha256: "1b54d5f1329a1e263269abc9e2543d90806131aa14fe7c6062a8054d57249287"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.3.8"
   shelf:
@@ -1073,7 +1081,7 @@ packages:
     description:
       name: shelf
       sha256: e7dd780a7ffb623c57850b33f43309312fc863fb6aa3d276a754bb299839ef12
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.4.2"
   shelf_web_socket:
@@ -1081,7 +1089,7 @@ packages:
     description:
       name: shelf_web_socket
       sha256: "3632775c8e90d6c9712f883e633716432a27758216dfb61bd86a8321c0580925"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.0.0"
   shortid:
@@ -1089,7 +1097,7 @@ packages:
     description:
       name: shortid
       sha256: d0b40e3dbb50497dad107e19c54ca7de0d1a274eb9b4404991e443dadb9ebedb
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.1.2"
   sky_engine:
@@ -1102,7 +1110,7 @@ packages:
     description:
       name: smooth_corner
       sha256: "112d7331f82ead81ec870c5d1eb0624f2e7e367eccd166c2fffe4c11d4f87c4f"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.1.1"
   source_gen:
@@ -1110,7 +1118,7 @@ packages:
     description:
       name: source_gen
       sha256: ec37cc0e6694374cbef59ed79685572c870a54ede6fa30a3e420feb3adffea02
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "4.2.3"
   source_span:
@@ -1118,7 +1126,7 @@ packages:
     description:
       name: source_span
       sha256: "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.10.2"
   sqflite:
@@ -1126,7 +1134,7 @@ packages:
     description:
       name: sqflite
       sha256: "58a799e6ac17dd32fbab93813d39ed835a75ccc0f8f85b8955fe318c6712b082"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.4.3"
   sqflite_android:
@@ -1134,7 +1142,7 @@ packages:
     description:
       name: sqflite_android
       sha256: d0548f9d7422a2dae99ec6f8b0a3074463b132d216fa5ba0d230eeefc901983b
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.4.3"
   sqflite_common:
@@ -1142,7 +1150,7 @@ packages:
     description:
       name: sqflite_common
       sha256: "5bf6a55c166e73bf651ba7ec3ed486e577620e3dc8f3a9c6a258a8031b624590"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.5.11"
   sqflite_darwin:
@@ -1150,7 +1158,7 @@ packages:
     description:
       name: sqflite_darwin
       sha256: c86ca18b8f666bbf903924687fe21cc16fc385d086005067e26619ca530bef9f
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.4.3+1"
   sqflite_platform_interface:
@@ -1158,7 +1166,7 @@ packages:
     description:
       name: sqflite_platform_interface
       sha256: f84939f84350d92d04416f8bc4dc52d3896aec7716cc9e80cf0146342139dc50
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.4.1"
   sqlcipher_flutter_libs:
@@ -1166,39 +1174,39 @@ packages:
     description:
       name: sqlcipher_flutter_libs
       sha256: "38d62d659d2fb8739bf25a42c9a350d1fdd6c29a5a61f13a946778ec75d27929"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.7.0+eol"
   sqlite3:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: "37356bcb56ce0d9404d602c41e4bdb7765e7e9732a3e47adb3d98c556a6abdad"
-      url: "https://pub.dev"
+      sha256: "752d9d746052359a2022f588bb979f2e7c4e0f9e4b6a1c3121f7626a1574974b"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "3.3.3"
+    version: "3.3.4"
   sqlite3_flutter_libs:
     dependency: transitive
     description:
       name: sqlite3_flutter_libs
       sha256: "3ed7553eee7bb368f8950f58ba29f634e06e813c029aff6a0d60862b96de8454"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.6.0+eol"
   sqlparser:
     dependency: transitive
     description:
       name: sqlparser
-      sha256: "40bdddb306a727be9ce510bd2d2b9a6c9db6c586d846ef7b22e3990a2b24f02d"
-      url: "https://pub.dev"
+      sha256: "772bb2f6f5bce0631a60f26b57d6e8882e1105c22345b05c163ee6ee5d7ba32d"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.44.5"
+    version: "0.45.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.12.1"
   stream_channel:
@@ -1206,7 +1214,7 @@ packages:
     description:
       name: stream_channel
       sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.1.4"
   stream_transform:
@@ -1214,7 +1222,7 @@ packages:
     description:
       name: stream_transform
       sha256: ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.1.1"
   string_scanner:
@@ -1222,7 +1230,7 @@ packages:
     description:
       name: string_scanner
       sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.4.1"
   synchronized:
@@ -1230,7 +1238,7 @@ packages:
     description:
       name: synchronized
       sha256: "93b153dcb6a26dcddee6ca087dd634b53e38c10b5aa163e8e49501a776456153"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.4.1"
   term_glyph:
@@ -1238,7 +1246,7 @@ packages:
     description:
       name: term_glyph
       sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.2.2"
   test_api:
@@ -1246,7 +1254,7 @@ packages:
     description:
       name: test_api
       sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.7.11"
   text_scroll:
@@ -1254,7 +1262,7 @@ packages:
     description:
       name: text_scroll
       sha256: "164b49e6134fca874989213d4e7ba225e2c3f9e30d9e32f14d543b2fc55716a0"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "0.2.1"
   tray_manager:
@@ -1271,7 +1279,7 @@ packages:
     description:
       name: typed_data
       sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.4.0"
   universal_io:
@@ -1279,7 +1287,7 @@ packages:
     description:
       name: universal_io
       sha256: f63cbc48103236abf48e345e07a03ce5757ea86285ed313a6a032596ed9301e2
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.3.1"
   universal_platform:
@@ -1287,7 +1295,7 @@ packages:
     description:
       name: universal_platform
       sha256: "64e16458a0ea9b99260ceb5467a214c1f298d647c659af1bff6d3bf82536b1ec"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.1.0"
   uri_parser:
@@ -1295,7 +1303,7 @@ packages:
     description:
       name: uri_parser
       sha256: "051c62e5f693de98ca9f130ee707f8916e2266945565926be3ff20659f7853ce"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.0.2"
   url_launcher:
@@ -1303,7 +1311,7 @@ packages:
     description:
       name: url_launcher
       sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "6.3.2"
   url_launcher_android:
@@ -1311,7 +1319,7 @@ packages:
     description:
       name: url_launcher_android
       sha256: b413d49b73867ac08dd2f9890efd3cc11f2a0e577618d50843440a1fb3776c32
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "6.3.32"
   url_launcher_ios:
@@ -1319,7 +1327,7 @@ packages:
     description:
       name: url_launcher_ios
       sha256: "580fe5dfb51671ae38191d316e027f6b76272b026370708c2d898799750a02b0"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "6.4.1"
   url_launcher_linux:
@@ -1327,7 +1335,7 @@ packages:
     description:
       name: url_launcher_linux
       sha256: d5e14138b3bc193a0f63c10a53c94b91d399df0512b1f29b94a043db7482384a
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.2.2"
   url_launcher_macos:
@@ -1335,7 +1343,7 @@ packages:
     description:
       name: url_launcher_macos
       sha256: "368adf46f71ad3c21b8f06614adb38346f193f3a59ba8fe9a2fd74133070ba18"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.2.5"
   url_launcher_platform_interface:
@@ -1343,7 +1351,7 @@ packages:
     description:
       name: url_launcher_platform_interface
       sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.3.2"
   url_launcher_web:
@@ -1351,7 +1359,7 @@ packages:
     description:
       name: url_launcher_web
       sha256: "85c81589622fbc87c1c683aaea164d3604a7777495a79d91e39ffcdec39ddb34"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.4.3"
   url_launcher_windows:
@@ -1359,7 +1367,7 @@ packages:
     description:
       name: url_launcher_windows
       sha256: "712c70ab1b99744ff066053cbe3e80c73332b38d46e5e945c98689b2e66fc15f"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.1.5"
   uuid:
@@ -1367,7 +1375,7 @@ packages:
     description:
       name: uuid
       sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "4.5.3"
   vector_math:
@@ -1375,7 +1383,7 @@ packages:
     description:
       name: vector_math
       sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.2.0"
   vm_service:
@@ -1383,7 +1391,7 @@ packages:
     description:
       name: vm_service
       sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "15.2.0"
   watcher:
@@ -1391,7 +1399,7 @@ packages:
     description:
       name: watcher
       sha256: "1398c9f081a753f9226febe8900fce8f7d0a67163334e1c94a2438339d79d635"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.2.1"
   web:
@@ -1399,7 +1407,7 @@ packages:
     description:
       name: web
       sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.1.1"
   web_socket:
@@ -1407,7 +1415,7 @@ packages:
     description:
       name: web_socket
       sha256: "34d64019aa8e36bf9842ac014bb5d2f5586ca73df5e4d9bf5c936975cae6982c"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.0.1"
   web_socket_channel:
@@ -1415,7 +1423,7 @@ packages:
     description:
       name: web_socket_channel
       sha256: d645757fb0f4773d602444000a8131ff5d48c9e47adfe9772652dd1a4f2d45c8
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.0.3"
   win32:
@@ -1423,7 +1431,7 @@ packages:
     description:
       name: win32
       sha256: ba6f4bba816c8d7e3c1580e170f3786d216951cc6b94babc3b814c08d2cb2738
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "6.3.0"
   window_manager:
@@ -1440,7 +1448,7 @@ packages:
     description:
       name: xdg_directories
       sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.1.0"
   xml:
@@ -1448,7 +1456,7 @@ packages:
     description:
       name: xml
       sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "6.6.1"
   yaml:
@@ -1456,7 +1464,7 @@ packages:
     description:
       name: yaml
       sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "3.1.3"
 sdks:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -74,6 +74,10 @@ dependencies:
       url: https://github.com/AfalpHy/tray_manager.git
       ref: main
       path: packages/tray_manager
+  # Powers the floating desktop lyrics window: it spawns a second native
+  # window with its own Flutter engine, so state must cross via platform
+  # channels instead of shared Dart globals (see window_controller_extension.dart).
+  desktop_multi_window: ^0.3.0
   lpinyin: ^2.0.3
   flex_color_picker: ^3.8.0
   google_fonts: ^8.0.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -117,6 +117,15 @@ dependency_overrides:
       url: https://github.com/AfalpHy/media-kit
       ref: main
       path: libs\macos\media_kit_libs_macos_audio\
+  # Upstream doesn't give secondary windows any way to opt into a
+  # transparent background on Linux (see multi_window_manager.cc), which
+  # made the desktop lyrics window render as opaque black. Patched to
+  # request an RGBA visual and transparent FlView background.
+  desktop_multi_window:
+    git:
+      url: https://github.com/lpifx/flutter-plugins
+      ref: main
+      path: packages/desktop_multi_window
 
 dev_dependencies:
   flutter_test:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -7,6 +7,7 @@
 #include "generated_plugin_registrant.h"
 
 #include <audio_service_win/audio_service_win_plugin_c_api.h>
+#include <desktop_multi_window/desktop_multi_window_plugin.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <media_kit_libs_windows_audio/media_kit_libs_windows_audio_plugin_c_api.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
@@ -18,6 +19,8 @@
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   AudioServiceWinPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("AudioServiceWinPluginCApi"));
+  DesktopMultiWindowPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("DesktopMultiWindowPlugin"));
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   MediaKitLibsWindowsAudioPluginCApiRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   audio_service_win
+  desktop_multi_window
   flutter_secure_storage_windows
   media_kit_libs_windows_audio
   permission_handler_windows

--- a/windows/runner/flutter_window.cpp
+++ b/windows/runner/flutter_window.cpp
@@ -3,6 +3,7 @@
 #include <optional>
 
 #include "flutter/generated_plugin_registrant.h"
+#include "desktop_multi_window/desktop_multi_window_plugin.h"
 
 FlutterWindow::FlutterWindow(const flutter::DartProject& project)
     : project_(project) {}
@@ -25,6 +26,15 @@ bool FlutterWindow::OnCreate() {
     return false;
   }
   RegisterPlugins(flutter_controller_->engine());
+  // Each window desktop_multi_window creates (e.g. the desktop lyrics
+  // window) runs on its own engine and needs plugins registered into it
+  // separately; this callback is how that second registration happens.
+  DesktopMultiWindowSetWindowCreatedCallback([](void *controller) {
+    auto *flutter_view_controller =
+        reinterpret_cast<flutter::FlutterViewController *>(controller);
+    auto *registry = flutter_view_controller->engine();
+    RegisterPlugins(registry);
+  });
   SetChildContent(flutter_controller_->view()->GetNativeWindow());
 
   flutter_controller_->engine()->SetNextFrameCallback([&]() {


### PR DESCRIPTION
## Summary
- Restores the floating desktop lyrics window, previously stubbed out with a "Desktop lyrics has been removed" toast, using `desktop_multi_window`
- Wired up consistently from the mini view, landscape bottom control bar, and the landscape lyrics page toggle buttons
- The lyrics window runs in its own isolate/engine, so playback state (current line, next line, play/pause, transport controls) is synced across a platform channel rather than shared Dart globals; every IPC call and window-creation path fails soft instead of crashing playback
- Registers the multi-window plugin creation callback natively on Linux, macOS, and Windows, since each spawned window gets its own engine/plugin registry
- Fixes the Linux window rendering as opaque black instead of a transparent overlay: `desktop_multi_window`'s secondary windows never requested an RGBA visual or transparent FlView background, so this is patched via a fork (`lpifx/flutter-plugins`, wired in through `dependency_overrides`)
- Adds a settings panel (**Settings > Desktop Lyrics Style**) to customize the floating window: single/double-line display (double line previews the next lyric), font family/size, and separate colors for the base lyric text, the karaoke sung portion, the outline/shadow, and the next-line preview

## Test plan
- [x] `flutter analyze` - no issues
- [x] `dart format --set-exit-if-changed` - no changes needed
- [x] `flutter pub get` - dependencies resolve cleanly, including the desktop_multi_window fork
- [x] `flutter build linux` - builds and links successfully
- [x] Installed the build to `/usr/lib/sylvakru` (the actual apt-installed location) and ran it from there; both the main window and the desktop lyrics window initialize without crashing
- [x] Verified via `xdotool` that the "Desktop Lyrics" window is created with correct geometry and, after the transparency fix, is no longer rendering as an opaque black rectangle
- [ ] macOS / Windows builds not verified locally (no access to those platforms in this environment) - native plugin-registration wiring mirrors the existing pattern used for the main window on each platform

此PR与代码由Claude Sonnet 5生成