### PR TITLE
fix: 修复本地缓存损坏崩溃、网络错误无提示、密码回退丢失，并补充单元测试

### DIFF
--- a/lib/base/audio_handler.dart
+++ b/lib/base/audio_handler.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:media_kit/media_kit.dart';
 import 'package:sylvakru/base/services/emby_client.dart';
 import 'package:sylvakru/base/services/metadata_service.dart';
+import 'package:sylvakru/base/services/play_queue_logic.dart';
 import 'package:sylvakru/base/services/subsonic_client.dart';
 import 'package:sylvakru/base/services/webdav_client.dart';
 import 'package:sylvakru/base/services/color_manager.dart';
@@ -270,46 +271,29 @@ class MyAudioHandler extends BaseAudioHandler {
   }
 
   bool insert2Next(MyAudioMetadata song) {
-    int songIndex = playQueue.indexOf(song);
-    if (songIndex != -1) {
-      if (songIndex == currentIndex) {
-        return false;
-      }
-      if (songIndex < currentIndex) {
-        playQueue.removeAt(songIndex);
-        playQueue.insert(currentIndex, song);
-        currentIndex -= 1;
-      } else {
-        playQueue.removeAt(songIndex);
-        playQueue.insert(currentIndex + 1, song);
-      }
-    } else {
-      playQueue.insert(currentIndex + 1, song);
-      if (playModeNotifier.value == 1 ||
-          (playModeNotifier.value == 2 && audioHandler._tmpPlayMode == 1)) {
-        _playQueueTmp.add(song);
-      }
+    final result = PlayQueueLogic.insert2Next(playQueue, currentIndex, song);
+    if (result == null) {
+      return false;
+    }
+    currentIndex = result.currentIndex;
+    if (result.wasNewlyInserted &&
+        (playModeNotifier.value == 1 ||
+            (playModeNotifier.value == 2 && audioHandler._tmpPlayMode == 1))) {
+      _playQueueTmp.add(song);
     }
     return true;
   }
 
   bool add2Last(MyAudioMetadata song) {
-    int songIndex = playQueue.indexOf(song);
-    if (songIndex != -1) {
-      if (songIndex == currentIndex) {
-        return false;
-      }
-      if (songIndex < currentIndex) {
-        currentIndex -= 1;
-      }
-      playQueue.removeAt(songIndex);
-      playQueue.add(song);
-    } else {
-      playQueue.add(song);
-      if (playModeNotifier.value == 1 ||
-          (playModeNotifier.value == 2 && audioHandler._tmpPlayMode == 1)) {
-        _playQueueTmp.add(song);
-      }
+    final result = PlayQueueLogic.add2Last(playQueue, currentIndex, song);
+    if (result == null) {
+      return false;
+    }
+    currentIndex = result.currentIndex;
+    if (result.wasNewlyInserted &&
+        (playModeNotifier.value == 1 ||
+            (playModeNotifier.value == 2 && audioHandler._tmpPlayMode == 1))) {
+      _playQueueTmp.add(song);
     }
     return true;
   }

--- a/lib/base/data/config.dart
+++ b/lib/base/data/config.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:sylvakru/base/app.dart';
 import 'package:sylvakru/base/services/emby_client.dart';
+import 'package:sylvakru/base/services/logger.dart';
 import 'package:sylvakru/base/services/navidrome_client.dart';
 import 'package:sylvakru/base/services/subsonic_client.dart';
 import 'package:sylvakru/base/services/webdav_client.dart';
@@ -19,7 +20,7 @@ class Config {
 
   Future<void> load() async {
     if (Platform.isIOS) {
-      final isPremiumTmp = await _secureStorage.read(key: 'isPremium');
+      final isPremiumTmp = await _trySecureRead('isPremium');
       if (isPremiumTmp != 'true') {
         isPremiumNotifier.value = false;
       }
@@ -37,9 +38,7 @@ class Config {
 
     final webdavMap = map['webdav'] as Map<String, dynamic>?;
     if (webdavMap != null) {
-      String? securePassword = await _secureStorage.read(
-        key: 'webdav_password',
-      );
+      String? securePassword = await _trySecureRead('webdav_password');
       securePassword ??= webdavMap['password'];
       securePassword ??= '';
 
@@ -52,9 +51,7 @@ class Config {
 
     final subsonicMap = map['subsonic'] as Map<String, dynamic>?;
     if (subsonicMap != null) {
-      String? securePassword = await _secureStorage.read(
-        key: 'subsonic_password',
-      );
+      String? securePassword = await _trySecureRead('subsonic_password');
       securePassword ??= subsonicMap['password'];
       securePassword ??= '';
 
@@ -67,9 +64,7 @@ class Config {
 
     final navidromeMap = map['navidrome'] as Map<String, dynamic>?;
     if (navidromeMap != null) {
-      String? securePassword = await _secureStorage.read(
-        key: 'navidrome_password',
-      );
+      String? securePassword = await _trySecureRead('navidrome_password');
       securePassword ??= navidromeMap['password'];
       securePassword ??= '';
 
@@ -82,7 +77,7 @@ class Config {
 
     final embyMap = map['emby'] as Map<String, dynamic>?;
     if (embyMap != null) {
-      String? securePassword = await _secureStorage.read(key: 'emby_password');
+      String? securePassword = await _trySecureRead('emby_password');
       securePassword ??= embyMap['password'];
       securePassword ??= '';
 
@@ -100,32 +95,43 @@ class Config {
   }
 
   Future<void> savePremium() async {
-    await _secureStorage.write(key: 'isPremium', value: 'true');
+    await _trySecureWrite('isPremium', 'true');
   }
 
   Future<void> save() async {
+    // Secure storage (keyring/Keychain) can fail to write - e.g. no Secret
+    // Service running on some Linux setups - and previously that failure was
+    // silently ignored while the plaintext password was still stripped from
+    // config.json, permanently losing the credential on the next load. Keep
+    // the plaintext as a fallback in that one field until a write actually
+    // succeeds, instead of losing it outright.
+    bool webdavSecured = true;
+    bool subsonicSecured = true;
+    bool navidromeSecured = true;
+    bool embySecured = true;
+
     if (webdavClient != null) {
-      await _secureStorage.write(
-        key: 'webdav_password',
-        value: webdavClient!.password,
+      webdavSecured = await _trySecureWrite(
+        'webdav_password',
+        webdavClient!.password,
       );
     }
     if (subsonicClient != null) {
-      await _secureStorage.write(
-        key: 'subsonic_password',
-        value: subsonicClient!.password,
+      subsonicSecured = await _trySecureWrite(
+        'subsonic_password',
+        subsonicClient!.password,
       );
     }
     if (navidromeClient != null) {
-      await _secureStorage.write(
-        key: 'navidrome_password',
-        value: navidromeClient!.password,
+      navidromeSecured = await _trySecureWrite(
+        'navidrome_password',
+        navidromeClient!.password,
       );
     }
     if (embyClient != null) {
-      await _secureStorage.write(
-        key: 'emby_password',
-        value: embyClient!.password,
+      embySecured = await _trySecureWrite(
+        'emby_password',
+        embyClient!.password,
       );
     }
 
@@ -135,27 +141,50 @@ class Config {
           'webdav': {
             'baseUrl': webdavClient!.baseUrl,
             'username': webdavClient!.username,
+            if (!webdavSecured) 'password': webdavClient!.password,
           },
 
         if (subsonicClient != null)
           'subsonic': {
             'baseUrl': subsonicClient!.baseUrl,
             'username': subsonicClient!.username,
+            if (!subsonicSecured) 'password': subsonicClient!.password,
           },
 
         if (navidromeClient != null)
           'navidrome': {
             'baseUrl': navidromeClient!.baseUrl,
             'username': navidromeClient!.username,
+            if (!navidromeSecured) 'password': navidromeClient!.password,
           },
 
         if (embyClient != null)
           'emby': {
             'baseUrl': embyClient!.baseUrl,
             'username': embyClient!.username,
+            if (!embySecured) 'password': embyClient!.password,
           },
       }),
     );
+  }
+
+  Future<String?> _trySecureRead(String key) async {
+    try {
+      return await _secureStorage.read(key: key);
+    } catch (e) {
+      logger.output('Failed to read "$key" from secure storage: $e');
+      return null;
+    }
+  }
+
+  Future<bool> _trySecureWrite(String key, String value) async {
+    try {
+      await _secureStorage.write(key: key, value: value);
+      return true;
+    } catch (e) {
+      logger.output('Failed to write "$key" to secure storage: $e');
+      return false;
+    }
   }
 
   bool _hasPlainTextPassword(Map<String, dynamic> map) {

--- a/lib/base/data/folder.dart
+++ b/lib/base/data/folder.dart
@@ -163,9 +163,7 @@ class Folder {
   }
 
   Future<void> sync() async {
-    final List<dynamic> songIdList = jsonDecode(
-      await _songIdListFile.readAsString(),
-    );
+    final songIdList = await readJsonListFile(_songIdListFile);
 
     for (final id in songIdList) {
       final song = library.id2Song[id];

--- a/lib/base/data/library.dart
+++ b/lib/base/data/library.dart
@@ -99,9 +99,7 @@ class Library {
   }
 
   Future<void> _initLocalFolders() async {
-    List<dynamic> folderIdList = jsonDecode(
-      await _localFolderIdListFile.readAsString(),
-    );
+    final folderIdList = await readJsonListFile(_localFolderIdListFile);
 
     for (final id in folderIdList) {
       localFolderList.add(await Folder.from(id, false));
@@ -109,9 +107,7 @@ class Library {
   }
 
   Future<void> _initWebdavFolders() async {
-    List<dynamic> folderIdList = jsonDecode(
-      await _webdavFolderIdListFile.readAsString(),
-    );
+    final folderIdList = await readJsonListFile(_webdavFolderIdListFile);
 
     for (final id in folderIdList) {
       webdavFolderList.add(await Folder.from(id, true));
@@ -124,9 +120,9 @@ class Library {
   }
 
   Future<void> loadFonts() async {
-    _fontMap =
-        (jsonDecode(_fontMapFile.readAsStringSync()) as Map<String, dynamic>)
-            .map((key, value) => MapEntry(key, List<String>.from(value)));
+    _fontMap = readJsonMapFileSync(
+      _fontMapFile,
+    ).map((key, value) => MapEntry(key, List<String>.from(value)));
     for (final entry in _fontMap.entries) {
       final name = entry.key;
       final fontPathList = entry.value;
@@ -561,8 +557,8 @@ class Library {
           pathAndModified.addAll(folder.pathAndModified);
         }
 
-        final List<dynamic> songIdList = jsonDecode(
-          await _getSongIdListFile(sourceType).readAsString(),
+        final songIdList = await readJsonListFile(
+          _getSongIdListFile(sourceType),
         );
 
         final pool = Pool(6);

--- a/lib/base/data/playlist.dart
+++ b/lib/base/data/playlist.dart
@@ -59,21 +59,17 @@ class PlaylistManager {
   }
 
   Future<void> load() async {
-    List<dynamic> localPlaylists = jsonDecode(await _localFile.readAsString());
+    final localPlaylists = await readJsonListFile(_localFile);
     for (String name in localPlaylists) {
       addPlaylist(Playlist(name: name));
     }
 
-    List<dynamic> webdavPlaylists = jsonDecode(
-      await _webdavFile.readAsString(),
-    );
+    final webdavPlaylists = await readJsonListFile(_webdavFile);
     for (String name in webdavPlaylists) {
       playlistsMap[name]!.setWebdavFile();
     }
 
-    List<dynamic> subsonicPlaylists = jsonDecode(
-      await _subsonicFile.readAsString(),
-    );
+    final subsonicPlaylists = await readJsonListFile(_subsonicFile);
     for (final map in subsonicPlaylists) {
       String? id = map['id'];
       String name = map['name'];
@@ -81,9 +77,7 @@ class PlaylistManager {
       playlistsMap[name]!.setSubsonicFile();
     }
 
-    List<dynamic> navidromePlaylists = jsonDecode(
-      await _navidromeFile.readAsString(),
-    );
+    final navidromePlaylists = await readJsonListFile(_navidromeFile);
     for (final map in navidromePlaylists) {
       String? id = map['id'];
       String name = map['name'];
@@ -91,7 +85,7 @@ class PlaylistManager {
       playlistsMap[name]!.setNavidromeFile();
     }
 
-    List<dynamic> embyPlaylists = jsonDecode(await _embyFile.readAsString());
+    final embyPlaylists = await readJsonListFile(_embyFile);
     for (final map in embyPlaylists) {
       String? id = map['id'];
       String name = map['name'];
@@ -360,8 +354,7 @@ class Playlist {
     if (file == null) {
       return;
     }
-    final contents = await file.readAsString();
-    List<dynamic> decoded = jsonDecode(contents);
+    final decoded = await readJsonListFile(file);
     for (String id in decoded) {
       MyAudioMetadata? song = library.id2Song[id];
       if (song == null) {
@@ -623,9 +616,7 @@ class Playlist {
   }
 
   void loadSetting() {
-    final content = _settingFile.readAsStringSync();
-    final Map<String, dynamic> json =
-        jsonDecode(content) as Map<String, dynamic>;
+    final json = readJsonMapFileSync(_settingFile);
 
     for (final sourceType in SourceType.values) {
       songListManager.getSortTypeNotifier2(sourceType).value =

--- a/lib/base/data/setting.dart
+++ b/lib/base/data/setting.dart
@@ -8,6 +8,7 @@ import 'package:sylvakru/base/services/interaction.dart';
 import 'package:sylvakru/base/widgets/lyric_list_view.dart';
 import 'package:sylvakru/base/data/artist_album.dart';
 import 'package:sylvakru/base/app.dart';
+import 'package:sylvakru/base/utils/path.dart';
 import 'package:sylvakru/base/widgets/manage_music_folders.dart';
 
 final exitOnCloseNotifier = ValueNotifier(false);
@@ -23,10 +24,7 @@ class Setting {
       save();
     }
 
-    final content = await file.readAsString();
-
-    final Map<String, dynamic> json =
-        jsonDecode(content) as Map<String, dynamic>;
+    final json = await readJsonMapFile(file);
 
     artistAlbumManager.loadSetting(json);
 

--- a/lib/base/services/emby_client.dart
+++ b/lib/base/services/emby_client.dart
@@ -2,6 +2,7 @@ import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
 import 'package:sylvakru/base/services/logger.dart';
+import 'package:sylvakru/base/services/network_error_reporter.dart';
 
 EmbyClient? embyClient;
 
@@ -77,9 +78,12 @@ class EmbyClient {
         logger.output(e.response!.data.toString());
       }
 
+      reportNetworkError('Emby', e.message ?? 'network error');
+
       return null;
     } catch (e) {
       logger.output('[Emby] Unknown error: $e');
+      reportNetworkError('Emby', e.toString());
       return null;
     }
   }

--- a/lib/base/services/lyric.dart
+++ b/lib/base/services/lyric.dart
@@ -140,9 +140,32 @@ Future<void> setParsedLyrics(MyAudioMetadata song) async {
       lines = song.lyrics!.split(RegExp(r'[\n]'));
     }
   }
-  lines.removeWhere((e) => e.isEmpty);
+  applyLrcParsing(
+    result,
+    lines,
+    noLyricsMessage: l10n.noLyrics,
+    parseFailedMessage: l10n.lyricsParseFailed,
+    songDuration: song.duration,
+  );
+}
+
+/// Fills in [result] from already-fetched raw LRC lines: parses word/line
+/// timestamps, detects karaoke (multiple timed tokens per line) and
+/// translation lines (a second line sharing the same timestamp as the one
+/// before it), and falls back to [noLyricsMessage]/[parseFailedMessage]
+/// placeholders when there's nothing to show. Split out from
+/// [setParsedLyrics] so the parsing itself can be unit tested without a
+/// network/file round trip.
+void applyLrcParsing(
+  ParsedLyrics result,
+  List<String> rawLines, {
+  required String noLyricsMessage,
+  required String parseFailedMessage,
+  Duration? songDuration,
+}) {
+  final lines = List<String>.from(rawLines)..removeWhere((e) => e.isEmpty);
   if (lines.isEmpty) {
-    result.lines.add(LyricLine(Duration.zero, l10n.noLyrics, []));
+    result.lines.add(LyricLine(Duration.zero, noLyricsMessage, []));
     return;
   }
 
@@ -195,10 +218,10 @@ Future<void> setParsedLyrics(MyAudioMetadata song) async {
     }
   }
   if (result.lines.isEmpty) {
-    result.lines.add(LyricLine(Duration.zero, l10n.lyricsParseFailed, []));
+    result.lines.add(LyricLine(Duration.zero, parseFailedMessage, []));
   } else {
     if (result.lines.last.tokens.last.end == null) {
-      result.lines.last.tokens.last.end = song.duration;
+      result.lines.last.tokens.last.end = songDuration;
     }
   }
 }

--- a/lib/base/services/network_error_reporter.dart
+++ b/lib/base/services/network_error_reporter.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/foundation.dart';
+
+/// Server clients (webdav/subsonic/navidrome/emby) run deep in the data
+/// layer with no BuildContext of their own, so failures can't call
+/// showCenterMessage() directly. They report through here instead;
+/// [ViewEntry] is the single place that listens and surfaces
+/// [lastNetworkErrorMessage] to the user.
+final networkErrorNotifier = ValueNotifier(0);
+String? lastNetworkErrorMessage;
+
+DateTime? _lastReportTime;
+
+/// Debounced globally across all sources: a sync loop hitting a downed
+/// server for hundreds of songs should surface one toast, not hundreds.
+void reportNetworkError(String sourceLabel, String message) {
+  final now = DateTime.now();
+  if (_lastReportTime != null &&
+      now.difference(_lastReportTime!) < const Duration(seconds: 5)) {
+    return;
+  }
+  _lastReportTime = now;
+  lastNetworkErrorMessage = '$sourceLabel: $message';
+  networkErrorNotifier.value++;
+}

--- a/lib/base/services/open_sonic_client.dart
+++ b/lib/base/services/open_sonic_client.dart
@@ -5,6 +5,7 @@ import 'package:crypto/crypto.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:sylvakru/base/services/logger.dart';
+import 'package:sylvakru/base/services/network_error_reporter.dart';
 
 abstract class OpenSubsonicClient {
   final String baseUrl;
@@ -119,9 +120,13 @@ abstract class OpenSubsonicClient {
         logger.output(e.response!.data.toString());
       }
 
+      reportNetworkError('$runtimeType', e.message ?? 'network error');
+
       return null;
     } catch (e) {
       logger.output('[$runtimeType] $e');
+
+      reportNetworkError('$runtimeType', e.toString());
 
       return null;
     }

--- a/lib/base/services/play_queue_logic.dart
+++ b/lib/base/services/play_queue_logic.dart
@@ -1,0 +1,69 @@
+import 'package:sylvakru/base/my_audio_metadata.dart';
+
+/// The result of moving a song within/into the play queue: where the
+/// currently-playing item ends up afterward, and whether [song] wasn't
+/// already queued (which callers use to decide whether it also needs to be
+/// remembered in the pre-shuffle queue).
+class QueueInsertResult {
+  final int currentIndex;
+  final bool wasNewlyInserted;
+
+  const QueueInsertResult(this.currentIndex, this.wasNewlyInserted);
+}
+
+/// Index bookkeeping for play-queue reordering, split out of
+/// [MyAudioHandler] so it can be unit tested without a live Player/platform
+/// channel - it only touches the queue list and the current index, no I/O.
+class PlayQueueLogic {
+  /// Moves [song] to play right after [currentIndex] (or inserts it there
+  /// if it isn't queued yet). Mutates [playQueue] in place. Returns null if
+  /// [song] is already the currently-playing item - nothing to do.
+  static QueueInsertResult? insert2Next(
+    List<MyAudioMetadata> playQueue,
+    int currentIndex,
+    MyAudioMetadata song,
+  ) {
+    final songIndex = playQueue.indexOf(song);
+    if (songIndex != -1) {
+      if (songIndex == currentIndex) {
+        return null;
+      }
+      playQueue.removeAt(songIndex);
+      if (songIndex < currentIndex) {
+        playQueue.insert(currentIndex, song);
+        return QueueInsertResult(currentIndex - 1, false);
+      } else {
+        playQueue.insert(currentIndex + 1, song);
+        return QueueInsertResult(currentIndex, false);
+      }
+    } else {
+      playQueue.insert(currentIndex + 1, song);
+      return QueueInsertResult(currentIndex, true);
+    }
+  }
+
+  /// Moves [song] to the end of the queue (or appends it if it isn't
+  /// queued yet). Mutates [playQueue] in place. Returns null if [song] is
+  /// already the currently-playing item - nothing to do.
+  static QueueInsertResult? add2Last(
+    List<MyAudioMetadata> playQueue,
+    int currentIndex,
+    MyAudioMetadata song,
+  ) {
+    final songIndex = playQueue.indexOf(song);
+    if (songIndex != -1) {
+      if (songIndex == currentIndex) {
+        return null;
+      }
+      final newIndex = songIndex < currentIndex
+          ? currentIndex - 1
+          : currentIndex;
+      playQueue.removeAt(songIndex);
+      playQueue.add(song);
+      return QueueInsertResult(newIndex, false);
+    } else {
+      playQueue.add(song);
+      return QueueInsertResult(currentIndex, true);
+    }
+  }
+}

--- a/lib/base/services/webdav_client.dart
+++ b/lib/base/services/webdav_client.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:dio/dio.dart';
 import 'package:sylvakru/base/services/logger.dart';
+import 'package:sylvakru/base/services/network_error_reporter.dart';
 import 'package:path/path.dart' as p;
 import 'package:xml/xml.dart';
 
@@ -99,9 +100,12 @@ class WebDavClient {
         logger.output(e.response!.data.toString());
       }
 
+      reportNetworkError('WebDAV', e.message ?? 'network error');
+
       return null;
     } catch (e) {
       logger.output('[WebDav] [$mark] Unknown error: $e');
+      reportNetworkError('WebDAV', e.toString());
       return null;
     }
   }

--- a/lib/base/utils/path.dart
+++ b/lib/base/utils/path.dart
@@ -1,8 +1,10 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:http/http.dart' as http;
 import 'package:sylvakru/base/app.dart';
 import 'package:sylvakru/base/data/library.dart';
+import 'package:sylvakru/base/services/logger.dart';
 import 'package:sylvakru/base/services/webdav_client.dart';
 
 bool isFileProviderStorePath(String path) {
@@ -45,6 +47,54 @@ void initFile(File file, bool isList) {
   if (!file.existsSync()) {
     file.createSync(recursive: true);
     file.writeAsStringSync(isList ? '[]' : '{}');
+  }
+}
+
+/// Decodes [file] as a JSON list, resetting it to `[]` and returning an
+/// empty list if the content is missing or corrupted (e.g. a crash mid-write)
+/// instead of letting the exception crash startup.
+List<dynamic> readJsonListFileSync(File file) {
+  try {
+    return jsonDecode(file.readAsStringSync()) as List<dynamic>;
+  } catch (e) {
+    logger.output('Corrupted JSON file ${file.path}, resetting: $e');
+    file.writeAsStringSync('[]');
+    return [];
+  }
+}
+
+/// Async counterpart of [readJsonListFileSync].
+Future<List<dynamic>> readJsonListFile(File file) async {
+  try {
+    return jsonDecode(await file.readAsString()) as List<dynamic>;
+  } catch (e) {
+    logger.output('Corrupted JSON file ${file.path}, resetting: $e');
+    await file.writeAsString('[]');
+    return [];
+  }
+}
+
+/// Decodes [file] as a JSON map, resetting it to `{}` and returning an empty
+/// map if the content is missing or corrupted, instead of letting the
+/// exception crash startup.
+Map<String, dynamic> readJsonMapFileSync(File file) {
+  try {
+    return jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+  } catch (e) {
+    logger.output('Corrupted JSON file ${file.path}, resetting: $e');
+    file.writeAsStringSync('{}');
+    return {};
+  }
+}
+
+/// Async counterpart of [readJsonMapFileSync].
+Future<Map<String, dynamic>> readJsonMapFile(File file) async {
+  try {
+    return jsonDecode(await file.readAsString()) as Map<String, dynamic>;
+  } catch (e) {
+    logger.output('Corrupted JSON file ${file.path}, resetting: $e');
+    await file.writeAsString('{}');
+    return {};
   }
 }
 

--- a/lib/view_entry.dart
+++ b/lib/view_entry.dart
@@ -6,6 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:sylvakru/base/audio_handler.dart';
 import 'package:sylvakru/base/services/interaction.dart';
 import 'package:sylvakru/base/services/keyboard.dart';
+import 'package:sylvakru/base/services/network_error_reporter.dart';
 import 'package:sylvakru/base/utils/dynamic_lyrics_page_route.dart';
 import 'package:sylvakru/base/utils/media_query.dart';
 import 'package:sylvakru/l10n/generated/app_localizations.dart';
@@ -50,6 +51,18 @@ class _ViewEntryState extends State<ViewEntry> with WidgetsBindingObserver {
         await NativeMenu.initIcons();
       });
     }
+
+    networkErrorNotifier.addListener(_onNetworkError);
+  }
+
+  // Server clients report failures here since they have no BuildContext of
+  // their own; this is the single place that turns that into something the
+  // user actually sees, instead of the failure only ever reaching the log.
+  void _onNetworkError() {
+    final message = lastNetworkErrorMessage;
+    if (message != null && mounted) {
+      showCenterMessage(context, message, duration: 3000);
+    }
   }
 
   @override
@@ -57,6 +70,7 @@ class _ViewEntryState extends State<ViewEntry> with WidgetsBindingObserver {
     if (Platform.isAndroid) {
       WidgetsBinding.instance.removeObserver(this);
     }
+    networkErrorNotifier.removeListener(_onNetworkError);
     super.dispose();
   }
 

--- a/test/lyric_parsing_test.dart
+++ b/test/lyric_parsing_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sylvakru/base/services/lyric.dart';
+
+const _noLyrics = 'no lyrics';
+const _parseFailed = 'parse failed';
+
+ParsedLyrics parse(List<String> lines, {Duration? songDuration}) {
+  final result = ParsedLyrics();
+  applyLrcParsing(
+    result,
+    lines,
+    noLyricsMessage: _noLyrics,
+    parseFailedMessage: _parseFailed,
+    songDuration: songDuration,
+  );
+  return result;
+}
+
+void main() {
+  group('applyLrcParsing', () {
+    test('falls back to noLyricsMessage when there are no lines', () {
+      final result = parse([]);
+      expect(result.lines, hasLength(1));
+      expect(result.lines.first.text, _noLyrics);
+      expect(result.isKaraoke, isFalse);
+    });
+
+    test('falls back to noLyricsMessage when all lines are empty strings', () {
+      final result = parse(['', '', '']);
+      expect(result.lines, hasLength(1));
+      expect(result.lines.first.text, _noLyrics);
+    });
+
+    test('falls back to parseFailedMessage for whitespace-only lines '
+        '(only exactly-empty strings are filtered before parsing)', () {
+      final result = parse(['   ', '\t']);
+      expect(result.lines, hasLength(1));
+      expect(result.lines.first.text, _parseFailed);
+    });
+
+    test(
+      'falls back to parseFailedMessage when no line matches the LRC format',
+      () {
+        final result = parse(['just plain text', 'no timestamps here']);
+        expect(result.lines, hasLength(1));
+        expect(result.lines.first.text, _parseFailed);
+      },
+    );
+
+    test('parses plain (non-karaoke) LRC lines in order', () {
+      final result = parse(['[00:01.000]First line', '[00:05.500]Second line']);
+
+      expect(result.isKaraoke, isFalse);
+      expect(result.lines, hasLength(2));
+      expect(result.lines[0].start, Duration(seconds: 1));
+      expect(result.lines[0].text, 'First line');
+      expect(result.lines[1].start, Duration(milliseconds: 5500));
+      expect(result.lines[1].text, 'Second line');
+    });
+
+    test(
+      'backfills the previous line\'s end time from the next line start',
+      () {
+        final result = parse([
+          '[00:01.000]First line',
+          '[00:05.000]Second line',
+        ]);
+
+        expect(result.lines[0].tokens.single.end, Duration(seconds: 5));
+      },
+    );
+
+    test('detects karaoke lines (multiple timed tokens per line)', () {
+      final result = parse(['[00:01.000]He[00:01.500]llo [00:02.000]world']);
+
+      expect(result.isKaraoke, isTrue);
+      expect(result.lines, hasLength(1));
+      expect(result.lines.first.text, 'Hello world');
+      expect(result.lines.first.tokens, hasLength(3));
+      expect(result.lines.first.tokens[0].text, 'He');
+      expect(result.lines.first.tokens[0].end, Duration(milliseconds: 1500));
+      expect(result.lines.first.tokens[1].text, 'llo ');
+      expect(result.lines.first.tokens[1].end, Duration(seconds: 2));
+      expect(result.lines.first.tokens[2].text, 'world');
+    });
+
+    test('treats a second line at the same timestamp as a translation', () {
+      final result = parse([
+        '[00:01.000]Hello world',
+        '[00:01.000]你好世界',
+        '[00:05.000]Next line',
+      ]);
+
+      expect(result.lines, hasLength(2));
+      expect(result.lines[0].text, 'Hello world');
+      expect(result.lines[0].translates, ['你好世界']);
+    });
+
+    test('supports angle-bracket timestamps as well as square brackets', () {
+      final result = parse(['<00:01.00>Hello']);
+
+      expect(result.lines, hasLength(1));
+      expect(result.lines.first.text, 'Hello');
+    });
+
+    test(
+      'sets the final token\'s end time to the song duration when nothing follows',
+      () {
+        final result = parse([
+          '[00:01.000]Only line',
+        ], songDuration: Duration(minutes: 3));
+
+        expect(result.lines.single.tokens.single.end, Duration(minutes: 3));
+      },
+    );
+
+    test('ignores lines whose only token is blank', () {
+      final result = parse(['[00:01.000]   ', '[00:02.000]Real line']);
+
+      expect(result.lines, hasLength(1));
+      expect(result.lines.first.text, 'Real line');
+    });
+  });
+}

--- a/test/play_queue_logic_test.dart
+++ b/test/play_queue_logic_test.dart
@@ -1,0 +1,112 @@
+import 'dart:io';
+
+import 'package:audio_tags_lofty/audio_tags_lofty.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sylvakru/base/app.dart';
+import 'package:sylvakru/base/my_audio_metadata.dart';
+import 'package:sylvakru/base/services/play_queue_logic.dart';
+
+MyAudioMetadata song(String id) {
+  return MyAudioMetadata(AudioMetadata(title: id), id: id);
+}
+
+void main() {
+  // MyAudioMetadata's constructor reads from appSupportDir to check for a
+  // cached cover art file; it only needs to exist, not actually contain
+  // anything relevant to these tests.
+  setUpAll(() {
+    appSupportDir = Directory.systemTemp.createTempSync('sylvakru_test');
+  });
+
+  group('PlayQueueLogic.insert2Next', () {
+    test('does nothing when the song is already playing', () {
+      final queue = [song('a'), song('b')];
+      final result = PlayQueueLogic.insert2Next(queue, 0, queue[0]);
+
+      expect(result, isNull);
+      expect(queue.map((e) => e.id), ['a', 'b']);
+    });
+
+    test('inserts a brand-new song right after currentIndex', () {
+      final queue = [song('a'), song('b')];
+      final newSong = song('c');
+      final result = PlayQueueLogic.insert2Next(queue, 0, newSong);
+
+      expect(result!.currentIndex, 0);
+      expect(result.wasNewlyInserted, isTrue);
+      expect(queue.map((e) => e.id), ['a', 'c', 'b']);
+    });
+
+    test(
+      'moves a song from later in the queue to right after currentIndex',
+      () {
+        final queue = [song('a'), song('b'), song('c')];
+        // 'c' is already queued after the current song ('a').
+        final result = PlayQueueLogic.insert2Next(queue, 0, queue[2]);
+
+        expect(result!.currentIndex, 0);
+        expect(result.wasNewlyInserted, isFalse);
+        expect(queue.map((e) => e.id), ['a', 'c', 'b']);
+      },
+    );
+
+    test(
+      'moving a song from earlier in the queue shifts currentIndex back by one',
+      () {
+        final queue = [song('a'), song('b'), song('c'), song('d')];
+        // 'a' is queued before the current song ('c' at index 2).
+        final result = PlayQueueLogic.insert2Next(queue, 2, queue[0]);
+
+        expect(result!.currentIndex, 1);
+        expect(result.wasNewlyInserted, isFalse);
+        expect(queue.map((e) => e.id), ['b', 'c', 'a', 'd']);
+      },
+    );
+  });
+
+  group('PlayQueueLogic.add2Last', () {
+    test('does nothing when the song is already playing', () {
+      final queue = [song('a'), song('b')];
+      final result = PlayQueueLogic.add2Last(queue, 0, queue[0]);
+
+      expect(result, isNull);
+      expect(queue.map((e) => e.id), ['a', 'b']);
+    });
+
+    test('appends a brand-new song to the end', () {
+      final queue = [song('a'), song('b')];
+      final newSong = song('c');
+      final result = PlayQueueLogic.add2Last(queue, 0, newSong);
+
+      expect(result!.currentIndex, 0);
+      expect(result.wasNewlyInserted, isTrue);
+      expect(queue.map((e) => e.id), ['a', 'b', 'c']);
+    });
+
+    test(
+      'moving a song from before currentIndex to the end shifts currentIndex back',
+      () {
+        final queue = [song('a'), song('b'), song('c')];
+        // 'a' is queued before the current song ('c' at index 2).
+        final result = PlayQueueLogic.add2Last(queue, 2, queue[0]);
+
+        expect(result!.currentIndex, 1);
+        expect(result.wasNewlyInserted, isFalse);
+        expect(queue.map((e) => e.id), ['b', 'c', 'a']);
+      },
+    );
+
+    test(
+      'moving a song from after currentIndex to the end leaves currentIndex unchanged',
+      () {
+        final queue = [song('a'), song('b'), song('c')];
+        // 'c' is queued after the current song ('a' at index 0).
+        final result = PlayQueueLogic.add2Last(queue, 0, queue[2]);
+
+        expect(result!.currentIndex, 0);
+        expect(result.wasNewlyInserted, isFalse);
+        expect(queue.map((e) => e.id), ['a', 'b', 'c']);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## 概述
- **网络请求失败会提示用户**：WebDAV/Subsonic/Navidrome/Emby 四个客户端请求失败时，之前只写日志、界面上悄无声息，现在会通过一个全局的轻量提示（带 5 秒防抖，避免同一时间大量请求失败导致刷屏）告诉用户
- **本地缓存 JSON 损坏不再导致启动崩溃**：`setting.json`、歌曲/文件夹 ID 列表、歌单配置等文件如果损坏（比如写入过程中崩溃），现在会自动重置为空列表/空对象并继续运行，而不是直接抛异常崩溃
- **修复安全存储的明文回退漏洞**：之前如果系统密钥环（Keychain/Secret Service）写入失败，会静默地把 `config.json` 里的明文密码抹掉，导致密码永久丢失且没有任何提示；现在只有确认密钥环写入成功后才会清除明文，写入失败时会保留明文作为兜底，并把失败记录到日志里
- **补充单元测试**：把歌词解析逻辑（`lyric.dart` 里的 LRC 逐字/翻译行/卡拉OK识别）和播放队列的下标运算（`audio_handler.dart` 里插队播放/加入队尾时的索引调整）拆分成纯函数，各自补上了单元测试，这两块之前完全没有测试覆盖

## 测试计划
- [x] `flutter analyze` — 无警告无错误
- [x] `dart format --set-exit-if-changed` — 无需改动
- [x] `flutter test` — 19 个新增测试全部通过
- [x] `flutter build linux` — 编译链接成功
- [x] 已安装到本机真实使用路径并运行验证，无崩溃

此PR与代码由Claude Sonnet 5生成