### PR TITLE
fix: 沉浸模式下全面屏手势上滑退出卡住（系统 UI 模式移出 build 幂等应用）

### DIFF
--- a/lib/view_entry.dart
+++ b/lib/view_entry.dart
@@ -31,6 +31,25 @@ class _ViewEntryState extends State<ViewEntry> with WidgetsBindingObserver {
   bool systemCanPop = false;
   Timer? _exitTimer;
   int keyValue = 0;
+  SystemUiMode? _appliedUiMode;
+
+  // 系统 UI 模式只在目标变化时应用，不能放在 build 里每次重设：全面屏手势
+  // 上滑时系统临时显示系统栏 → insets 变化触发重建 → 立刻又把栏藏回去，
+  // 返回桌面的手势被打断（平板宽屏沉浸模式下上滑卡住回不了桌面）。
+  void _applySystemUiMode(SystemUiMode mode) {
+    if (_appliedUiMode == mode) {
+      return;
+    }
+    _appliedUiMode = mode;
+    if (mode == SystemUiMode.manual) {
+      SystemChrome.setEnabledSystemUIMode(
+        SystemUiMode.manual,
+        overlays: [SystemUiOverlay.top],
+      );
+    } else {
+      SystemChrome.setEnabledSystemUIMode(mode);
+    }
+  }
 
   @override
   void initState() {
@@ -92,6 +111,12 @@ class _ViewEntryState extends State<ViewEntry> with WidgetsBindingObserver {
       if (state == .resumed) {
         systemCanPop = false;
         _exitTimer?.cancel();
+        // 回到前台系统可能已恢复系统栏，重新应用一次当前 UI 模式
+        final uiMode = _appliedUiMode;
+        if (uiMode != null) {
+          _appliedUiMode = null;
+          _applySystemUiMode(uiMode);
+        }
         // rebuild PopScope to allow it to handle pop
         setState(() {
           keyValue++;
@@ -148,17 +173,16 @@ class _ViewEntryState extends State<ViewEntry> with WidgetsBindingObserver {
           return MiniView();
         }
         if (viewMode == .bigPicture) {
-          SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersive);
+          _applySystemUiMode(SystemUiMode.immersiveSticky);
           return BigPictureView();
         }
         if (isTooNarrow(context)) {
-          SystemChrome.setEnabledSystemUIMode(
-            SystemUiMode.manual,
-            overlays: [SystemUiOverlay.top],
-          );
+          _applySystemUiMode(SystemUiMode.manual);
           return PortraitView();
         }
-        SystemChrome.setEnabledSystemUIMode(SystemUiMode.immersive);
+        // immersiveSticky：上滑临时显示的系统栏是透明浮层、不派发 insets
+        // 变化也会自动隐藏，全面屏手势可正常完成；immersive 被唤出后会常驻
+        _applySystemUiMode(SystemUiMode.immersiveSticky);
         return LandscapeView();
       },
     );


### PR DESCRIPTION
## 问题

平板（或宽屏横屏）沉浸模式下，用全面屏手势从底部上滑退出应用会卡住，无法回到桌面（真机：小米平板 2410CRP4CC / Android 16 复现）。

## 根因

`view()` 里的 `SystemChrome.setEnabledSystemUIMode(...)` 在 **build 流程内每次重建都会重新执行**：

1. 上滑手势开始时，系统临时显示系统栏；
2. 窗口 insets 变化触发 Flutter 重建；
3. build 里立刻又把系统栏藏回去，正在进行的返回桌面手势被系统中断。

竖屏分支保留了状态栏、insets 变化路径不同，所以手机上不明显。

## 修复

- 系统 UI 模式抽成 `_applySystemUiMode`，**只在目标模式变化时应用**（消除 build 副作用），回前台 `resumed` 时重新应用一次（系统可能已恢复系统栏）；
- 沉浸模式从 `immersive` 换成 `immersiveSticky`：上滑临时显示的系统栏是透明浮层，不派发 insets 变化且几秒后自动隐藏，手势可正常完成，视觉上仍是全沉浸。原来的 `immersive` 被唤出后系统栏本会常驻，只是被每次重建重新隐藏的副作用掩盖了。

## 验证

同样的改动已在基于本仓库的分支上通过 `flutter analyze`（0 issues）与全量 Dart 测试（129 passed），并在小米平板真机装机验证：横屏沉浸下上滑可顺畅回桌面，全沉浸观感不变。（本地 Flutter 为 3.44.5，未能在 main 钉住的 3.44.8 下复跑 analyze，改动仅使用稳定 API。）