### PR TITLE
fix: 主界面背景虚化层漏加 RepaintBoundary 导致窗口缩放卡顿

### DIFF
--- a/lib/landscape_view/landscape_view.dart
+++ b/lib/landscape_view/landscape_view.dart
@@ -43,20 +43,27 @@ class LandscapeView extends StatelessWidget {
             final pageWidth = MediaQuery.widthOf(context);
             final pageHight = MediaQuery.heightOf(context);
 
-            return BackdropFilter(
-              filter: ImageFilter.blur(
-                sigmaX: pageWidth * 0.03,
-                sigmaY: pageHight * 0.03,
-              ),
-              child: ValueListenableBuilder(
-                valueListenable: layersManager.backgroundChangeNotifier,
-                builder: (context, value, child) {
-                  return AnimatedContainer(
-                    duration: Duration(milliseconds: 500),
-                    curve: Curves.easeInOutCubic,
-                    color: backgroundCoverArtColor.withAlpha(180),
-                  );
-                },
+            // Without this, this always-visible background blur has no
+            // layer of its own, so every resize (e.g. un-maximizing) forces
+            // the whole tree behind it to repaint in the same frame as the
+            // blur recompute - unlike the identical effect on the lyrics
+            // pages, which already isolates it this way.
+            return RepaintBoundary(
+              child: BackdropFilter(
+                filter: ImageFilter.blur(
+                  sigmaX: pageWidth * 0.03,
+                  sigmaY: pageHight * 0.03,
+                ),
+                child: ValueListenableBuilder(
+                  valueListenable: layersManager.backgroundChangeNotifier,
+                  builder: (context, value, child) {
+                    return AnimatedContainer(
+                      duration: Duration(milliseconds: 500),
+                      curve: Curves.easeInOutCubic,
+                      color: backgroundCoverArtColor.withAlpha(180),
+                    );
+                  },
+                ),
               ),
             );
           },


### PR DESCRIPTION
## 概述
主界面（`landscape_view.dart`）里生动模式（vivid theme）下始终显示的背景虚化层（`BackdropFilter`）漏加了 `RepaintBoundary`——同样的虚化效果在横屏/竖屏歌词详情页里都用 `RepaintBoundary` 做了隔离，唯独主界面这处没有。

缺了这层隔离，每次窗口尺寸变化（比如取消最大化）时，虚化层重新计算的同时会连带整个背后的界面树一起重绘，造成明显的卡顿。

## 测试计划
- [x] `flutter analyze` — 无警告无错误
- [x] 复现环境确认：本机实际 `mainPageTheme` 设置为 `vivid`，命中此代码路径
- [x] `flutter build linux` — 编译链接成功
- [x] 已安装到本机真实使用路径运行验证，取消最大化不再卡顿

此PR与代码由Claude Sonnet 5生成